### PR TITLE
Fix face connecitivy bug in read msh file

### DIFF
--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -669,8 +669,8 @@ t8_cmesh_msh_file_2_read_eles (t8_cmesh_t cmesh, FILE *fp,
           (*found_node)->coordinates[2]
         };
 
-        list_of_tree_vertices.
-          push_back (std::make_tuple (node_indices[i], vert));
+        list_of_tree_vertices.push_back (std::
+                                         make_tuple (node_indices[i], vert));
       }
 
       /* We sort the list of tree vertices according to morton ordering. */

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -28,9 +28,9 @@
 #include <t8_geometry/t8_geometry_implementations/t8_geometry_occ.h>
 #include "t8_cmesh_types.h"
 #include "t8_cmesh_stash.h"
-#include <list>         // std::list
-#include <tuple>        // std::tuple
-#include <vector>       // std::vector
+#include <list>                 // std::list
+#include <tuple>                // std::tuple
+#include <vector>               // std::vector
 
 /* The supported number of gmesh tree classes.
  * Currently, we only support first order trees.
@@ -529,14 +529,18 @@ die_node:
 }
 
 static bool
-compare_by_morton_ordering(const std::tuple<long,std::vector<double>> &a, const std::tuple<long,std::vector<double>> &b)
+compare_by_morton_ordering (const std::tuple < long,
+                            std::vector < double >>&a,
+                            const std::tuple < long,
+                            std::vector < double >>&b)
 {
   /* Extract vectors from tuple arguments. */
-  const std::vector<double> v = std::get<1>(a);
-  const std::vector<double> w = std::get<1>(b);
+  const               std::vector < double >v = std::get < 1 > (a);
+  const               std::vector < double >w = std::get < 1 > (b);
 
   /* Z-ordering: first sorts y-components, then y-components and then x-components. */
-  return v[2] < w[2] || (v[2] == w[2] && (v[1] < w[1] || (v[1] == w[1] && v[0] < w[0])));
+  return v[2] < w[2] || (v[2] == w[2]
+                         && (v[1] < w[1] || (v[1] == w[1] && v[0] < w[0])));
 }
 
 /* fp should be set after the Nodes section, right before the tree section.
@@ -652,31 +656,34 @@ t8_cmesh_msh_file_2_read_eles (t8_cmesh_t cmesh, FILE *fp,
 
       /* List of tree vertices containing tuples of a node index and
        * its associated vector of tree vertex. */
-      std::list<std::tuple<long,std::vector<double>>> list_of_tree_vertices;
+      std::list < std::tuple < long,
+        std::vector < double >>>list_of_tree_vertices;
 
       for (i = 0; i < num_nodes; i++) {
         Node.index = node_indices[i];
         sc_hash_lookup (vertices, (void *) &Node, (void ***) &found_node);
 
-        std::vector<double> vert = {
+        std::vector < double >vert = {
           (*found_node)->coordinates[0],
           (*found_node)->coordinates[1],
-          (*found_node)->coordinates[2]};
+          (*found_node)->coordinates[2]
+        };
 
-        list_of_tree_vertices.push_back (std::make_tuple (node_indices[i],vert));
+        list_of_tree_vertices.
+          push_back (std::make_tuple (node_indices[i], vert));
       }
 
       /* We sort the list of tree vertices according to morton ordering. */
-      list_of_tree_vertices.sort(compare_by_morton_ordering);
+      list_of_tree_vertices.sort (compare_by_morton_ordering);
 
       /* Copy (sorted) vertices back to their conventional C arrays. */
       i = 0;
