### PR TITLE
Move installed t8code data into subdirectory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,7 @@ dist_t8aclocal_DATA = config/t8_include.m4 \
                       config/t8_vtk.m4
 
 # install t8 data in the correct directory
-t8datadir = $(datadir)/data
+t8datadir = $(datadir)/t8code/data
 
 # setup test environment
 if T8_MPIRUN


### PR DESCRIPTION
Install data of t8code into `<prefix>/share/t8code` instead of directly into `<prefix>/share`. See #152.