### PR TITLE
More const parameter in second linear_id-test

### DIFF
--- a/test/t8_schemes/t8_gtest_init_linear_id.cxx
+++ b/test/t8_schemes/t8_gtest_init_linear_id.cxx
@@ -124,30 +124,23 @@ TEST_P(linear_id, id_at_other_level)
   const int max_lvl = 4;
   const int add_lvl = 3;
 #endif
-  int level;
-  t8_linearidx_t  num_desc;   /* number of descendants from the root (number of elements to check) */
-  t8_linearidx_t  child_desc; /* Number of descendants of the current element */
-  t8_linearidx_t  id;         /* id of the element at level */
-  t8_linearidx_t  leaf_id;    /* current leaf_id, relative to the current element */
-  t8_linearidx_t  id_at_lvl;  /* The id of the element at level level+add_lvl */
-  t8_linearidx_t  test_id;    /* The computed id at level level of the descendant */
-  for (level = 0; level < max_lvl; level++) {
+  for (int level = 0; level < max_lvl; level++) {
     /* Compute the number of elements at the current level */
-    num_desc = ts->t8_element_count_leafs_from_root (level);
-    for (id = 0; id < num_desc; id++) {
+    const t8_linearidx_t num_desc = ts->t8_element_count_leafs_from_root (level);
+    for (t8_linearidx_t id = 0; id < num_desc; id++) {
       /* Set the child at the current level */
       ts->t8_element_set_linear_id(child, level, id); 
       /* Compute the id of child at a higher level. */
-      id_at_lvl = ts->t8_element_get_linear_id(child, level+add_lvl);
+      const t8_linearidx_t id_at_lvl = ts->t8_element_get_linear_id(child, level+add_lvl);
       /* Compute how many leafs/descendants child has at level level+add_lvl */
-      child_desc = ts->t8_element_count_leafs(child, level + add_lvl);
+      const t8_linearidx_t child_desc = ts->t8_element_count_leafs(child, level + add_lvl);
       /* Iterate over all descendants */
-      for(leaf_id = 0; leaf_id < child_desc; leaf_id++){
+      for(t8_linearidx_t leaf_id = 0; leaf_id < child_desc; leaf_id++){
         /* Set the descendant (test) at level of the descendants and shift the 
          * leaf_id into the region of the descendants of child*/
         ts->t8_element_set_linear_id(test, level + add_lvl, id_at_lvl + leaf_id);
         /* Compute the id of the descendant (test) at the current level */
-        test_id = ts->t8_element_get_linear_id(test, level);
+        const t8_linearidx_t test_id = ts->t8_element_get_linear_id(test, level);
         /* test_id and id should be equal. */
         EXPECT_EQ(id, test_id);
       }


### PR DESCRIPTION
Similar to the first test I updated the scope of variables in the test and made the const if possible.



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [x] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] New tests use the Google Test framework
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [x] Testing of this template: If you feel something is missing from this list, contact the developers
