### PR TITLE
Check whether a given geometry is linear.

### DIFF
--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
@@ -21,6 +21,7 @@
 */
 
 #include <t8_geometry/t8_geometry_implementations/t8_geometry_linear.hxx>
+#include <t8_geometry/t8_geometry_implementations/t8_geometry_linear.h>
 #include <t8_geometry/t8_geometry_helpers.h>
 
 t8_geometry_linear::t8_geometry_linear (int dim):
@@ -98,13 +99,26 @@ t8_geometry_linear_new (int dimension)
 void
 t8_geometry_linear_destroy (t8_geometry_c **geom)
 {
-#ifdef T8_ENABLE_DEBUG
-  t8_geometry_c      *pgeom = *geom;
-  T8_ASSERT (dynamic_cast < t8_geometry_linear * >(pgeom) != NULL);
-#endif
+  T8_ASSERT (geom != NULL);
+  T8_ASSERT (t8_geom_is_linear (*geom));
 
   delete             *geom;
   *geom = NULL;
 }
+
+#if T8_ENABLE_DEBUG
+int
+t8_geom_is_linear (const t8_geometry_c *geometry)
+{
+  /* Try to dynamic cast the geometry into linear geometry. This is only successful if
+   * geometry pointed to a t8_geometry_linear.
+   * If successful, then is_linear_geom will be true.
+   */
+  const int           is_linear_geom =
+    (dynamic_cast < const t8_geometry_linear * >(geometry) != NULL);
+
+  return is_linear_geom;
+}
+#endif
 
 T8_EXTERN_C_END ();

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.h
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.h
@@ -44,6 +44,15 @@ t8_geometry_c      *t8_geometry_linear_new (int dimension);
  */
 void                t8_geometry_linear_destroy (t8_geometry_c **geom);
 
+#if T8_ENABLE_DEBUG
+/** Query whether a given geometry is \ref t8_geometry_linear.
+ * \param [in] geometry   A geometry.
+ * \return     True (non-zero) if and only if the geometry is of type \ref t8_geometry_linear.
+ * \note       This function is currently only available in debug mode.
+ */
+int                 t8_geom_is_linear (const t8_geometry_c *geometry);
+#endif
+
 T8_EXTERN_C_END ();
 
 #endif /* !T8_GEOMETRY_LINEAR_H! */


### PR DESCRIPTION
**_Describe your changes here:_**

We implement a check function that queries whether a given geometry is of type t8_geometry_linear.
This function is required in some forest geometry implementations that assume that a given geometry is linear.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] New tests use the Google Test framework
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [x] Testing of this template: If you feel something is missing from this list, contact the developers