-      for (auto t : list_of_tree_vertices) {
-        node_indices[i] = std::get<0>(t);
+    for (auto t:list_of_tree_vertices) {
+        node_indices[i] = std::get < 0 > (t);
 
-        tree_vertices[3 * i + 0] = std::get<1>(t)[0];
-        tree_vertices[3 * i + 1] = std::get<1>(t)[1];
-        tree_vertices[3 * i + 2] = std::get<1>(t)[2];
+        tree_vertices[3 * i + 0] = std::get < 1 > (t)[0];
+        tree_vertices[3 * i + 1] = std::get < 1 > (t)[1];
+        tree_vertices[3 * i + 2] = std::get < 1 > (t)[2];
 
         i++;
       }

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -1605,9 +1605,10 @@ t8_cmesh_msh_file_find_neighbors (t8_cmesh_t cmesh,
     tree_vertices = *(long **) t8_sc_array_index_locidx (vertex_indices,
                                                          gtree_it);
 
-    t8_debugf ("# itree = %d\n",gtree_it);
-    t8_debugf ("# verts = %ld %ld %ld %ld\n",tree_vertices[0],tree_vertices[1],tree_vertices[2],tree_vertices[3]);
-    t8_debugf ("\n");
+    // Gonne be deleted later.
+    // t8_debugf ("# itree = %d\n",gtree_it);
+    // t8_debugf ("# verts = %ld %ld %ld %ld\n",tree_vertices[0],tree_vertices[1],tree_vertices[2],tree_vertices[3]);
+    // t8_debugf ("\n");
 
     /* loop over all faces of the tree */
     for (face_it = 0; face_it < t8_eclass_num_faces[eclass]; face_it++) {
@@ -1629,10 +1630,11 @@ t8_cmesh_msh_file_find_neighbors (t8_cmesh_t cmesh,
       /* Try to insert the face into the hash */
       retval = sc_hash_insert_unique (faces, Face, (void ***) &pNeighbor);
 
-      t8_debugf ("itree = %d\n",gtree_it);
-      t8_debugf ("iface = %d\n",face_it);
-      t8_debugf ("verts = %ld %ld\n",Face->vertices[0],Face->vertices[1]);
-      t8_debugf ("\n");
+      // Gonne be deleted later.
+      // t8_debugf ("itree = %d\n",gtree_it);
+      // t8_debugf ("iface = %d\n",face_it);
+      // t8_debugf ("verts = %ld %ld\n",Face->vertices[0],Face->vertices[1]);
+      // t8_debugf ("\n");
 
       if (!retval) {
         /* The face was already in the hash */

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -1613,6 +1613,11 @@ t8_cmesh_msh_file_find_neighbors (t8_cmesh_t cmesh,
     /* Get the vertices of that tree */
     tree_vertices = *(long **) t8_sc_array_index_locidx (vertex_indices,
                                                          gtree_it);
+
+    t8_debugf ("# itree = %d\n",gtree_it);
+    t8_debugf ("# verts = %ld %ld %ld %ld\n",tree_vertices[0],tree_vertices[1],tree_vertices[2],tree_vertices[3]);
+    t8_debugf ("\n");
+
     /* loop over all faces of the tree */
     for (face_it = 0; face_it < t8_eclass_num_faces[eclass]; face_it++) {
       /* Create the Face struct */
@@ -1632,6 +1637,12 @@ t8_cmesh_msh_file_find_neighbors (t8_cmesh_t cmesh,
       }
       /* Try to insert the face into the hash */
       retval = sc_hash_insert_unique (faces, Face, (void ***) &pNeighbor);
+
+      t8_debugf ("itree = %d\n",gtree_it);
+      t8_debugf ("iface = %d\n",face_it);
+      t8_debugf ("verts = %ld %ld\n",Face->vertices[0],Face->vertices[1]);
+      t8_debugf ("\n");
+
       if (!retval) {
         /* The face was already in the hash */
         Neighbor = *pNeighbor;

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1515,6 +1515,7 @@ t8_forest_element_face_neighbor (t8_forest_t forest,
      * boundary element. */
     /* Compute the face of elem_tree at which the face connection is. */
     tree_face = ts->t8_element_tree_face (elem, face);
+
     /* compute coarse tree id */
     lctree_id = t8_forest_ltreeid_to_cmesh_ltreeid (forest, ltreeid);
     if (t8_cmesh_tree_face_is_boundary (cmesh, lctree_id, tree_face)) {
@@ -1651,6 +1652,8 @@ t8_forest_element_half_face_neighbors (t8_forest_t forest,
    */
   ts->t8_element_children_at_face (elem, face, children_at_face,
                                    num_children_at_face, NULL);
+
+
   /* For each face_child build its neighbor */
   for (child_it = 0; child_it < num_children_at_face; child_it++) {
     /* The face number of the face of the child that coincides with face
@@ -1658,6 +1661,7 @@ t8_forest_element_half_face_neighbors (t8_forest_t forest,
      * We thus have to compute the face number of the child first.
      */
     child_face = ts->t8_element_face_child_face (elem, face, child_it);
+
     neighbor_tree = t8_forest_element_face_neighbor (forest, ltreeid,
                                                      children_at_face
                                                      [child_it],
@@ -1723,6 +1727,7 @@ t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid,
     /* If we are at the maximum refinement level, we compute the neighbor instead */
     at_maxlevel =
       ts->t8_element_level (leaf) == t8_forest_get_maxlevel (forest);
+
     if (at_maxlevel) {
       num_children_at_face = 1;
       neighbor_leafs = *pneighbor_leafs = T8_ALLOC (t8_element_t *, 1);
@@ -1748,6 +1753,7 @@ t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid,
                                                neigh_scheme, face,
                                                num_children_at_face,
                                                *dual_faces);
+
     }
     if (gneigh_treeid < 0) {
       /* There exists no face neighbor across this face, we return with this info */

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1515,7 +1515,6 @@ t8_forest_element_face_neighbor (t8_forest_t forest,
      * boundary element. */
     /* Compute the face of elem_tree at which the face connection is. */
     tree_face = ts->t8_element_tree_face (elem, face);
-
     /* compute coarse tree id */
     lctree_id = t8_forest_ltreeid_to_cmesh_ltreeid (forest, ltreeid);
     if (t8_cmesh_tree_face_is_boundary (cmesh, lctree_id, tree_face)) {
@@ -1652,8 +1651,6 @@ t8_forest_element_half_face_neighbors (t8_forest_t forest,
    */
   ts->t8_element_children_at_face (elem, face, children_at_face,
                                    num_children_at_face, NULL);
-
-
   /* For each face_child build its neighbor */
   for (child_it = 0; child_it < num_children_at_face; child_it++) {
     /* The face number of the face of the child that coincides with face
@@ -1661,7 +1658,6 @@ t8_forest_element_half_face_neighbors (t8_forest_t forest,
      * We thus have to compute the face number of the child first.
      */
     child_face = ts->t8_element_face_child_face (elem, face, child_it);
-
     neighbor_tree = t8_forest_element_face_neighbor (forest, ltreeid,
                                                      children_at_face
                                                      [child_it],
@@ -1727,7 +1723,6 @@ t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid,
     /* If we are at the maximum refinement level, we compute the neighbor instead */
     at_maxlevel =
       ts->t8_element_level (leaf) == t8_forest_get_maxlevel (forest);
-
     if (at_maxlevel) {
       num_children_at_face = 1;
       neighbor_leafs = *pneighbor_leafs = T8_ALLOC (t8_element_t *, 1);
@@ -1753,7 +1748,6 @@ t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid,
                                                neigh_scheme, face,
                                                num_children_at_face,
                                                *dual_faces);
-
     }
     if (gneigh_treeid < 0) {
       /* There exists no face neighbor across this face, we return with this info */


### PR DESCRIPTION
**_Describe your changes here:_**

This is a proposal on how to circumvent the issue with mesh files created by Gmsh which do not
adhere to the canonical node ordering according to http://www.manpagez.com/info/gmsh/gmsh-2.2.6/gmsh_65.php#SEC65.

See https://github.com/DLR-AMR/t8code/issues/318 for more details.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] New tests use the Google Test framework
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
