### PR TITLE
Preparation for improved way to access parent/ancestor information of pyramids 

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -60,6 +60,7 @@ t8_default_scheme_pyramid_c::t8_element_init (int length, t8_element_t *elem,
       t8_dpyramid_init_linear_id (pyramid + i, 0, 0);
       T8_ASSERT (t8_dpyramid_is_valid (pyramid + i));
     }
+    pyramid->pyramid.type = 6;
   }
 #endif
 }
@@ -300,7 +301,7 @@ t8_default_scheme_pyramid_c::t8_element_is_family (t8_element_t **fam)
     T8_ASSERT (t8_element_is_valid (fam[i]));
   }
 #endif
-  return t8_dpyramid_is_family ((const t8_dpyramid_t **) fam);
+  return t8_dpyramid_is_family ((t8_dpyramid_t **) fam);
 }
 
 int
@@ -420,9 +421,9 @@ t8_default_scheme_pyramid_c::t8_element_anchor (const t8_element_t *elem,
   t8_dpyramid_t      *pyra = (t8_dpyramid_t *) elem;
 
   T8_ASSERT (t8_element_is_valid (elem));
-  anchor[0] = pyra->x;
-  anchor[1] = pyra->y;
-  anchor[2] = pyra->z;
+  anchor[0] = pyra->pyramid.x;
+  anchor[1] = pyra->pyramid.y;
+  anchor[2] = pyra->pyramid.z;
 }
 
 void
@@ -475,9 +476,10 @@ t8_default_scheme_pyramid_c::t8_element_general_function (const t8_element_t
 {
   T8_ASSERT (outdata != NULL);
   T8_ASSERT (t8_element_is_valid (elem));
-  *((int8_t *) outdata) = ((const t8_dpyramid_t *) elem)->type;
+  *((int8_t *) outdata) = ((const t8_dpyramid_t *) elem)->pyramid.type;
   /* Safety check to catch datatype conversion errors */
-  T8_ASSERT (*((int8_t *) outdata) == ((const t8_dpyramid_t *) elem)->type);
+  T8_ASSERT (*((int8_t *) outdata) ==
+             ((const t8_dpyramid_t *) elem)->pyramid.type);
 }
 
 #ifdef T8_ENABLE_DEBUG

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid.h
@@ -55,7 +55,17 @@ typedef int32_t     t8_dpyramid_coord_t;
 */
 typedef int8_t t8_dpyramid_type_t;
 
-/** This data type stores a pyramid. */
-typedef t8_dtet_t t8_dpyramid_t;
+/**
+ * This data type stores a pyramid. 
+ * The coordinates, the level and the type of a pyramid are stored in the tet-struct \a pyramid.
+ * Level, at which the shape switches from tet, to pyra. -1 if not computed for a pyramid with the shape of a tet
+ * undefined, if the pyramid has the shape of a pyramid.
+ */
+typedef struct t8_dpyramid
+{
+  t8_dtet_t           pyramid;  /* Coordinates, level and type */
+  int8_t              switch_shape_at_level;
+}
+t8_dpyramid_t;
 
 #endif /* T8_DPYRAMID_H */

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -37,16 +37,16 @@ compute_cubeid (const t8_dpyramid_t *p, const int level)
   t8_dpyramid_cube_id_t cube_id = 0;
   t8_dpyramid_coord_t h;
 
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   h = T8_DPYRAMID_LEN (level);
 
   if (level == 0) {
     return 0;
   }
-
-  cube_id |= ((p->x & h) ? 0x01 : 0);
-  cube_id |= ((p->y & h) ? 0x02 : 0);
-  cube_id |= ((p->z & h) ? 0x04 : 0);
+  cube_id |= ((p->pyramid.x & h) ? 0x01 : 0);
+  cube_id |= ((p->pyramid.y & h) ? 0x02 : 0);
+  cube_id |= ((p->pyramid.z & h) ? 0x04 : 0);
 
   return cube_id;
 }
@@ -76,8 +76,9 @@ compute_type_same_shape_ext (const t8_dpyramid_t *p, const int level,
   int                 i;
 
   T8_ASSERT (0 <= level && level <= known_level);
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
-  T8_ASSERT (known_level <= p->level);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (known_level <= p->pyramid.level);
   if (level == known_level) {
     return known_type;
   }
@@ -107,8 +108,10 @@ compute_type_same_shape_ext (const t8_dpyramid_t *p, const int level,
 t8_dpyramid_type_t
 compute_type_same_shape (const t8_dpyramid_t *p, const int level)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
-  return compute_type_same_shape_ext (p, level, p->type, p->level);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
+  return compute_type_same_shape_ext (p, level, p->pyramid.type,
+                                      p->pyramid.level);
 }
 
 /**
@@ -121,80 +124,111 @@ static void
 t8_dpyramid_cut_coordinates (t8_dpyramid_t *p, const int shift)
 {
   T8_ASSERT (0 <= shift && shift <= T8_DPYRAMID_MAXLEVEL);
-  p->x = (p->x >> shift) << shift;
-  p->y = (p->y >> shift) << shift;
-  p->z = (p->z >> shift) << shift;
+  p->pyramid.x = (p->pyramid.x >> shift) << shift;
+  p->pyramid.y = (p->pyramid.y >> shift) << shift;
+  p->pyramid.z = (p->pyramid.z >> shift) << shift;
 }
 
 int
 t8_dpyramid_ancestor_id (const t8_dpyramid_t *p, const int level)
 {
   t8_dpyramid_t       helper;
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   t8_dpyramid_ancestor (p, level, &helper);
   return t8_dpyramid_child_id (&helper);
 }
 
 int
-t8_dpyramid_is_family (const t8_dpyramid_t **fam)
+t8_dpyramid_is_family (t8_dpyramid_t **fam)
 {
 
-  const int           level = fam[0]->level;
+  const int           level = fam[0]->pyramid.level;
   int                 i, type_of_first;
   t8_dpyramid_coord_t inc = T8_DPYRAMID_LEN (level), x_inc, y_inc;
   if (t8_dpyramid_shape (fam[0]) == T8_ECLASS_TET) {
-    return t8_dtet_is_familypv (fam);
+    int                 is_family;
+    t8_dtet_t         **tet_fam = T8_ALLOC (t8_dtet_t *, T8_DTET_CHILDREN);
+    for (i = 0; i < T8_DTET_CHILDREN; i++) {
+      tet_fam[i] = &fam[i]->pyramid;
+    }
+
+    is_family = t8_dtet_is_familypv ((const t8_dtet_t **) tet_fam);
+    T8_FREE (tet_fam);
+    return is_family;
   }
   else {
     if (level == 0) {
       return 0;
     }
     /*The type of parent is the type of the first child in z-curve-order */
-    type_of_first = fam[0]->type;
+    type_of_first = fam[0]->pyramid.type;
     T8_ASSERT (type_of_first == T8_DPYRAMID_FIRST_TYPE
                || type_of_first == T8_DPYRAMID_SECOND_TYPE);
     for (i = 1; i < T8_DPYRAMID_CHILDREN; i++) {
       /*All elements must have the same level to be a family */
-      if (fam[i]->level != level) {
+      if (fam[i]->pyramid.level != level) {
         return 0;
       }
       /*Check if every family-member has the correct type */
       if (t8_dpyramid_parenttype_Iloc_to_type[type_of_first][i] !=
-          fam[i]->type) {
+          fam[i]->pyramid.type) {
         return 0;
       }
     }
 
-    x_inc = fam[0]->x + inc;
-    y_inc = fam[0]->y + inc;
+    x_inc = fam[0]->pyramid.x + inc;
+    y_inc = fam[0]->pyramid.y + inc;
     /*Check the coordinates of the anchor-coordinate */
     if (type_of_first == T8_DPYRAMID_FIRST_TYPE) {
-      return fam[0]->z == fam[1]->z && fam[0]->z == fam[2]->z
-        && fam[0]->z == fam[3]->z && fam[0]->z == fam[4]->z
-        && fam[0]->z == fam[5]->z && fam[0]->z == fam[6]->z
-        && fam[0]->z == fam[7]->z && fam[0]->z == fam[8]->z
-        && fam[0]->z == (fam[9]->z - inc) && fam[0]->x == fam[3]->x
-        && fam[0]->x == fam[4]->x && x_inc == fam[1]->x && x_inc == fam[2]->x
-        && x_inc == fam[5]->x && x_inc == fam[6]->x && x_inc == fam[7]->x
-        && x_inc == fam[8]->x && x_inc == fam[9]->x && fam[0]->y == fam[1]->y
-        && fam[0]->y == fam[2]->y && y_inc == fam[3]->y && y_inc == fam[4]->y
-        && y_inc == fam[5]->y && y_inc == fam[6]->y && y_inc == fam[7]->y
-        && y_inc == fam[8]->y && y_inc == fam[9]->y;
+      return fam[0]->pyramid.z == fam[1]->pyramid.z
+        && fam[0]->pyramid.z == fam[2]->pyramid.z
+        && fam[0]->pyramid.z == fam[3]->pyramid.z
+        && fam[0]->pyramid.z == fam[4]->pyramid.z
+        && fam[0]->pyramid.z == fam[5]->pyramid.z
+        && fam[0]->pyramid.z == fam[6]->pyramid.z
+        && fam[0]->pyramid.z == fam[7]->pyramid.z
+        && fam[0]->pyramid.z == fam[8]->pyramid.z
+        && fam[0]->pyramid.z == (fam[9]->pyramid.z - inc)
+        && fam[0]->pyramid.x == fam[3]->pyramid.x
+        && fam[0]->pyramid.x == fam[4]->pyramid.x
+        && x_inc == fam[1]->pyramid.x && x_inc == fam[2]->pyramid.x
+        && x_inc == fam[5]->pyramid.x && x_inc == fam[6]->pyramid.x
+        && x_inc == fam[7]->pyramid.x && x_inc == fam[8]->pyramid.x
+        && x_inc == fam[9]->pyramid.x
+        && fam[0]->pyramid.y == fam[1]->pyramid.y
+        && fam[0]->pyramid.y == fam[2]->pyramid.y
+        && y_inc == fam[3]->pyramid.y && y_inc == fam[4]->pyramid.y
+        && y_inc == fam[5]->pyramid.y && y_inc == fam[6]->pyramid.y
+        && y_inc == fam[7]->pyramid.y && y_inc == fam[8]->pyramid.y
+        && y_inc == fam[9]->pyramid.y;
     }
     else {
-      return fam[1]->z == fam[0]->z + inc && fam[1]->z == fam[2]->z
-        && fam[1]->z == fam[3]->z && fam[1]->z == fam[4]->z
-        && fam[1]->z == fam[5]->z && fam[1]->z == fam[6]->z
-        && fam[1]->z == fam[7]->z && fam[1]->z == fam[8]->z
-        && fam[1]->z == fam[9]->z && fam[0]->x == fam[1]->x
-        && fam[0]->x == fam[2]->x && fam[0]->x == fam[3]->x
-        && fam[0]->x == fam[4]->x && fam[0]->x == fam[7]->x
-        && fam[0]->x == fam[8]->x && x_inc == fam[5]->x && x_inc == fam[6]->x
-        && x_inc == fam[9]->x && fam[0]->y == fam[1]->y
-        && fam[0]->y == fam[2]->y && fam[0]->y == fam[3]->y
-        && fam[0]->y == fam[4]->y && fam[0]->y == fam[5]->y
-        && fam[0]->y == fam[6]->y && y_inc == fam[7]->y && y_inc == fam[8]->y
-        && y_inc == fam[9]->y;
+      return fam[1]->pyramid.z == fam[0]->pyramid.z + inc
+        && fam[1]->pyramid.z == fam[2]->pyramid.z
+        && fam[1]->pyramid.z == fam[3]->pyramid.z
+        && fam[1]->pyramid.z == fam[4]->pyramid.z
+        && fam[1]->pyramid.z == fam[5]->pyramid.z
+        && fam[1]->pyramid.z == fam[6]->pyramid.z
+        && fam[1]->pyramid.z == fam[7]->pyramid.z
+        && fam[1]->pyramid.z == fam[8]->pyramid.z
+        && fam[1]->pyramid.z == fam[9]->pyramid.z
+        && fam[0]->pyramid.x == fam[1]->pyramid.x
+        && fam[0]->pyramid.x == fam[2]->pyramid.x
+        && fam[0]->pyramid.x == fam[3]->pyramid.x
+        && fam[0]->pyramid.x == fam[4]->pyramid.x
+        && fam[0]->pyramid.x == fam[7]->pyramid.x
+        && fam[0]->pyramid.x == fam[8]->pyramid.x
+        && x_inc == fam[5]->pyramid.x && x_inc == fam[6]->pyramid.x
+        && x_inc == fam[9]->pyramid.x
+        && fam[0]->pyramid.y == fam[1]->pyramid.y
+        && fam[0]->pyramid.y == fam[2]->pyramid.y
+        && fam[0]->pyramid.y == fam[3]->pyramid.y
+        && fam[0]->pyramid.y == fam[4]->pyramid.y
+        && fam[0]->pyramid.y == fam[5]->pyramid.y
+        && fam[0]->pyramid.y == fam[6]->pyramid.y
+        && y_inc == fam[7]->pyramid.y && y_inc == fam[8]->pyramid.y
+        && y_inc == fam[9]->pyramid.y;
     }
   }
 }
