### PR TITLE
Fix an uninitialized memory error in debug printing in partition

### DIFF
--- a/src/t8_forest/t8_forest_partition.cxx
+++ b/src/t8_forest/t8_forest_partition.cxx
@@ -912,6 +912,9 @@ t8_forest_partition_recv_message (t8_forest_t forest, sc_MPI_Comm comm,
     mpiret = sc_MPI_Get_count (status, sc_MPI_BYTE, &recv_bytes);
     SC_CHECK_MPI (mpiret);
   }
+  else {
+    recv_bytes = byte_to_self;
+  }
   t8_debugf ("Receiving message of %i bytes from process %i\n", recv_bytes,
              proc);
 


### PR DESCRIPTION
**_Describe your changes here:_**

Mini bugfix. When partition was executed with a single process a debugging message was printing 
an uninitialized value. This came up when running the code with valgrind.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [ ] New tests use the Google Test framework
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
