### PR TITLE
Write the global tree id when linked with vtk

### DIFF
--- a/src/t8_forest/t8_forest_vtk.cxx
+++ b/src/t8_forest/t8_forest_vtk.cxx
@@ -554,7 +554,7 @@ t8_forest_vtk_write_file_via_API (t8_forest_t forest, const char *fileprefix,
         cellTypes[elem_id] = t8_curved_eclass_vtk_type[element_shape];
       }
       if (write_treeid == 1) {
-        vtk_treeid->InsertNextValue (itree);
+        vtk_treeid->InsertNextValue (gtreeid);
       }
       if (write_mpirank == 1) {
         vtk_mpirank->InsertNextValue (forest->mpirank);


### PR DESCRIPTION
closes #310 
We want to write the global-id just as if t8code wasn't linked with vtk.



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] New tests use the Google Test framework
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