@@ -203,25 +237,26 @@ int
 t8_dpyramid_is_root_boundary (const t8_dpyramid_t *p, const int face)
 {
   T8_ASSERT (0 <= face && face <= T8_DPYRAMID_FACES);
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
-  t8_dpyramid_coord_t coord_touching_root = T8_DPYRAMID_ROOT_LEN -
-    T8_DPYRAMID_LEN (p->level);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
+  t8_dpyramid_coord_t coord_touching_root =
+    T8_DPYRAMID_ROOT_LEN - T8_DPYRAMID_LEN (p->pyramid.level);
   if (!t8_dpyramid_is_inside_root (p)) {
     return 0;
   }
-  switch (p->type) {
+  switch (p->pyramid.type) {
   case 0:
-    return (face == 1 && p->x == p->z) ||
-      (face == 0 && p->x == coord_touching_root);
+    return (face == 1 && p->pyramid.x == p->pyramid.z) ||
+      (face == 0 && p->pyramid.x == coord_touching_root);
   case 1:
-    return (face == 2 && p->y == p->z) ||
-      (face == 0 && p->x == coord_touching_root);
+    return (face == 2 && p->pyramid.y == p->pyramid.z) ||
+      (face == 0 && p->pyramid.x == coord_touching_root);
   case 2:
-    return (face == 2 && p->x == p->z) ||
-      (face == 0 && p->y == coord_touching_root);
+    return (face == 2 && p->pyramid.x == p->pyramid.z) ||
+      (face == 0 && p->pyramid.y == coord_touching_root);
   case 3:
-    return (face == 1 && p->y == p->z) ||
-      (face == 0 && p->y == coord_touching_root);
+    return (face == 1 && p->pyramid.y == p->pyramid.z) ||
+      (face == 0 && p->pyramid.y == coord_touching_root);
   case 4:
     return 0;                   /*type 4 tets never touch a root boundary */
   case 5:
@@ -229,15 +264,15 @@ t8_dpyramid_is_root_boundary (const t8_dpyramid_t *p, const int face)
   case T8_DPYRAMID_FIRST_TYPE:
     switch (face) {
     case 0:
-      return p->x == p->z;
+      return p->pyramid.x == p->pyramid.z;
     case 1:
-      return p->x == coord_touching_root;
+      return p->pyramid.x == coord_touching_root;
     case 2:
-      return p->y == p->z;
+      return p->pyramid.y == p->pyramid.z;
     case 3:
-      return p->y == coord_touching_root;
+      return p->pyramid.y == coord_touching_root;
     case 4:
-      return p->z == 0;
+      return p->pyramid.z == 0;
     default:
       SC_ABORT_NOT_REACHED ();
     }
@@ -264,23 +299,25 @@ t8_dpyramid_compare (const t8_dpyramid_t *p1, const t8_dpyramid_t *p2)
 {
   int                 maxlvl;
   t8_linearidx_t      id1, id2;
-  T8_ASSERT (p1->x >= 0 && p1->y >= 0 && p1->z >= 0 &&
-             p1->level >= 0 && p1->level <= T8_DPYRAMID_MAXLEVEL);
-  T8_ASSERT (p2->x >= 0 && p2->y >= 0 && p2->z >= 0 &&
-             p2->level >= 0 && p2->level <= T8_DPYRAMID_MAXLEVEL);
-  maxlvl = SC_MAX (p1->level, p2->level);
+  T8_ASSERT (p1->pyramid.x >= 0 && p1->pyramid.y >= 0 && p1->pyramid.z >= 0 &&
+             p1->pyramid.level >= 0
+             && p1->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (p2->pyramid.x >= 0 && p2->pyramid.y >= 0 && p2->pyramid.z >= 0
+             && p2->pyramid.level >= 0
+             && p2->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
+  maxlvl = SC_MAX (p1->pyramid.level, p2->pyramid.level);
 
   id1 = t8_dpyramid_linear_id (p1, maxlvl);
   id2 = t8_dpyramid_linear_id (p2, maxlvl);
   if (id1 == id2) {
     /* The linear ids are the same, the pyramid with the smaller level
      * is considered smaller */
-    if (p1->level == p2->level) {
-      T8_ASSERT (p1->type == p2->type);
+    if (p1->pyramid.level == p2->pyramid.level) {
+      T8_ASSERT (p1->pyramid.type == p2->pyramid.type);
       return 0;
     }
     else {
-      return p1->level - p2->level;
+      return p1->pyramid.level - p2->pyramid.level;
     }
   }
   /* return negative if id1 < id2, zero if id1 = id2, positive if id1 >
@@ -291,8 +328,9 @@ t8_dpyramid_compare (const t8_dpyramid_t *p1, const t8_dpyramid_t *p2)
 int
 t8_dpyramid_get_level (const t8_dpyramid_t *p)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
-  return p->level;
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
+  return p->pyramid.level;
 }
 
 /**
@@ -348,10 +386,10 @@ t8_dpyramid_init_linear_id (t8_dpyramid_t *p, const int level,
   T8_ASSERT (0 <= level && level <= T8_DPYRAMID_MAXLEVEL);
   T8_ASSERT (0 <= id && id <= 2 * p_sum1 - p_sum2);
 
-  p->level = level;
-  p->x = 0;
-  p->y = 0;
-  p->z = 0;
+  p->pyramid.level = level;
+  p->pyramid.x = 0;
+  p->pyramid.y = 0;
+  p->pyramid.z = 0;
   type = T8_DPYRAMID_ROOT_TPYE; /*This is the type of the root pyramid */
   for (i = 1; i <= level; i++) {
     offset_expo = T8_DPYRAMID_MAXLEVEL - i;
@@ -360,12 +398,12 @@ t8_dpyramid_init_linear_id (t8_dpyramid_t *p, const int level,
     // Thy types of the tetrahedron children of pyramid are always 0 or 3
     if (type == 0 || type == 3) {
       /* Ensure that a valid tet is used in init_linear_id_with_level */
-      p->type = type;
-      p->level = i;
+      p->pyramid.type = type;
+      p->pyramid.level = i;
 #if T8_ENABLE_DEBUG
       ((t8_dtet_t *) p)->eclass_int8 = T8_ECLASS_TET;
 #endif
-      t8_dtet_init_linear_id_with_level (p, id, i, level, type);
+      t8_dtet_init_linear_id_with_level (&(p->pyramid), id, i, level, type);
       return;
     }
     /* The local index depends on the alternating number of predecessors
@@ -376,16 +414,16 @@ t8_dpyramid_init_linear_id (t8_dpyramid_t *p, const int level,
     cube_id = t8_dpyramid_parenttype_Iloc_to_cid[type][local_index];
     T8_ASSERT (cube_id >= 0);
     /* Set the element in its cube */
-    p->x |= (cube_id % 2 == 1) ? 1 << offset_expo : 0;
-    p->y |= (cube_id == 2 || cube_id == 3 || cube_id == 6 || cube_id == 7) ?
-      1 << offset_expo : 0;
-    p->z |= (cube_id > 3) ? 1 << offset_expo : 0;
+    p->pyramid.x |= (cube_id % 2 == 1) ? 1 << offset_expo : 0;
+    p->pyramid.y |= (cube_id == 2 || cube_id == 3 || cube_id == 6
+                     || cube_id == 7) ? 1 << offset_expo : 0;
+    p->pyramid.z |= (cube_id > 3) ? 1 << offset_expo : 0;
     /*Compute the type */
     type = t8_dpyramid_parenttype_Iloc_to_type[type][local_index];
     T8_ASSERT (type >= 0);
   }
   T8_ASSERT (id == 0);
-  p->type = type;
+  p->pyramid.type = type;
 }
 
 int
@@ -393,8 +431,8 @@ t8_dpyramid_type_at_level (const t8_dpyramid_t *p, const int level)
 {
   T8_ASSERT (0 <= level && level <= T8_DPYRAMID_MAXLEVEL);
 
-  if (level >= p->level) {
-    return p->type;
+  if (level >= p->pyramid.level) {
+    return p->pyramid.type;
   }
   if (t8_dpyramid_shape (p) == T8_ECLASS_PYRAMID) {
     /* The shape does not switch, we can use the compute_type_same_shape function */
@@ -403,8 +441,8 @@ t8_dpyramid_type_at_level (const t8_dpyramid_t *p, const int level)
   else {
     /* The shape may switch */
     T8_ASSERT (t8_dpyramid_shape (p) == T8_ECLASS_TET);
-    int                 current_level = p->level;
-    int                 type_at_level = p->type;
+    int                 current_level = p->pyramid.level;
+    int                 type_at_level = p->pyramid.type;
     /* The shape can not switch for tets that do not have type 0/3 */
     while (type_at_level != 0 && type_at_level != 3 && current_level > level) {
       /* The shape does not switch, we can use compute_type_same_shape_ext */
@@ -425,8 +463,8 @@ t8_dpyramid_type_at_level (const t8_dpyramid_t *p, const int level)
       t8_dpyramid_t       first_pyra;
       t8_dpyramid_t       tmp_pyra;
       t8_dpyramid_copy (p, &tmp_pyra);
-      tmp_pyra.type = type_at_level;
-      tmp_pyra.level = current_level;
+      tmp_pyra.pyramid.type = type_at_level;
+      tmp_pyra.pyramid.level = current_level;
       /* Compute the last level where the shape is a tetrahedron. If last_tet_level == 0
        * then the parent is already a pyramid. */
       int                 last_tet_level =
@@ -435,20 +473,21 @@ t8_dpyramid_type_at_level (const t8_dpyramid_t *p, const int level)
         /* last_tet was calculated by t8_dpyramid_is_inside_tet */
         current_level = SC_MAX (last_tet_level, level);
         if (current_level > last_tet_level) {
-          t8_dtet_ancestor (p, current_level, &last_tet);
+          t8_dtet_ancestor (&(p->pyramid), current_level,
+                            &(last_tet.pyramid));
         }
-        type_at_level = last_tet.type;
+        type_at_level = last_tet.pyramid.type;
       }
       else {
         /* last_tet_level is the current_level */
-        t8_dtet_ancestor (p, current_level, &last_tet);
-        type_at_level = last_tet.type;
+        t8_dtet_ancestor (&(p->pyramid), current_level, &(last_tet.pyramid));
+        type_at_level = last_tet.pyramid.type;
       }
       /* At this point the shape switches. */
       if (current_level > level) {
         current_level--;
         t8_dpyramid_tetparent_type (&last_tet, &first_pyra);
-        type_at_level = first_pyra.type;
+        type_at_level = first_pyra.pyramid.type;
       }
       /* The shape is now a pyramid, and won't switch anymore. */
       while (current_level > level) {
@@ -468,14 +507,15 @@ t8_dpyramid_type_at_level (const t8_dpyramid_t *p, const int level)
 t8_linearidx_t
 t8_dpyramid_linear_id (const t8_dpyramid_t *p, const int level)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   t8_linearidx_t      id = 0, pyra_shift, sum_1 = 1, sum_2 = 1, local_id;
   t8_dpyramid_t       parent, copy;
   int                 i, num_pyra, num_tet;
 
   t8_dpyramid_copy (p, &copy);
-  copy.type = t8_dpyramid_type_at_level (p, level);
-  copy.level = level;
+  copy.pyramid.type = t8_dpyramid_type_at_level (p, level);
+  copy.pyramid.level = level;
   t8_dpyramid_cut_coordinates (&copy, T8_DPYRAMID_MAXLEVEL - level);
 
   for (i = level; i > 0; i--) {
@@ -496,7 +536,7 @@ t8_dpyramid_linear_id (const t8_dpyramid_t *p, const int level)
     else {
       /* The number of pyramid-predecessors */
       num_pyra =
-        t8_dpyramid_parenttype_iloc_pyra_w_lower_id[parent.type -
+        t8_dpyramid_parenttype_iloc_pyra_w_lower_id[parent.pyramid.type -
                                                     T8_DPYRAMID_FIRST_TYPE]
         [local_id];
     }
@@ -509,7 +549,7 @@ t8_dpyramid_linear_id (const t8_dpyramid_t *p, const int level)
     sum_1 = sum_1 << 3;
     sum_2 *= 6;
   }
-  T8_ASSERT (p->level >= 0);
+  T8_ASSERT (p->pyramid.level >= 0);
   return id;
 }
 
@@ -526,89 +566,95 @@ t8_dpyramid_face_neighbour (const t8_dpyramid_t *p, const int face,
                             t8_dpyramid_t *neigh)
 {
   T8_ASSERT (0 <= face && face < T8_DPYRAMID_FACES);
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
-  t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (p->level);
-  neigh->x = p->x;
-  neigh->y = p->y;
-  neigh->z = p->z;
-  neigh->level = p->level;
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
+  t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (p->pyramid.level);
+  neigh->pyramid.x = p->pyramid.x;
+  neigh->pyramid.y = p->pyramid.y;
+  neigh->pyramid.z = p->pyramid.z;
+  neigh->pyramid.level = p->pyramid.level;
   if (t8_dpyramid_shape (p) == T8_ECLASS_PYRAMID) {
     /*pyramid touches tet or pyra */
     /*Compute the type of the neighbour */
     if (face == 0 || face == 1) {
-      neigh->type = 3;
+      neigh->pyramid.type = 3;
     }
     else if (face == 2 || face == 3) {
-      neigh->type = 0;
+      neigh->pyramid.type = 0;
     }
     else {
       /*face == 4 */
-      neigh->type =
-        ((p->type ==
+      neigh->pyramid.type =
+        ((p->pyramid.type ==
           T8_DPYRAMID_FIRST_TYPE) ? T8_DPYRAMID_SECOND_TYPE :
          T8_DPYRAMID_FIRST_TYPE);
     }
     /*Compute the coords of the neighbour */
     /*Do nothing for face == 0 || face == 2 */
     if (face == 1) {
-      neigh->x += ((p->type == T8_DPYRAMID_FIRST_TYPE) ? length : 0);
-      neigh->y += ((p->type == T8_DPYRAMID_FIRST_TYPE) ? 0 : -length);
+      neigh->pyramid.x +=
+        ((p->pyramid.type == T8_DPYRAMID_FIRST_TYPE) ? length : 0);
+      neigh->pyramid.y +=
+        ((p->pyramid.type == T8_DPYRAMID_FIRST_TYPE) ? 0 : -length);
     }
     else if (face == 3) {
-      neigh->x += ((p->type == T8_DPYRAMID_FIRST_TYPE) ? 0 : -length);
-      neigh->y += ((p->type == T8_DPYRAMID_FIRST_TYPE) ? length : 0);
+      neigh->pyramid.x +=
+        ((p->pyramid.type == T8_DPYRAMID_FIRST_TYPE) ? 0 : -length);
+      neigh->pyramid.y +=
+        ((p->pyramid.type == T8_DPYRAMID_FIRST_TYPE) ? length : 0);
     }
     else if (face == 4) {
-      neigh->z += ((p->type == T8_DPYRAMID_FIRST_TYPE) ? -length : length);
+      neigh->pyramid.z +=
+        ((p->pyramid.type == T8_DPYRAMID_FIRST_TYPE) ? -length : length);
     }
 
-    return t8_dpyramid_type_face_to_nface[p->type -
+    return t8_dpyramid_type_face_to_nface[p->pyramid.type -
                                           T8_DPYRAMID_FIRST_TYPE][face];
   }
   else {
     /*Check if the neighbor is a tet, or a pyra */
-    if (p->type != 0 && p->type != 3) {
+    if (p->pyramid.type != 0 && p->pyramid.type != 3) {
       /*tets of these types never have a pyra-neighbor */
-      return t8_dtet_face_neighbour (p, face, neigh);
+      return t8_dtet_face_neighbour (&(p->pyramid), face, &(neigh->pyramid));
     }
     if (t8_dpyramid_tet_boundary (p, face)) {
       /*tet touches pyra, compute the pyra */
-      if (p->type == 0) {
+      if (p->pyramid.type == 0) {
         switch (face) {
         case 0:
-          neigh->x += length;
-          neigh->type = T8_DPYRAMID_SECOND_TYPE;
+          neigh->pyramid.x += length;
+          neigh->pyramid.type = T8_DPYRAMID_SECOND_TYPE;
           return 3;
         case 1:
-          neigh->type = T8_DPYRAMID_SECOND_TYPE;
+          neigh->pyramid.type = T8_DPYRAMID_SECOND_TYPE;
           return 2;
         case 2:
-          neigh->type = T8_DPYRAMID_FIRST_TYPE;
+          neigh->pyramid.type = T8_DPYRAMID_FIRST_TYPE;
           return 2;
         case 3:
-          neigh->y -= length;
-          neigh->type = T8_DPYRAMID_FIRST_TYPE;
+          neigh->pyramid.y -= length;
+          neigh->pyramid.type = T8_DPYRAMID_FIRST_TYPE;
           return 3;
         default:
           SC_ABORT_NOT_REACHED ();
         }
       }
       else {
-        /*p->type == 3 */
+        /*p->pyramid.type == 3 */
         switch (face) {
         case 0:
-          neigh->y += length;
-          neigh->type = T8_DPYRAMID_SECOND_TYPE;
+          neigh->pyramid.y += length;
+          neigh->pyramid.type = T8_DPYRAMID_SECOND_TYPE;
           return 1;
         case 1:
-          neigh->type = T8_DPYRAMID_SECOND_TYPE;
+          neigh->pyramid.type = T8_DPYRAMID_SECOND_TYPE;
           return 0;
         case 2:
-          neigh->type = T8_DPYRAMID_FIRST_TYPE;
+          neigh->pyramid.type = T8_DPYRAMID_FIRST_TYPE;
           return 0;
         case 3:
-          neigh->x -= length;
-          neigh->type = T8_DPYRAMID_FIRST_TYPE;
+          neigh->pyramid.x -= length;
+          neigh->pyramid.type = T8_DPYRAMID_FIRST_TYPE;
           return 1;
         default:
           SC_ABORT_NOT_REACHED ();
@@ -617,7 +663,7 @@ t8_dpyramid_face_neighbour (const t8_dpyramid_t *p, const int face,
     }
     else {
       /*tet touches tet */
-      return t8_dtet_face_neighbour (p, face, neigh);
+      return t8_dtet_face_neighbour (&(p->pyramid), face, &(neigh->pyramid));
     }
   }
 }
@@ -627,7 +673,8 @@ t8_dpyramid_face_parent_face (const t8_dpyramid_t *elem, const int face)
 {
   t8_dpyramid_t       parent;
   int                 child_id;
-  T8_ASSERT (0 <= elem->level && elem->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= elem->pyramid.level
+             && elem->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   T8_ASSERT (0 <= face && face < T8_DPYRAMID_FACES);
   /*parent is a pyramid */
   if (t8_dpyramid_shape (elem) == T8_ECLASS_PYRAMID) {
@@ -637,7 +684,7 @@ t8_dpyramid_face_parent_face (const t8_dpyramid_t *elem, const int face)
      * of the parent are the same*/
     for (i = 0; i < 4; i++) {
       if (t8_dpyramid_type_face_to_children_at_face
-          [parent.type - T8_DPYRAMID_FIRST_TYPE][face][i]
+          [parent.pyramid.type - T8_DPYRAMID_FIRST_TYPE][face][i]
           == child_id) {
         return face;
       }
@@ -649,12 +696,13 @@ t8_dpyramid_face_parent_face (const t8_dpyramid_t *elem, const int face)
     child_id = t8_dpyramid_child_id_unknown_parent (elem, &parent);
     /*Parent is also a tet, we can call the tet-routine */
     if (t8_dpyramid_shape (&parent) == T8_ECLASS_TET) {
-      return t8_dtet_face_parent_face (elem, face);
+      return t8_dtet_face_parent_face (&(elem->pyramid), face);
     }
     /*tet with a pyramid-parent */
     else {
-      /*Only tets of type 0 or 3 have a pyra-parent. Parent can have type 6 or 7 */
-      if (elem->type == 0 && parent.type == T8_DPYRAMID_FIRST_TYPE) {
+      /*Only tets of type 0 or 3 have a pyra-parent.pyramid. Parent can have type 6 or 7 */
+      if (elem->pyramid.type == 0
+          && parent.pyramid.type == T8_DPYRAMID_FIRST_TYPE) {
         if (child_id == 3 && face == 1) {
           return 0;
         }
@@ -664,7 +712,8 @@ t8_dpyramid_face_parent_face (const t8_dpyramid_t *elem, const int face)
         else
           return -1;
       }
-      else if (elem->type == 3 && parent.type == T8_DPYRAMID_FIRST_TYPE) {
+      else if (elem->pyramid.type == 3
+               && parent.pyramid.type == T8_DPYRAMID_FIRST_TYPE) {
         if (child_id == 1 && face == 1) {
           return 2;
         }
@@ -674,7 +723,8 @@ t8_dpyramid_face_parent_face (const t8_dpyramid_t *elem, const int face)
         else
           return -1;
       }
-      else if (elem->type == 0 && parent.type == T8_DPYRAMID_SECOND_TYPE) {
+      else if (elem->pyramid.type == 0
+               && parent.pyramid.type == T8_DPYRAMID_SECOND_TYPE) {
         if (child_id == 1 && face == 3) {
           return 1;
         }
@@ -684,7 +734,8 @@ t8_dpyramid_face_parent_face (const t8_dpyramid_t *elem, const int face)
         else
           return -1;
       }
-      else if (elem->type == 3 && parent.type == T8_DPYRAMID_SECOND_TYPE) {
+      else if (elem->pyramid.type == 3
+               && parent.pyramid.type == T8_DPYRAMID_SECOND_TYPE) {
         if (child_id == 2 && face == 3) {
           return 3;
         }
@@ -709,16 +760,17 @@ t8_dpyramid_face_parent_face (const t8_dpyramid_t *elem, const int face)
 static int
 t8_dpyramid_tet_pyra_face_connection (const t8_dpyramid_t *p, const int face)
 {
-  T8_ASSERT (p->type == 0 || p->type == 3);
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (p->pyramid.type == 0 || p->pyramid.type == 3);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   /* Depending on its cube-id at its level and its type,
    * 3 faces of a tet connect to a pyramid, one is connecting to a tet*/
-  t8_dpyramid_cube_id_t cube_id = compute_cubeid (p, p->level);
+  t8_dpyramid_cube_id_t cube_id = compute_cubeid (p, p->pyramid.level);
   if ((cube_id == 2 && face != 1) || (cube_id == 6 && face != 2)) {
-    return p->type == 0;
+    return p->pyramid.type == 0;
   }
   else if ((cube_id == 1 && face != 1) || (cube_id == 5 && face != 2)) {
-    return p->type == 3;
+    return p->pyramid.type == 3;
   }
   else if (cube_id == 3) {
     return face != 0;
@@ -734,9 +786,11 @@ t8_dpyramid_tet_pyra_face_connection (const t8_dpyramid_t *p, const int face)
 int
 t8_dpyramid_tet_boundary (const t8_dpyramid_t *p, const int face)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   t8_dpyramid_t       anc;
-  const int           level = t8_dpyramid_is_inside_tet (p, p->level, &anc);
+  const int           level =
+    t8_dpyramid_is_inside_tet (p, p->pyramid.level, &anc);
   int                 bey_id, i, type_temp, valid_touch;
   t8_dpyramid_cube_id_t cube_id;
   if (level == 0) {
@@ -746,10 +800,10 @@ t8_dpyramid_tet_boundary (const t8_dpyramid_t *p, const int face)
   /*Check if anc-face is connecting to a tet or to a pyra */
   valid_touch = t8_dpyramid_tet_pyra_face_connection (&anc, face);
   if (valid_touch) {
-    type_temp = p->type;
+    type_temp = p->pyramid.type;
     /* If so, check if the tet always lies in the corner of of its parent at this face.
      * Otherwise, the neighbor is a tet*/
-    for (i = p->level; i > anc.level; i--) {
+    for (i = p->pyramid.level; i > anc.pyramid.level; i--) {
       cube_id = compute_cubeid (p, i);
       bey_id = t8_dtet_type_cid_to_beyid[type_temp][cube_id];
       if (t8_dpyramid_face_childid_to_is_inside[face][bey_id] == -1) {
@@ -765,7 +819,8 @@ t8_dpyramid_tet_boundary (const t8_dpyramid_t *p, const int face)
 int
 t8_dpyramid_tree_face (const t8_dpyramid_t *p, const int face)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   if (t8_dpyramid_is_root_boundary (p, face)) {
     if (t8_dpyramid_shape (p) == T8_ECLASS_PYRAMID) {
       /*If p is a pyramid and touches the boundary, the face-number is the same */
@@ -773,16 +828,18 @@ t8_dpyramid_tree_face (const t8_dpyramid_t *p, const int face)
     }
     else {
       /*p is a tet and in some occasions p shares a face with its tree */
-      if (face == 0 && (p->type == 3 || p->type == 2)) {
+      if (face == 0 && (p->pyramid.type == 3 || p->pyramid.type == 2)) {
         return 3;
       }
-      else if (face == 0 && (p->type == 0 || p->type == 1)) {
+      else if (face == 0 && (p->pyramid.type == 0 || p->pyramid.type == 1)) {
         return 1;
       }
-      else if ((face == 1 && p->type == 3) || (face == 2 && p->type == 1)) {
+      else if ((face == 1 && p->pyramid.type == 3)
+               || (face == 2 && p->pyramid.type == 1)) {
         return 2;
       }
-      else if ((face == 1 && p->type == 0) || (face == 2 && p->type == 2)) {
+      else if ((face == 1 && p->pyramid.type == 0)
+               || (face == 2 && p->pyramid.type == 2)) {
         return 0;
       }
       else
@@ -795,18 +852,22 @@ t8_dpyramid_tree_face (const t8_dpyramid_t *p, const int face)
 int
 t8_dpyramid_is_inside_root (const t8_dpyramid_t *p)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   /*Check, if p is root pyramid */
-  if (p->level == 0) {
-    return p->type == T8_DPYRAMID_ROOT_TPYE && p->x == 0 && p->y == 0
-      && p->z == 0;
+  if (p->pyramid.level == 0) {
+    return p->pyramid.type == T8_DPYRAMID_ROOT_TPYE && p->pyramid.x == 0
+      && p->pyramid.y == 0 && p->pyramid.z == 0;
   }
   /*Check, if all coordinates are in the limit set by the length of root */
-  if ((0 <= p->z) && (p->z < T8_DPYRAMID_ROOT_LEN) &&
-      (p->x >= p->z) && (p->x < T8_DPYRAMID_ROOT_LEN) &&
-      (p->y >= p->z) && (p->y < T8_DPYRAMID_ROOT_LEN)) {
-    if ((p->x == p->z && (p->type == 3 || p->type == 5)) ||
-        (p->y == p->z && (p->type == 0 || p->type == 4))) {
+  if ((0 <= p->pyramid.z) && (p->pyramid.z < T8_DPYRAMID_ROOT_LEN) &&
+      (p->pyramid.x >= p->pyramid.z) && (p->pyramid.x < T8_DPYRAMID_ROOT_LEN)
+      && (p->pyramid.y >= p->pyramid.z)
+      && (p->pyramid.y < T8_DPYRAMID_ROOT_LEN)) {
+    if ((p->pyramid.x == p->pyramid.z
+         && (p->pyramid.type == 3 || p->pyramid.type == 5))
+        || (p->pyramid.y == p->pyramid.z
+            && (p->pyramid.type == 0 || p->pyramid.type == 4))) {
       return 0;
     }
     else {
@@ -823,7 +884,8 @@ t8_dpyramid_face_neighbor_inside (const t8_dpyramid_t *p,
                                   t8_dpyramid_t *neigh,
                                   const int face, int *neigh_face)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   /*Compute the face-neighbor, then check if it is inside root */
   *neigh_face = t8_dpyramid_face_neighbour (p, face, neigh);
   return t8_dpyramid_is_inside_root (neigh);
@@ -834,18 +896,20 @@ t8_dpyramid_first_descendant (const t8_dpyramid_t *p, t8_dpyramid_t *desc,
                               const int level)
 {
   t8_linearidx_t      id;
-  T8_ASSERT (level >= p->level);
+  T8_ASSERT (level >= p->pyramid.level);
   T8_ASSERT (0 <= level && level <= T8_DPYRAMID_MAXLEVEL);
   if (t8_dpyramid_shape (p) == T8_ECLASS_PYRAMID) {
     /*The first descendant of a pyramid has the same anchor coords, but another level */
     t8_dpyramid_copy (p, desc);
-    desc->level = level;
+    desc->pyramid.level = level;
   }
   else {
     id = t8_dpyramid_linear_id (p, level);
     t8_dpyramid_init_linear_id (desc, level, id);
   }
-  T8_ASSERT (p->x <= desc->x && p->y <= desc->y && p->z <= desc->z);
+  T8_ASSERT (p->pyramid.x <= desc->pyramid.x
+             && p->pyramid.y <= desc->pyramid.y
+             && p->pyramid.z <= desc->pyramid.z);
 }
 
 /** Compute the descendant at a corner of a tet up to a given level.
@@ -861,7 +925,7 @@ t8_dpyramid_corner_descendant (const t8_dpyramid_t *p, t8_dpyramid_t *d,
                                const int corner, const int level)
 {
   int                 child_id, i;
-  T8_ASSERT (p->level <= level && level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (p->pyramid.level <= level && level <= T8_DPYRAMID_MAXLEVEL);
   T8_ASSERT (t8_dpyramid_shape (p) == T8_ECLASS_TET);
   T8_ASSERT (0 <= corner && corner < T8_DTET_CORNERS);
   if (corner == 0) {
@@ -870,11 +934,11 @@ t8_dpyramid_corner_descendant (const t8_dpyramid_t *p, t8_dpyramid_t *d,
   else if (corner == 1 || corner == 2) {
     /*The child at this corner is iterativle the child at child-id up to the
        given level */
-    child_id = t8_dtet_parenttype_beyid_to_Iloc[p->type][corner];
-    t8_dtet_t           tmp;
+    child_id = t8_dtet_parenttype_beyid_to_Iloc[p->pyramid.type][corner];
+    t8_dpyramid_t       tmp;
     t8_dpyramid_copy (p, &tmp);
-    for (i = p->level; i < level; i++) {
-      t8_dtet_child (&tmp, child_id, d);
+    for (i = p->pyramid.level; i < level; i++) {
+      t8_dpyramid_child (&tmp, child_id, d);
       t8_dpyramid_copy (d, &tmp);
     }
   }
@@ -889,40 +953,40 @@ t8_dpyramid_first_descendant_face (const t8_dpyramid_t *p, const int face,
                                    t8_dpyramid_t *first_desc, const int level)
 {
   int                 corner;
-  t8_dpyramid_coord_t off_set = T8_DPYRAMID_LEN (p->level) -
+  t8_dpyramid_coord_t off_set = T8_DPYRAMID_LEN (p->pyramid.level) -
     T8_DPYRAMID_LEN (level);
   T8_ASSERT (0 <= face && face < T8_DPYRAMID_FACES);
   T8_ASSERT (0 <= level && level <= T8_DPYRAMID_MAXLEVEL);
-  T8_ASSERT (p->level <= level);
+  T8_ASSERT (p->pyramid.level <= level);
 
   if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
     corner = t8_dtet_face_corner[face][0];
     t8_dpyramid_corner_descendant (p, first_desc, corner, level);
   }
-  else if (p->level == T8_DPYRAMID_MAXLEVEL) {
+  else if (p->pyramid.level == T8_DPYRAMID_MAXLEVEL) {
     t8_dpyramid_copy (p, first_desc);
   }
   else {
     /*Shift the coordinate of p to compute the descendant */
-    if ((p->type == T8_DPYRAMID_FIRST_TYPE
+    if ((p->pyramid.type == T8_DPYRAMID_FIRST_TYPE
          && (face == 0 || face == 2 || face == 4))
-        || (p->type == T8_DPYRAMID_SECOND_TYPE && face != 4)) {
+        || (p->pyramid.type == T8_DPYRAMID_SECOND_TYPE && face != 4)) {
       /*No shifting is needed, fd is the first child with given level */
       t8_dpyramid_child (p, 0, first_desc);
-      first_desc->level = level;
+      first_desc->pyramid.level = level;
     }
     else {
       /*shifting is needed, the fd does not have the same coord as p */
       t8_dpyramid_copy (p, first_desc);
-      first_desc->level = level;
-      if (p->type == T8_DPYRAMID_FIRST_TYPE && face == 1) {
-        first_desc->x |= off_set;
+      first_desc->pyramid.level = level;
+      if (p->pyramid.type == T8_DPYRAMID_FIRST_TYPE && face == 1) {
+        first_desc->pyramid.x |= off_set;
       }
-      else if (p->type == T8_DPYRAMID_FIRST_TYPE && face == 3) {
-        first_desc->y |= off_set;
+      else if (p->pyramid.type == T8_DPYRAMID_FIRST_TYPE && face == 3) {
+        first_desc->pyramid.y |= off_set;
       }
-      else if (p->type == T8_DPYRAMID_SECOND_TYPE && face == 4) {
-        first_desc->z |= off_set;
+      else if (p->pyramid.type == T8_DPYRAMID_SECOND_TYPE && face == 4) {
+        first_desc->pyramid.z |= off_set;
       }
     }
   }
@@ -934,23 +998,23 @@ t8_dpyramid_last_descendant (const t8_dpyramid_t *p, t8_dpyramid_t *desc,
 {
   t8_linearidx_t      id = 0, t_id;
   int                 exponent;
-  T8_ASSERT (level >= p->level);
+  T8_ASSERT (level >= p->pyramid.level);
   if (t8_dpyramid_shape (p) == T8_ECLASS_PYRAMID) {
     t8_dpyramid_copy (p, desc);
-    desc->level = level;
+    desc->pyramid.level = level;
     /* Shift the coords to the eights cube. The type of the last descendant is
      * is the type of the input pyramid*/
     t8_dpyramid_coord_t coord_offset =
-      T8_DPYRAMID_LEN (p->level) - T8_DPYRAMID_LEN (level);
-    desc->x |= coord_offset;
-    desc->y |= coord_offset;
-    desc->z |= coord_offset;
+      T8_DPYRAMID_LEN (p->pyramid.level) - T8_DPYRAMID_LEN (level);
+    desc->pyramid.x |= coord_offset;
+    desc->pyramid.y |= coord_offset;
+    desc->pyramid.z |= coord_offset;
   }
   else {
     /* Compute current id, shift it to the id of the last desendant and compute it
      * via its id*/
     t_id = t8_dpyramid_linear_id (p, level);
-    exponent = level - p->level;
+    exponent = level - p->pyramid.level;
     id = (((t8_linearidx_t) 1) << 3 * exponent) - 1;
     id += t_id;
     t8_dpyramid_init_linear_id (desc, level, id);
@@ -965,11 +1029,11 @@ t8_dpyramid_last_descendant_face (const t8_dpyramid_t *p,
   /*Computation is similar to first-descendant-face */
   int                 corner;
   t8_dpyramid_coord_t off_set =
-    T8_DPYRAMID_LEN (p->level) - T8_DPYRAMID_LEN (level);
+    T8_DPYRAMID_LEN (p->pyramid.level) - T8_DPYRAMID_LEN (level);
 
   T8_ASSERT (0 <= face && face < T8_DPYRAMID_FACES);
   T8_ASSERT (0 <= level && level <= T8_DPYRAMID_MAXLEVEL);
-  T8_ASSERT (p->level <= level);
+  T8_ASSERT (p->pyramid.level <= level);
 
   if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
     T8_ASSERT (0 <= face && face < T8_DTET_FACES);
@@ -979,24 +1043,24 @@ t8_dpyramid_last_descendant_face (const t8_dpyramid_t *p,
   }
   else {
     t8_dpyramid_copy (p, last_desc);
-    last_desc->level = level;
-    if ((p->type == T8_DPYRAMID_FIRST_TYPE && face != 4) ||
-        (p->type == T8_DPYRAMID_SECOND_TYPE
+    last_desc->pyramid.level = level;
+    if ((p->pyramid.type == T8_DPYRAMID_FIRST_TYPE && face != 4) ||
+        (p->pyramid.type == T8_DPYRAMID_SECOND_TYPE
          && (face == 0 || face == 2 || face == 4))) {
       /*No shifting needed */
       t8_dpyramid_last_descendant (p, last_desc, level);
     }
-    else if (p->type == T8_DPYRAMID_SECOND_TYPE && face == 1) {
-      last_desc->x |= off_set;
-      last_desc->z |= off_set;
+    else if (p->pyramid.type == T8_DPYRAMID_SECOND_TYPE && face == 1) {
+      last_desc->pyramid.x |= off_set;
+      last_desc->pyramid.z |= off_set;
     }
-    else if (p->type == T8_DPYRAMID_SECOND_TYPE && face == 3) {
-      last_desc->y |= off_set;
-      last_desc->z |= off_set;
+    else if (p->pyramid.type == T8_DPYRAMID_SECOND_TYPE && face == 3) {
+      last_desc->pyramid.y |= off_set;
+      last_desc->pyramid.z |= off_set;
     }
-    else if (p->type == T8_DPYRAMID_FIRST_TYPE && face == 4) {
-      last_desc->x |= off_set;
-      last_desc->y |= off_set;
+    else if (p->pyramid.type == T8_DPYRAMID_FIRST_TYPE && face == 4) {
+      last_desc->pyramid.x |= off_set;
+      last_desc->pyramid.y |= off_set;
     }
   }
 }
@@ -1004,7 +1068,8 @@ t8_dpyramid_last_descendant_face (const t8_dpyramid_t *p,
 int
 t8_dpyramid_num_corners (const t8_dpyramid_t *p)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
     return T8_DTET_CORNERS;
   }
@@ -1016,7 +1081,8 @@ t8_dpyramid_num_corners (const t8_dpyramid_t *p)
 int
 t8_dpyramid_num_children (const t8_dpyramid_t *p)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
     return T8_DTET_CHILDREN;
   }
@@ -1028,9 +1094,10 @@ t8_dpyramid_num_children (const t8_dpyramid_t *p)
 int
 t8_dpyramid_num_siblings (const t8_dpyramid_t *p)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   t8_dpyramid_t       parent;
-  if (p->level == 0) {
+  if (p->pyramid.level == 0) {
     /* A level zero pyramid has only itself as sibling. */
     return 1;
   }
@@ -1041,7 +1108,8 @@ t8_dpyramid_num_siblings (const t8_dpyramid_t *p)
 int
 t8_dpyramid_num_faces (const t8_dpyramid_t *p)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
     return T8_DTET_FACES;
   }
@@ -1053,7 +1121,8 @@ t8_dpyramid_num_faces (const t8_dpyramid_t *p)
 int
 t8_dpyramid_max_num_faces (const t8_dpyramid_t *p)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
     return T8_DTET_FACES;
   }
@@ -1068,36 +1137,37 @@ t8_dpyramid_boundary_face (const t8_dpyramid_t *p, const int face,
 {
   /* face is face of of p */
   T8_ASSERT (0 <= face && face < T8_DPYRAMID_FACES);
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   if (face == 4) {
     /*On the bottom every face is a quad */
     /*Coordinates are scaled, because quad and pyra might have different root-len */
     p4est_quadrant_t   *q = (p4est_quadrant_t *) boundary;
-    q->x = ((int64_t) p->x * P4EST_ROOT_LEN) / T8_DPYRAMID_ROOT_LEN;
-    q->y = ((int64_t) p->y * P4EST_ROOT_LEN) / T8_DPYRAMID_ROOT_LEN;
-    q->level = p->level;
+    q->x = ((int64_t) p->pyramid.x * P4EST_ROOT_LEN) / T8_DPYRAMID_ROOT_LEN;
+    q->y = ((int64_t) p->pyramid.y * P4EST_ROOT_LEN) / T8_DPYRAMID_ROOT_LEN;
+    q->level = p->pyramid.level;
   }
   else {
     /* Boundary-face is a triangle. */
-    /* p-x give t->x for root-face 2,3 and p->y gives t->x for 0,1.
-     * t->y is determined by p->z*/
+    /* p-x give t->x for root-face 2,3 and p->pyramid.y gives t->x for 0,1.
+     * t->y is determined by p->pyramid.z*/
     t8_dtri_t          *t = (t8_dtri_t *) boundary;
-    t->level = p->level;
-    t->y = p->z * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
+    t->level = p->pyramid.level;
+    t->y = p->pyramid.z * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
     if (t8_dpyramid_shape (p) == T8_ECLASS_PYRAMID) {
       t->type = 0;
       switch (face) {
       case 0:
-        t->x = p->y * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
+        t->x = p->pyramid.y * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
         break;
       case 1:
-        t->x = p->y * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
+        t->x = p->pyramid.y * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
         break;
       case 2:
-        t->x = p->x * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
+        t->x = p->pyramid.x * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
         break;
       case 3:
-        t->x = p->x * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
+        t->x = p->pyramid.x * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
         break;
       default:
         SC_ABORT_NOT_REACHED ();
@@ -1106,21 +1176,23 @@ t8_dpyramid_boundary_face (const t8_dpyramid_t *p, const int face,
     else {
       /*Boundary is given by a tet-surface. The cases are ordered by root-face-
        * enumeration*/
-      if ((face == 1 && p->type == 0) || (face == 2 && p->type == 2)) {
-        t->x = p->y * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
-        t->type = p->type == 0 ? 1 : 0;
+      if ((face == 1 && p->pyramid.type == 0)
+          || (face == 2 && p->pyramid.type == 2)) {
+        t->x = p->pyramid.y * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
+        t->type = p->pyramid.type == 0 ? 1 : 0;
       }
-      else if (face == 0 && (p->type == 0 || p->type == 1)) {
-        t->x = p->y * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
-        t->type = p->type == 0 ? 1 : 0;
+      else if (face == 0 && (p->pyramid.type == 0 || p->pyramid.type == 1)) {
+        t->x = p->pyramid.y * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
+        t->type = p->pyramid.type == 0 ? 1 : 0;
       }
-      else if ((face == 1 && p->type == 3) || (face == 2 && p->type == 1)) {
-        t->x = p->x * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
-        t->type = p->type == 3 ? 1 : 0;
+      else if ((face == 1 && p->pyramid.type == 3)
+               || (face == 2 && p->pyramid.type == 1)) {
+        t->x = p->pyramid.x * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
+        t->type = p->pyramid.type == 3 ? 1 : 0;
       }
       else {
-        t->x = p->x * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
-        t->type = p->type == 3 ? 1 : 0;
+        t->x = p->pyramid.x * T8_DTRI_ROOT_BY_DPYRAMID_ROOT;
+        t->type = p->pyramid.type == 3 ? 1 : 0;
       }
     }
     T8_ASSERT (t->type == 0 || t->type == 1);
@@ -1140,37 +1212,43 @@ t8_dpyramid_extrude_face (const t8_element_t *face, t8_dpyramid_t *p,
      * depending on their maxlvl.*/
     p4est_quadrant_t   *q = (p4est_quadrant_t *) face;
     /*Typecast to int64, we multiply two (possible at max) int32 */
-    p->x = ((int64_t) q->x * T8_DPYRAMID_ROOT_LEN) / P4EST_ROOT_LEN;
-    p->y = ((int64_t) q->y * T8_DPYRAMID_ROOT_LEN) / P4EST_ROOT_LEN;
-    p->z = 0;
-    p->type = T8_DPYRAMID_ROOT_TPYE;
-    p->level = q->level;
+    p->pyramid.x = ((int64_t) q->x * T8_DPYRAMID_ROOT_LEN) / P4EST_ROOT_LEN;
+    p->pyramid.y = ((int64_t) q->y * T8_DPYRAMID_ROOT_LEN) / P4EST_ROOT_LEN;
+    p->pyramid.z = 0;
+    p->pyramid.type = T8_DPYRAMID_ROOT_TPYE;
+    p->pyramid.level = q->level;
     return root_face;
   }
   else {
-    /*t->y gives the height of the pyramid, t->x gives the p->x or p->y, depending on
+    /*t->y gives the height of the pyramid, t->x gives the p->pyramid.x or p->pyramid.y, depending on
      * the root_face. The other coordinate is determined by the root_face.*/
     t8_dtri_t          *t = (t8_dtri_t *) face;
-    p->z = ((int64_t) t->y * T8_DPYRAMID_ROOT_LEN) / T8_DTRI_ROOT_LEN;
+    p->pyramid.z = ((int64_t) t->y * T8_DPYRAMID_ROOT_LEN) / T8_DTRI_ROOT_LEN;
     /* level is the same */
-    p->level = t->level;
+    p->pyramid.level = t->level;
     switch (root_face) {
     case 0:
-      p->x = p->z;
+      p->pyramid.x = p->pyramid.z;
       /*Typecast to int64, we multiply two (possible at max) int32 */
-      p->y = ((int64_t) t->x * T8_DPYRAMID_ROOT_LEN) / T8_DTRI_ROOT_LEN;
+      p->pyramid.y =
+        ((int64_t) t->x * T8_DPYRAMID_ROOT_LEN) / T8_DTRI_ROOT_LEN;
       break;
     case 1:
-      p->x = T8_DPYRAMID_ROOT_LEN - T8_DPYRAMID_LEN (p->level);
-      p->y = ((int64_t) t->x * T8_DPYRAMID_ROOT_LEN) / T8_DTRI_ROOT_LEN;
+      p->pyramid.x =
+        T8_DPYRAMID_ROOT_LEN - T8_DPYRAMID_LEN (p->pyramid.level);
+      p->pyramid.y =
+        ((int64_t) t->x * T8_DPYRAMID_ROOT_LEN) / T8_DTRI_ROOT_LEN;
       break;
     case 2:
-      p->x = ((int64_t) t->x * T8_DPYRAMID_ROOT_LEN) / T8_DTRI_ROOT_LEN;
-      p->y = p->z;
+      p->pyramid.x =
+        ((int64_t) t->x * T8_DPYRAMID_ROOT_LEN) / T8_DTRI_ROOT_LEN;
+      p->pyramid.y = p->pyramid.z;
       break;
     case 3:
-      p->x = ((int64_t) t->x * T8_DPYRAMID_ROOT_LEN) / T8_DTRI_ROOT_LEN;
-      p->y = T8_DPYRAMID_ROOT_LEN - T8_DPYRAMID_LEN (p->level);
+      p->pyramid.x =
+        ((int64_t) t->x * T8_DPYRAMID_ROOT_LEN) / T8_DTRI_ROOT_LEN;
+      p->pyramid.y =
+        T8_DPYRAMID_ROOT_LEN - T8_DPYRAMID_LEN (p->pyramid.level);
       break;
     default:
       SC_ABORT_NOT_REACHED ();
@@ -1178,17 +1256,19 @@ t8_dpyramid_extrude_face (const t8_element_t *face, t8_dpyramid_t *p,
     /*Description of triangles extruding to a pyramid */
     if ((t->y == (t->x & t->y)) && t->type == 0) {
       /*type zero in a pyramid extend to a pyramid */
-      p->type = T8_DPYRAMID_FIRST_TYPE;
+      p->pyramid.type = T8_DPYRAMID_FIRST_TYPE;
       extruded_face = root_face;
     }
     else {
       /*type 0 not in a pyramid extend to a tetrahedron */
-      p->type = t8_dpyramid_tritype_rootface_to_tettype[t->type][root_face];
+      p->pyramid.type =
+        t8_dpyramid_tritype_rootface_to_tettype[t->type][root_face];
       extruded_face =
         t8_dpyramid_tritype_rootface_to_face[t->type][root_face];
     }
   }
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   /*return the face-number of the extruded face */
   return extruded_face;
 }
@@ -1197,17 +1277,17 @@ int
 t8_dpyramid_child_id_unknown_parent (const t8_dpyramid_t *p,
                                      t8_dpyramid_t *parent)
 {
-  T8_ASSERT (p->level >= 0);
-  if (p->level == 0) {
-    /* P has no parent. We deliberately set the type of the parent to -1,
+  T8_ASSERT (p->pyramid.level >= 0);
+  if (p->pyramid.level == 0) {
+    /* P has no parent.pyramid. We deliberately set the type of the parent to -1,
      * because a) parent should not be used and setting the type to an invalid
      *            value improves chances of catching a non-allowed use of it in an assertion later.
-     *         b) t8_dpyramid_successor caused a compiler warning of parent.type may be used uninitialize
+     *         b) t8_dpyramid_successor caused a compiler warning of parent.pyramid.type may be used uninitialize
      *            in a subsequent call to t8_dpyramid_shape. This case is actually never executed, but the
      *            compiler doesn't know about it. To prevent this warning, we set the type here.
      */
-    parent->type = -1;
-    parent->level = -1;
+    parent->pyramid.type = -1;
+    parent->pyramid.level = -1;
     return -1;
   }
   t8_dpyramid_parent (p, parent);
@@ -1219,22 +1299,22 @@ int
 t8_dpyramid_child_id_known_parent (const t8_dpyramid_t *p,
                                    t8_dpyramid_t *parent)
 {
-  t8_dpyramid_cube_id_t cube_id = compute_cubeid (p, p->level);
+  t8_dpyramid_cube_id_t cube_id = compute_cubeid (p, p->pyramid.level);
   if (t8_dpyramid_shape (parent) == T8_ECLASS_PYRAMID) {
-    T8_ASSERT (t8_dpyramid_type_cid_to_Iloc[p->type][cube_id] >= 0);
-    return t8_dpyramid_type_cid_to_Iloc[p->type][cube_id];
+    T8_ASSERT (t8_dpyramid_type_cid_to_Iloc[p->pyramid.type][cube_id] >= 0);
+    return t8_dpyramid_type_cid_to_Iloc[p->pyramid.type][cube_id];
   }
   else {
-    return t8_dtet_child_id (p);
+    return t8_dtet_child_id (&(p->pyramid));
   }
 }
 
 int
 t8_dpyramid_child_id (const t8_dpyramid_t *p)
 {
-  T8_ASSERT (p->level >= 0);
+  T8_ASSERT (p->pyramid.level >= 0);
   t8_dpyramid_t       parent;
-  if (p->level == 0)
+  if (p->pyramid.level == 0)
     return -1;
   return t8_dpyramid_child_id_unknown_parent (p, &parent);
 }
@@ -1245,30 +1325,35 @@ t8_dpyramid_child (const t8_dpyramid_t *elem, const int child_id,
 {
 
   t8_dpyramid_cube_id_t cube_id;
-  t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (elem->level + 1);
+  t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (elem->pyramid.level + 1);
   T8_ASSERT (0 <= child_id && child_id < T8_DPYRAMID_CHILDREN);
-  T8_ASSERT (0 <= elem->level && elem->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= elem->pyramid.level
+             && elem->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
 
   if (t8_dpyramid_shape (elem) == T8_ECLASS_TET) {
-    t8_dtet_child (elem, child_id, child);
+    /*Todo: Set switch_shape_at_level */
+    t8_dtet_child (&(elem->pyramid), child_id, &(child->pyramid));
   }
   else {
     /* Compute the cube id and shift the coordinates accordingly */
-    cube_id = t8_dpyramid_parenttype_Iloc_to_cid[elem->type][child_id];
+    cube_id =
+      t8_dpyramid_parenttype_Iloc_to_cid[elem->pyramid.type][child_id];
     T8_ASSERT (cube_id >= 0);
-    child->level = elem->level + 1;
-    child->x = elem->x + ((cube_id & 0x01) ? length : 0);
-    child->y = elem->y + ((cube_id & 0x02) ? length : 0);
-    child->z = elem->z + ((cube_id & 0x04) ? length : 0);
-    child->type = t8_dpyramid_parenttype_Iloc_to_type[elem->type][child_id];
+    child->pyramid.level = elem->pyramid.level + 1;
+    child->pyramid.x = elem->pyramid.x + ((cube_id & 0x01) ? length : 0);
+    child->pyramid.y = elem->pyramid.y + ((cube_id & 0x02) ? length : 0);
+    child->pyramid.z = elem->pyramid.z + ((cube_id & 0x04) ? length : 0);
+    child->pyramid.type =
+      t8_dpyramid_parenttype_Iloc_to_type[elem->pyramid.type][child_id];
   }
-  T8_ASSERT (child->type >= 0);
+  T8_ASSERT (child->pyramid.type >= 0);
 }
 
 void
 t8_dpyramid_children (const t8_dpyramid_t *p, t8_dpyramid_t **c)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   int                 i, num_children;
   num_children = t8_dpyramid_num_children (p);
   for (i = num_children - 1; i >= 0; i--) {
@@ -1285,7 +1370,20 @@ t8_dpyramid_children_at_face (const t8_dpyramid_t *p, const int face,
   T8_ASSERT (0 <= face && face < T8_DPYRAMID_FACES);
   if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
     /*Use tet-algo */
-    t8_dtet_children_at_face (p, face, children, num_children, child_indices);
+    t8_dtet_t         **tet_children =
+      T8_ALLOC (t8_dtet_t *, T8_DTET_FACE_CHILDREN);
+    int                 i;
+    for (i = 0; i < T8_DTET_FACE_CHILDREN; i++) {
+      tet_children[i] = T8_ALLOC (t8_dtet_t, 1);
+    }
+    t8_dtet_children_at_face (&(p->pyramid), face, tet_children, num_children,
+                              child_indices);
+    for (i = 0; i < T8_DTET_FACE_CHILDREN; i++) {
+      /* TODO: set switch_shape_at_level */
+      t8_dtet_copy (tet_children[i], &(children[i]->pyramid));
+      T8_FREE (tet_children[i]);
+    }
+    T8_FREE (tet_children);
   }
   else {
     int                *children_at_face_id,
@@ -1299,7 +1397,7 @@ t8_dpyramid_children_at_face (const t8_dpyramid_t *p, const int face,
     /*Fill the child ids with the child-ids at the face */
     for (i = 0; i < T8_DPYRAMID_FACE_CHILDREN; i++) {
       children_at_face_id[i] =
-        t8_dpyramid_type_face_to_children_at_face[p->type -
+        t8_dpyramid_type_face_to_children_at_face[p->pyramid.type -
                                                   T8_DPYRAMID_FIRST_TYPE]
         [face][i];
     }
@@ -1318,11 +1416,11 @@ t8_dpyramid_face_child_face (const t8_dpyramid_t *p, const int face,
   T8_ASSERT (0 <= face && face < T8_DPYRAMID_FACES);
   T8_ASSERT (0 <= face_child && face_child < T8_DPYRAMID_CHILDREN);
   if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
-    return t8_dtet_face_child_face (p, face, face_child);
+    return t8_dtet_face_child_face (&(p->pyramid), face, face_child);
   }
   else {
     int                 child_face =
-      t8_dpyramid_type_face_to_child_face[p->type -
+      t8_dpyramid_type_face_to_child_face[p->pyramid.type -
                                           T8_DPYRAMID_FIRST_TYPE][face]
       [face_child];
     T8_ASSERT (child_face >= 0 && child_face <= T8_DPYRAMID_FACES);
@@ -1371,18 +1469,24 @@ int
 t8_dpyramid_is_inside_pyra (const t8_dpyramid_t *tet,
                             const t8_dpyramid_t *check)
 {
-  t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (check->level);
-  t8_dpyramid_coord_t diff = tet->z - check->z;
+  t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (check->pyramid.level);
+  t8_dpyramid_coord_t diff = tet->pyramid.z - check->pyramid.z;
   T8_ASSERT (t8_dpyramid_shape (tet) == T8_ECLASS_TET);
 
-  T8_ASSERT (0 <= tet->level && tet->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= tet->pyramid.level
+             && tet->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
 
   /* test if tet is inside the pyramids with coordinates given by check and type 6 */
-  if (((check->x + diff) <= tet->x && tet->x < (check->x + length)) &&
-      ((check->y + diff) <= tet->y && tet->y < (check->y + length)) &&
-      (check->z <= tet->z && tet->z < (check->z + length))) {
-    if ((check->x + diff == tet->x && (tet->type == 3 || tet->type == 1)) ||
-        (check->y + diff == tet->y && (tet->type == 0 || tet->type == 2))) {
+  if (((check->pyramid.x + diff) <= tet->pyramid.x
+       && tet->pyramid.x < (check->pyramid.x + length))
+      && ((check->pyramid.y + diff) <= tet->pyramid.y
+          && tet->pyramid.y < (check->pyramid.y + length))
+      && (check->pyramid.z <= tet->pyramid.z
+          && tet->pyramid.z < (check->pyramid.z + length))) {
+    if ((check->pyramid.x + diff == tet->pyramid.x
+         && (tet->pyramid.type == 3 || tet->pyramid.type == 1))
+        || (check->pyramid.y + diff == tet->pyramid.y
+            && (tet->pyramid.type == 0 || tet->pyramid.type == 2))) {
       /*tet touches face of pyra but is outside of pyra */
       return 0;
     }
@@ -1392,11 +1496,17 @@ t8_dpyramid_is_inside_pyra (const t8_dpyramid_t *tet,
     }
   }
   /* test if tet is inside the pyramids with coordinates given by check and type 7 */
-  else if ((check->x <= tet->x && tet->x <= (check->x + diff)) &&
-           (check->y <= tet->y && tet->y <= (check->y + diff)) &&
-           (check->z <= tet->z && tet->z < (check->z + length))) {
-    if ((check->x + diff == tet->x && (tet->type == 0 || tet->type == 2)) ||
-        (check->y + diff == tet->y && (tet->type == 3 || tet->type == 1))) {
+  else
+    if ((check->pyramid.x <= tet->pyramid.x
+         && tet->pyramid.x <= (check->pyramid.x + diff))
+        && (check->pyramid.y <= tet->pyramid.y
+            && tet->pyramid.y <= (check->pyramid.y + diff))
+        && (check->pyramid.z <= tet->pyramid.z
+            && tet->pyramid.z < (check->pyramid.z + length))) {
+    if ((check->pyramid.x + diff == tet->pyramid.x
+         && (tet->pyramid.type == 0 || tet->pyramid.type == 2))
+        || (check->pyramid.y + diff == tet->pyramid.y
+            && (tet->pyramid.type == 3 || tet->pyramid.type == 1))) {
       /*tet touches face of pyra, but is outside of pyra */
       return 0;
     }
@@ -1423,25 +1533,28 @@ t8_dpyramid_is_inside_tet (const t8_dpyramid_t *tet, const int level,
                            t8_dpyramid_t *anc)
 {
   T8_ASSERT (t8_dpyramid_shape (tet) == T8_ECLASS_TET);
-  T8_ASSERT (tet->type == 0 || tet->type == 3);
+  T8_ASSERT (tet->pyramid.type == 0 || tet->pyramid.type == 3);
   int                 i;
   t8_dpyramid_coord_t coord_at_level;
   /*the tet is initialized, the ancestor will be computed */
   t8_dpyramid_t       pyra_at_level;    /* Candidate pyramid, where the tet could lie in. */
-  pyra_at_level.x = 0;
-  pyra_at_level.y = 0;
-  pyra_at_level.z = 0;
+  pyra_at_level.pyramid.x = 0;
+  pyra_at_level.pyramid.y = 0;
+  pyra_at_level.pyramid.z = 0;
   for (i = 1; i < level; i++) {
     /*Update the coordinate of tet to i first bits */
     coord_at_level = (1 << (T8_DPYRAMID_MAXLEVEL - i));
-    pyra_at_level.x = pyra_at_level.x | (tet->x & coord_at_level);
-    pyra_at_level.y = pyra_at_level.y | (tet->y & coord_at_level);
-    pyra_at_level.z = pyra_at_level.z | (tet->z & coord_at_level);
-    pyra_at_level.level = i;
+    pyra_at_level.pyramid.x =
+      pyra_at_level.pyramid.x | (tet->pyramid.x & coord_at_level);
+    pyra_at_level.pyramid.y =
+      pyra_at_level.pyramid.y | (tet->pyramid.y & coord_at_level);
+    pyra_at_level.pyramid.z =
+      pyra_at_level.pyramid.z | (tet->pyramid.z & coord_at_level);
+    pyra_at_level.pyramid.level = i;
     if (t8_dpyramid_is_inside_pyra (tet, &pyra_at_level) == 0) {
       /*tet is inside a tet */
       if (anc != NULL) {
-        t8_dtet_ancestor (tet, i, anc);
+        t8_dtet_ancestor (&(tet->pyramid), i, &(anc->pyramid));
       }
       return i;
     }
@@ -1454,63 +1567,65 @@ void
 t8_dpyramid_tetparent_type (const t8_dpyramid_t *p, t8_dpyramid_t *parent)
 {
   T8_ASSERT (t8_dpyramid_shape (p) == T8_ECLASS_TET);
-  if ((p->z >> (T8_DPYRAMID_MAXLEVEL - p->level)) % 2 == 0) {
-    parent->type = T8_DPYRAMID_FIRST_TYPE;
+  if ((p->pyramid.z >> (T8_DPYRAMID_MAXLEVEL - p->pyramid.level)) % 2 == 0) {
+    parent->pyramid.type = T8_DPYRAMID_FIRST_TYPE;
   }
   else {
-    parent->type = T8_DPYRAMID_SECOND_TYPE;
+    parent->pyramid.type = T8_DPYRAMID_SECOND_TYPE;
   }
 }
 
 void
 t8_dpyramid_parent (const t8_dpyramid_t *p, t8_dpyramid_t *parent)
 {
-  T8_ASSERT (p->level > 0);
+  T8_ASSERT (p->pyramid.level > 0);
   T8_ASSERT (T8_DPYRAMID_MAXLEVEL == T8_DTET_MAXLEVEL);
-  t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (p->level);
+  t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (p->pyramid.level);
 
   if (t8_dpyramid_shape (p) == T8_ECLASS_PYRAMID) {
     /*The parent of a pyramid is a pyramid, maybe of different type */
 
-    t8_dpyramid_cube_id_t cube_id = compute_cubeid (p, p->level);
+    t8_dpyramid_cube_id_t cube_id = compute_cubeid (p, p->pyramid.level);
 
-    parent->type =
-      t8_dpyramid_type_cid_to_parenttype[p->type -
+    parent->pyramid.type =
+      t8_dpyramid_type_cid_to_parenttype[p->pyramid.type -
                                          T8_DPYRAMID_FIRST_TYPE][cube_id];
-    parent->x = p->x & ~length;
-    parent->y = p->y & ~length;
-    parent->z = p->z & ~length;
-    T8_ASSERT (parent->type >= 0);
-    parent->level = p->level - 1;
+    parent->pyramid.x = p->pyramid.x & ~length;
+    parent->pyramid.y = p->pyramid.y & ~length;
+    parent->pyramid.z = p->pyramid.z & ~length;
+    T8_ASSERT (parent->pyramid.type >= 0);
+    parent->pyramid.level = p->pyramid.level - 1;
   }
-  else if (p->type != 0 && p->type != 3) {
+  else if (p->pyramid.type != 0 && p->pyramid.type != 3) {
     /* The direct tet-child of a pyra has type 0 or type 3, therefore
      * in this case the parent is a tetrahedron*/
-    t8_dtet_parent (p, parent);
+    /*TODO: Set switch_type_at_level */
+    t8_dtet_parent (&(p->pyramid), &(parent->pyramid));
   }
-  else if (t8_dpyramid_is_inside_tet (p, p->level, NULL) != 0) {
+  else if (t8_dpyramid_is_inside_tet (p, p->pyramid.level, NULL) != 0) {
     /*Pyramid- / tetparent detection */
     /*If a tetrahedron does not reach a "significant point" its parent is a tet */
     /*Tetcase */ ;
-    t8_dtet_parent (p, parent);
+    t8_dtet_parent (&(p->pyramid), &(parent->pyramid));
   }
   else {
     /*p does not lie in larger tet => parent is pyra */
     t8_dpyramid_tetparent_type (p, parent);
-    parent->x = p->x & ~length;
-    parent->y = p->y & ~length;
-    parent->z = p->z & ~length;
-    parent->level = p->level - 1;
+    parent->pyramid.x = p->pyramid.x & ~length;
+    parent->pyramid.y = p->pyramid.y & ~length;
+    parent->pyramid.z = p->pyramid.z & ~length;
+    parent->pyramid.level = p->pyramid.level - 1;
   }
-  T8_ASSERT (parent->level >= 0);
+  T8_ASSERT (parent->pyramid.level >= 0);
 }
 
 t8_element_shape_t
 t8_dpyramid_shape (const t8_dpyramid_t *p)
 {
-  T8_ASSERT (0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (0 <= p->pyramid.level
+             && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   /*The pyramid has the shape of a tetrahedron */
-  if (p->type < T8_DPYRAMID_FIRST_TYPE) {
+  if (p->pyramid.type < T8_DPYRAMID_FIRST_TYPE) {
     return T8_ECLASS_TET;
   }
   else {
@@ -1528,8 +1643,8 @@ t8_dpyramid_successor_recursion (const t8_dpyramid_t *elem,
   t8_dpyramid_copy (elem, succ);
 
   T8_ASSERT (1 <= level && level <= T8_DPYRAMID_MAXLEVEL);
-  succ->level = level;
-  T8_ASSERT (succ->type >= 0);
+  succ->pyramid.level = level;
+  T8_ASSERT (succ->pyramid.type >= 0);
   child_id = t8_dpyramid_child_id_unknown_parent (elem, parent);
   /*Compute number of children */
   num_children = t8_dpyramid_num_children (parent);
@@ -1539,14 +1654,14 @@ t8_dpyramid_successor_recursion (const t8_dpyramid_t *elem,
     /* Last-child-case. The successor is the successor of the parent element,
      * but with the given level */
     t8_dpyramid_successor_recursion (succ, succ, parent, level - 1);
-    succ->level = level;
+    succ->pyramid.level = level;
     /* bits auf level auf child 0 setzen */
     t8_dpyramid_cut_coordinates (succ, shift);
   }
   else {
     /* Not the last element. Compute child with local ID child_id+1 */
     t8_dpyramid_child (parent, child_id + 1, succ);
-    succ->level = level;
+    succ->pyramid.level = level;
   }
 }
 
@@ -1566,37 +1681,37 @@ t8_dpyramid_compute_coords (const t8_dpyramid_t *p, const int vertex,
   T8_ASSERT (0 <= vertex && vertex < T8_DPYRAMID_CORNERS);
 
   if (t8_dpyramid_shape (p) == T8_ECLASS_PYRAMID) {
-    length = T8_DPYRAMID_LEN (p->level);
-    coords[0] = p->x;
-    coords[1] = p->y;
-    coords[2] = p->z;
+    length = T8_DPYRAMID_LEN (p->pyramid.level);
+    coords[0] = p->pyramid.x;
+    coords[1] = p->pyramid.y;
+    coords[2] = p->pyramid.z;
     switch (vertex) {
     case 0:
-      coords[2] += (p->type == T8_DPYRAMID_SECOND_TYPE) ? length : 0;
+      coords[2] += (p->pyramid.type == T8_DPYRAMID_SECOND_TYPE) ? length : 0;
       break;
     case 1:
       coords[0] += length;
-      coords[2] += (p->type == T8_DPYRAMID_SECOND_TYPE) ? length : 0;
+      coords[2] += (p->pyramid.type == T8_DPYRAMID_SECOND_TYPE) ? length : 0;
       break;
     case 2:
       coords[1] += length;
-      coords[2] += (p->type == T8_DPYRAMID_SECOND_TYPE) ? length : 0;
+      coords[2] += (p->pyramid.type == T8_DPYRAMID_SECOND_TYPE) ? length : 0;
       break;
     case 3:
       coords[0] += length;
       coords[1] += length;
-      coords[2] += (p->type == T8_DPYRAMID_SECOND_TYPE) ? length : 0;
+      coords[2] += (p->pyramid.type == T8_DPYRAMID_SECOND_TYPE) ? length : 0;
       break;
     case 4:
-      coords[0] += (p->type == T8_DPYRAMID_FIRST_TYPE) ? length : 0;
-      coords[1] += (p->type == T8_DPYRAMID_FIRST_TYPE) ? length : 0;
-      coords[2] += (p->type == T8_DPYRAMID_FIRST_TYPE) ? length : 0;
+      coords[0] += (p->pyramid.type == T8_DPYRAMID_FIRST_TYPE) ? length : 0;
+      coords[1] += (p->pyramid.type == T8_DPYRAMID_FIRST_TYPE) ? length : 0;
+      coords[2] += (p->pyramid.type == T8_DPYRAMID_FIRST_TYPE) ? length : 0;
       break;
     }
   }
   else {
     T8_ASSERT (0 <= vertex && vertex < T8_DTET_CORNERS);
-    t8_dtet_compute_coords (p, vertex, coords);
+    t8_dtet_compute_coords (&(p->pyramid), vertex, coords);
   }
 }
 
@@ -1620,14 +1735,15 @@ t8_dpyramid_first_pyra_anc (const t8_dpyramid_t *tet,
 {
   T8_ASSERT (t8_dpyramid_shape (tet) == T8_ECLASS_TET);
   /*There are no tets on level 0 */
-  T8_ASSERT (1 <= tet->level && tet->level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (1 <= tet->pyramid.level
+             && tet->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   /*The ancestor has to have the shape of a pyramid */
   t8_dpyramid_t       last_tet_anc;
   /* t8_dpyramid_is_inside_tet works only for tets of type 0 or type 3 */
-  if (tet->type != 0 && tet->type != 3) {
+  if (tet->pyramid.type != 0 && tet->pyramid.type != 3) {
     /*Find the first tet-anc of type 0 or type 3 */
-    t8_dpyramid_type_t  type_at_level = tet->type;
-    int                 level = tet->level;
+    t8_dpyramid_type_t  type_at_level = tet->pyramid.type;
+    int                 level = tet->pyramid.level;
     while (type_at_level != 0 && type_at_level != 3) {
       level--;
       type_at_level =
@@ -1637,28 +1753,29 @@ t8_dpyramid_first_pyra_anc (const t8_dpyramid_t *tet,
     T8_ASSERT (type_at_level == 0 || type_at_level == 3);
     t8_dpyramid_t       tmp_tet;
 
-    t8_dtet_ancestor (tet, level, &tmp_tet);
-    T8_ASSERT (tmp_tet.type == 0 || tmp_tet.type == 3);
+    t8_dtet_ancestor (&(tet->pyramid), level, &(tmp_tet.pyramid));
+    T8_ASSERT (tmp_tet.pyramid.type == 0 || tmp_tet.pyramid.type == 3);
     /* With this call tmp_tet has type 0 or type 3 and the first-pyra-anc
      * will be computed using one of the next cases. */
     t8_dpyramid_first_pyra_anc (&tmp_tet, first_pyra_anc);
   }
-  else if (t8_dpyramid_is_inside_tet (tet, tet->level, &last_tet_anc) != 0) {
+  else if (t8_dpyramid_is_inside_tet (tet, tet->pyramid.level, &last_tet_anc)
+           != 0) {
     /*The parent of last_tet_anc is a pyramid */
-    if (last_tet_anc.level == 1) {
-      first_pyra_anc->type = 6;
+    if (last_tet_anc.pyramid.level == 1) {
+      first_pyra_anc->pyramid.type = 6;
     }
     else {
       t8_dpyramid_tetparent_type (&last_tet_anc, first_pyra_anc);
     }
-    T8_ASSERT (last_tet_anc.level >= 1);
+    T8_ASSERT (last_tet_anc.pyramid.level >= 1);
     /*Update coordinates */
-    t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (last_tet_anc.level);
-    first_pyra_anc->x = last_tet_anc.x & ~length;
-    first_pyra_anc->y = last_tet_anc.y & ~length;
-    first_pyra_anc->z = last_tet_anc.z & ~length;
+    t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (last_tet_anc.pyramid.level);
+    first_pyra_anc->pyramid.x = last_tet_anc.pyramid.x & ~length;
+    first_pyra_anc->pyramid.y = last_tet_anc.pyramid.y & ~length;
+    first_pyra_anc->pyramid.z = last_tet_anc.pyramid.z & ~length;
     /*set the level */
-    first_pyra_anc->level = last_tet_anc.level - 1;
+    first_pyra_anc->pyramid.level = last_tet_anc.pyramid.level - 1;
   }
   else {
     /* The parent of the tet is already a pyramid */
@@ -1676,8 +1793,8 @@ static int
 t8_dpyramid_switches_type_at_level (const t8_dpyramid_t *tet)
 {
   T8_ASSERT (t8_dpyramid_shape (tet) == T8_ECLASS_TET);
-  t8_dpyramid_type_t  type_at_level = tet->type;
-  int                 level = tet->level;
+  t8_dpyramid_type_t  type_at_level = tet->pyramid.type;
+  int                 level = tet->pyramid.level;
   int                 last_tet_level;
   t8_dpyramid_t       tmp_tet;
   /* A tetrahedron that has not type 0 or type 3 can not switch the shape, because
@@ -1689,8 +1806,8 @@ t8_dpyramid_switches_type_at_level (const t8_dpyramid_t *tet)
   }
   T8_ASSERT (type_at_level == 0 || type_at_level == 3);
   t8_dpyramid_copy (tet, &tmp_tet);
-  tmp_tet.type = type_at_level;
-  tmp_tet.level = level;
+  tmp_tet.pyramid.type = type_at_level;
+  tmp_tet.pyramid.level = level;
   /* t8_pyramid_is_inside computes the level where the shape switches for 
    * tets of type 0 or 3. */
   last_tet_level = t8_dpyramid_is_inside_tet (&tmp_tet, level, NULL);
@@ -1714,21 +1831,21 @@ void
 t8_dpyramid_ancestor (const t8_dpyramid_t *pyra, const int level,
                       t8_dpyramid_t *anc)
 {
-  T8_ASSERT (0 <= level && level <= pyra->level);
+  T8_ASSERT (0 <= level && level <= pyra->pyramid.level);
   /*Set the coordinates and the level of the ancestor */
   t8_dpyramid_copy (pyra, anc);
-  if (pyra->level == level) {
+  if (pyra->pyramid.level == level) {
     return;
   }
-  else if (level == pyra->level - 1) {
+  else if (level == pyra->pyramid.level - 1) {
     /* We can reuse the parent computation if we want to go only one level up. */
     t8_dpyramid_parent (pyra, anc);
     return;
   }
   /* The coordinates of the anc are defined by the level. */
   t8_dpyramid_cut_coordinates (anc, T8_DPYRAMID_MAXLEVEL - level);
-  anc->level = level;
-  anc->type = t8_dpyramid_type_at_level (pyra, level);
+  anc->pyramid.level = level;
+  anc->pyramid.type = t8_dpyramid_type_at_level (pyra, level);
 }
 
 void
@@ -1775,15 +1892,16 @@ t8_dpyramid_nearest_common_ancestor (const t8_dpyramid_t *pyra1,
     t8_dpyramid_type_t  p1_type_at_level;       /* type of pyra1 at level */
     t8_dpyramid_type_t  p2_type_at_level;       /* type of pyra2 at level */
     /* Compute the first level, at which the coordinates differ */
-    maxclor = pyra1->x ^ pyra2->x;
-    maxclor |= pyra1->y ^ pyra2->y;
-    maxclor |= pyra1->z ^ pyra2->z;
+    maxclor = pyra1->pyramid.x ^ pyra2->pyramid.x;
+    maxclor |= pyra1->pyramid.y ^ pyra2->pyramid.y;
+    maxclor |= pyra1->pyramid.z ^ pyra2->pyramid.z;
     level = SC_LOG2_32 (maxclor) + 1;
     T8_ASSERT (level <= T8_DPYRAMID_MAXLEVEL);
     /* This is the highest possible level. The coordinates are the same,
      * but the types can be different.*/
     cube_level = SC_MIN (T8_DPYRAMID_MAXLEVEL - level,
-                         (int) SC_MIN (pyra1->level, pyra2->level));
+                         (int) SC_MIN (pyra1->pyramid.level,
+                                       pyra2->pyramid.level));
     real_level = cube_level;
     p1_type_at_level = compute_type_same_shape (pyra1, cube_level);
     p2_type_at_level = compute_type_same_shape (pyra2, cube_level);
@@ -1801,11 +1919,11 @@ t8_dpyramid_nearest_common_ancestor (const t8_dpyramid_t *pyra1,
     T8_ASSERT (real_level >= 0);
     /* Fill the nca */
     t8_dpyramid_copy (pyra1, nca);
-    nca->level = real_level;
+    nca->pyramid.level = real_level;
     /* Correct the coordinates of the nca */
     t8_dpyramid_cut_coordinates (nca, T8_DPYRAMID_MAXLEVEL - real_level);
     /* Set the computed type */
-    nca->type = p1_type_at_level;
+    nca->pyramid.type = p1_type_at_level;
     return;
   }
   else {
@@ -1821,9 +1939,9 @@ t8_dpyramid_nearest_common_ancestor (const t8_dpyramid_t *pyra1,
     t8_dpyramid_type_t  p1_type_at_level;       /* type of pyra1 at level */
     t8_dpyramid_type_t  p2_type_at_level;       /* type of pyra2 at level */
     /* Compute the first level, at which the coordinates differ */
-    maxclor = pyra1->x ^ pyra2->x;
-    maxclor |= pyra1->y ^ pyra2->y;
-    maxclor |= pyra1->z ^ pyra2->z;
+    maxclor = pyra1->pyramid.x ^ pyra2->pyramid.x;
+    maxclor |= pyra1->pyramid.y ^ pyra2->pyramid.y;
+    maxclor |= pyra1->pyramid.z ^ pyra2->pyramid.z;
     level = SC_LOG2_32 (maxclor) + 1;
     T8_ASSERT (level <= T8_DPYRAMID_MAXLEVEL);
     t8_dpyramid_t       pyra1_anc;
@@ -1834,7 +1952,8 @@ t8_dpyramid_nearest_common_ancestor (const t8_dpyramid_t *pyra1,
     /* Cube level is the highest possible level where the nca can be. the coordinates
      * match at the level, but the type can be different.*/
     cube_level = SC_MIN (T8_DPYRAMID_MAXLEVEL - level,
-                         (int) SC_MIN (pyra1->level, pyra2->level));
+                         (int) SC_MIN (pyra1->pyramid.level,
+                                       pyra2->pyramid.level));
     real_level = cube_level;
 
     /* Get the levels where the elements switch from a tet-shape to a pyra-shape. */
@@ -1845,8 +1964,8 @@ t8_dpyramid_nearest_common_ancestor (const t8_dpyramid_t *pyra1,
     t8_dpyramid_ancestor (pyra1, real_level, &pyra1_anc);
     t8_dpyramid_ancestor (pyra2, real_level, &pyra2_anc);
 
-    p1_type_at_level = pyra1_anc.type;
-    p2_type_at_level = pyra2_anc.type;
+    p1_type_at_level = pyra1_anc.pyramid.type;
+    p2_type_at_level = pyra2_anc.pyramid.type;
 
     /* We iterate over the levels and check if the types of both tets match and 
      * stop at that level.
@@ -1865,30 +1984,32 @@ t8_dpyramid_nearest_common_ancestor (const t8_dpyramid_t *pyra1,
     }
     if (real_level < level_switch_pyra1) {
       /* The first element switches the shape. The type is computed using 
-       * assuming a pyramid-parent.*/
+       * assuming a pyramid-parent.pyramid.*/
       t8_dpyramid_t       first_pyra1;
-      t8_dtet_ancestor (pyra1, level_switch_pyra1, &last_tet1);
+      t8_dtet_ancestor (&(pyra1->pyramid), level_switch_pyra1,
+                        &(last_tet1.pyramid));
       t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (level_switch_pyra1);
-      first_pyra1.x = last_tet1.x & ~length;
-      first_pyra1.y = last_tet1.y & ~length;
-      first_pyra1.z = last_tet1.z & ~length;
+      first_pyra1.pyramid.x = last_tet1.pyramid.x & ~length;
+      first_pyra1.pyramid.y = last_tet1.pyramid.y & ~length;
+      first_pyra1.pyramid.z = last_tet1.pyramid.z & ~length;
       t8_dpyramid_tetparent_type (&last_tet1, &first_pyra1);
-      first_pyra1.level = level_switch_pyra1 - 1;
+      first_pyra1.pyramid.level = level_switch_pyra1 - 1;
       t8_dpyramid_nearest_common_ancestor (&first_pyra1, pyra2, nca);
       return;
     }
     else if (real_level < level_switch_pyra2) {
 
       /* The second element switches the shape. The type is computed using 
-       * assuming a pyramid-parent.*/
+       * assuming a pyramid-parent.pyramid.*/
       t8_dpyramid_t       first_pyra2;
-      t8_dtet_ancestor (pyra2, level_switch_pyra2, &last_tet2);
+      t8_dtet_ancestor (&(pyra2->pyramid), level_switch_pyra2,
+                        &(last_tet2.pyramid));
       t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (level_switch_pyra2);
-      first_pyra2.x = last_tet2.x & ~length;
-      first_pyra2.y = last_tet2.y & ~length;
-      first_pyra2.z = last_tet2.z & ~length;
+      first_pyra2.pyramid.x = last_tet2.pyramid.x & ~length;
+      first_pyra2.pyramid.y = last_tet2.pyramid.y & ~length;
+      first_pyra2.pyramid.z = last_tet2.pyramid.z & ~length;
       t8_dpyramid_tetparent_type (&last_tet2, &first_pyra2);
-      first_pyra2.level = level_switch_pyra2 - 1;
+      first_pyra2.pyramid.level = level_switch_pyra2 - 1;
       t8_dpyramid_nearest_common_ancestor (&first_pyra2, pyra1, nca);
       return;
     }
@@ -1896,7 +2017,7 @@ t8_dpyramid_nearest_common_ancestor (const t8_dpyramid_t *pyra1,
       /* No anc switches the shape, the nca is a tet */
       T8_ASSERT (p1_type_at_level == p2_type_at_level);
       T8_ASSERT (p1_type_at_level < T8_DPYRAMID_FIRST_TYPE);
-      t8_dtet_ancestor (pyra1, real_level, nca);
+      t8_dtet_ancestor (&(pyra1->pyramid), real_level, &(nca->pyramid));
       return;
     }
   }
@@ -1910,20 +2031,25 @@ t8_dpyramid_is_valid (const t8_dpyramid_t *p)
     ((int64_t) 2 * T8_DPYRAMID_ROOT_LEN) - 1;
   t8_element_shape_t  shape = t8_dpyramid_shape (p);
   /*Check the level */
-  is_valid = 0 <= p->level && p->level <= T8_DPYRAMID_MAXLEVEL;
+  is_valid = 0 <= p->pyramid.level
+    && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL;
   /*Check coordinates, we allow a boundary layer around the root-pyramid */
-  is_valid = is_valid && -T8_DPYRAMID_ROOT_LEN <= p->x && p->x <= max_coord;
-  is_valid = is_valid && -T8_DPYRAMID_ROOT_LEN <= p->y && p->y <= max_coord;
-  is_valid = is_valid && -T8_DPYRAMID_ROOT_LEN <= p->z && p->z <= max_coord;
+  is_valid = is_valid && -T8_DPYRAMID_ROOT_LEN <= p->pyramid.x
+    && p->pyramid.x <= max_coord;
+  is_valid = is_valid && -T8_DPYRAMID_ROOT_LEN <= p->pyramid.y
+    && p->pyramid.y <= max_coord;
+  is_valid = is_valid && -T8_DPYRAMID_ROOT_LEN <= p->pyramid.z
+    && p->pyramid.z <= max_coord;
 
   /*The shape can be a pyramid or a tet */
   is_valid = is_valid && (shape == T8_ECLASS_PYRAMID
                           || shape == T8_ECLASS_TET);
   /*Check the type */
-  is_valid = is_valid && 0 <= p->type && p->type < T8_DPYRAMID_NUM_TYPES;
+  is_valid = is_valid && 0 <= p->pyramid.type
+    && p->pyramid.type < T8_DPYRAMID_NUM_TYPES;
 
-  if (p->level == 0) {
-    is_valid = is_valid && (p->type == T8_DPYRAMID_ROOT_TPYE);
+  if (p->pyramid.level == 0) {
+    is_valid = is_valid && (p->pyramid.type == T8_DPYRAMID_ROOT_TPYE);
   }
 
   return is_valid;
@@ -1932,6 +2058,6 @@ t8_dpyramid_is_valid (const t8_dpyramid_t *p)
 void
 t8_dpyramid_debug_print (const t8_dpyramid_t *p)
 {
-  t8_debugf ("x: %i, y: %i, z: %i, type %i, level: %i\n", p->x, p->y, p->z,
-             p->type, p->level);
+  t8_debugf ("x: %i, y: %i, z: %i, type %i, level: %i\n", p->pyramid.x,
+             p->pyramid.y, p->pyramid.z, p->pyramid.type, p->pyramid.level);
 }

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
@@ -155,7 +155,7 @@ int                 t8_dpyramid_compare (const t8_dpyramid_t *p1,
  * \param [in]  fam A collection of pyramids
  * \return      Nonzero if \a fam is a family of pyramids
  */
-int                 t8_dpyramid_is_family (const t8_dpyramid_t **fam);
+int                 t8_dpyramid_is_family (t8_dpyramid_t **fam);
 
 /** Compute whether a given pyramid shares a given face with its root tree.
  * \param [in]  p       The input pyramid

--- a/test/t8_forest/t8_test_element_general_function.cxx
+++ b/test/t8_forest/t8_test_element_general_function.cxx
@@ -87,7 +87,7 @@ test_element_general_function (sc_MPI_Comm comm)
           should_be = ((t8_dprism_t *) element)->tri.type;
           break;
         case T8_ECLASS_PYRAMID:
-          should_be = ((t8_dpyramid_t *) element)->type;
+          should_be = ((t8_dpyramid_t *) element)->pyramid.type;
           break;
         }
         SC_CHECK_ABORTF (outdata == should_be,

--- a/test/t8_schemes/t8_test_pyra_face_descendant.cxx
+++ b/test/t8_schemes/t8_test_pyra_face_descendant.cxx
@@ -33,8 +33,9 @@ t8_linear_face_descendant (t8_element_t *elem, t8_element_t *tmp,
                            t8_element_t *test, t8_eclass_scheme_c *ts,
                            int maxlvl)
 {
-  int                 level = ts->t8_element_level (elem),
-    type = ((t8_dpyramid_t *) elem)->type, child_id, i, j, k, num_faces;
+  int                 level = ts->t8_element_level (elem);
+  int                 type = ((t8_dpyramid_t *) elem)->pyramid.type;
+  int                 child_id, i, j, k, num_faces;
   if (type < 6) {
     num_faces = T8_DTET_FACES;
   }
@@ -104,7 +105,7 @@ t8_recursive_face_desendant (t8_element_t *elem, t8_element_t *test,
   else {
     num_faces = T8_DTET_FACES;
   }
-  type = ((t8_dpyramid_t *) elem)->type;
+  type = ((t8_dpyramid_t *) elem)->pyramid.type;
   /* Check face descendants from current-level + 1 to given maximum level */
   for (i = level + 1; i < maxlvl; i++) {
     for (j = 0; j < num_faces; j++) {


### PR DESCRIPTION
**_Describe your changes here:_**
Extend the t8_dpyramid_t struct, so that it is no longer the same as a t8_dtet_t struct, but instead has such a struct and additional information as variables.

In this PR, all source and test code is adapted to the new struct, so that additional functionality can be introduced in the upcoming PRs. This is mainly the inclusion of `pyramid.`, so `p->x` is changed to `p->pyramid.x`

The PR already includes the new variable switch_shape_at_level in the pyramid struct, although it is not yet used. The actual functionality will be introduced in the next PR.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] New tests use the Google Test framework
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
