### PR TITLE
fix in linear id for level < t->level

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
@@ -1342,9 +1342,12 @@ t8_dtri_linear_id (const t8_dtri_t *t, int level)
    * origin with the same type as t */
   if (level > my_level) {
     exponent = (level - my_level) * T8_DTRI_DIM;
+    type_temp = t->type;
+    level = my_level;
   }
-  level = my_level;
-  type_temp = compute_type (t, level);
+  else {
+    type_temp = compute_type (t, level);
+  }
   for (i = level; i > 0; i--) {
     cid = compute_cubeid (t, i);
     id |=


### PR DESCRIPTION
Fix a bug, where the linear id was computed wrong when the level was lower than t->level

level was always set to t->level, even if we want to compute the id on a lower level than t->level. 
Furthermore, the first computation of type_temp was wrong, too, because the level was not set correct. 

This PR fixes this issue.



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] New tests use the Google Test framework
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
