### PR TITLE
Pyramid: compute and use switch_shape_at_level

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -442,6 +442,7 @@ t8_default_scheme_pyramid_c::t8_element_nca (const t8_element_t *elem1,
 {
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
+
   t8_dpyramid_nearest_common_ancestor ((const t8_dpyramid_t *) elem1,
                                        (const t8_dpyramid_t *) elem2,
                                        (t8_dpyramid_t *) nca);

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -1676,21 +1676,7 @@ t8_dpyramid_parent (const t8_dpyramid_t *p, t8_dpyramid_t *parent)
     parent->pyramid.level = p->pyramid.level - 1;
     parent->switch_shape_at_level = -1;
   }
-  else if (p->pyramid.type != 0 && p->pyramid.type != 3) {
-    /* The direct tet-child of a pyra has type 0 or type 3, therefore
-     * in this case the parent is a tetrahedron*/
-
-    t8_dtet_parent (&(p->pyramid), &(parent->pyramid));
-    parent->switch_shape_at_level = p->switch_shape_at_level;
-  }
-  else if (t8_dpyramid_is_inside_tet (p, p->pyramid.level, NULL) != 0) {
-    /*Pyramid- / tetparent detection */
-    /*If a tetrahedron does not reach a "significant point" its parent is a tet */
-    /*Tetcase */ ;
-    t8_dtet_parent (&(p->pyramid), &(parent->pyramid));
-    parent->switch_shape_at_level = p->switch_shape_at_level;
-  }
-  else {
+  else if (p->switch_shape_at_level == p->pyramid.level) {
     /*p does not lie in larger tet => parent is pyra */
     parent->pyramid.type = t8_dpyramid_tetparent_type (p);
     parent->pyramid.x = p->pyramid.x & ~length;
@@ -1698,6 +1684,12 @@ t8_dpyramid_parent (const t8_dpyramid_t *p, t8_dpyramid_t *parent)
     parent->pyramid.z = p->pyramid.z & ~length;
     parent->pyramid.level = p->pyramid.level - 1;
     parent->switch_shape_at_level = -1;
+  }
+  else {
+    /* The direct tet-child of a pyra has type 0 or type 3, therefore
+     * in this case the parent is a tetrahedron*/
+    t8_dtet_parent (&(p->pyramid), &(parent->pyramid));
+    parent->switch_shape_at_level = p->switch_shape_at_level;
   }
   T8_ASSERT (parent->pyramid.level >= 0);
 }

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -2020,7 +2020,9 @@ t8_dpyramid_is_valid (const t8_dpyramid_t *p)
   if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
     is_valid = is_valid && (p->switch_shape_at_level > 0);
     is_valid = is_valid && (p->switch_shape_at_level <= T8_DPYRAMID_MAXLEVEL);
-    is_valid = is_valid && (p->switch_shape_at_level <= p->pyramid.level);
+    is_valid = is_valid
+      && (p->switch_shape_at_level ==
+          t8_dpyramid_compute_switch_shape_at_level (p));
   }
   else {
     is_valid = is_valid && (p->switch_shape_at_level < 0);

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -856,15 +856,16 @@ t8_dpyramid_tet_boundary (const t8_dpyramid_t *p, const int face)
 {
   T8_ASSERT (0 <= p->pyramid.level
              && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
+  T8_ASSERT (t8_dpyramid_shape (p) == T8_ECLASS_TET);
+  T8_ASSERT (p->pyramid.type == 0 || p->pyramid.type == 3);
   t8_dpyramid_t       anc;
-  const int           level =
-    t8_dpyramid_is_inside_tet (p, p->pyramid.level, &anc);
   int                 bey_id, i, type_temp, valid_touch;
   t8_dpyramid_cube_id_t cube_id;
-  if (level == 0) {
+  if (p->pyramid.level == p->switch_shape_at_level) {
     /*Check if the face is connecting to a tet or to a pyra */
     return t8_dpyramid_tet_pyra_face_connection (p, face);
   }
+  t8_dpyramid_ancestor (p, p->switch_shape_at_level, &anc);
   /*Check if anc-face is connecting to a tet or to a pyra */
   valid_touch = t8_dpyramid_tet_pyra_face_connection (&anc, face);
   if (valid_touch) {

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -26,7 +26,6 @@
 #include <p4est_bits.h>
 #include <t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h>
 #include <t8_schemes/t8_default/t8_default_tet/t8_dtet_connectivity.h>
-#include <t8_schemes/t8_default/t8_default_tri/t8_dtri_connectivity.h>
 #include <t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h>
 
 typedef int8_t t8_dpyramid_cube_id_t;

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -1171,13 +1171,14 @@ t8_dpyramid_num_siblings (const t8_dpyramid_t *p)
 {
   T8_ASSERT (0 <= p->pyramid.level
              && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
-  t8_dpyramid_t       parent;
-  if (p->pyramid.level == 0) {
-    /* A level zero pyramid has only itself as sibling. */
-    return 1;
+  if (t8_dpyramid_shape (p) == T8_ECLASS_PYRAMID ||
+      p->switch_shape_at_level == p->pyramid.level) {
+    /* The parent is a pyramid. */
+    return T8_DPYRAMID_CHILDREN;
   }
-  t8_dpyramid_parent (p, &parent);
-  return t8_dpyramid_num_children (&parent);
+  else {
+    return T8_DTET_CHILDREN;
+  }
 }
 
 int

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -497,72 +497,23 @@ t8_dpyramid_type_at_level (const t8_dpyramid_t *p, const int level)
   if (level >= p->pyramid.level) {
     return p->pyramid.type;
   }
-  if (t8_dpyramid_shape (p) == T8_ECLASS_PYRAMID) {
+  if (t8_dpyramid_shape (p) == T8_ECLASS_PYRAMID ||
+      level >= p->switch_shape_at_level) {
     /* The shape does not switch, we can use the compute_type_same_shape function */
     return compute_type_same_shape (p, level);
   }
   else {
-    /* The shape may switch */
+    /* The shape switches */
     T8_ASSERT (t8_dpyramid_shape (p) == T8_ECLASS_TET);
-    int                 current_level = p->pyramid.level;
-    int                 type_at_level = p->pyramid.type;
-    /* The shape can not switch for tets that do not have type 0/3 */
-    while (type_at_level != 0 && type_at_level != 3 && current_level > level) {
-      /* The shape does not switch, we can use compute_type_same_shape_ext */
-      current_level--;
-      type_at_level =
-        compute_type_same_shape_ext (p, current_level, type_at_level,
-                                     current_level + 1);
-    }
-    if (level == current_level) {
+    t8_dpyramid_t       anc;
+    t8_dpyramid_ancestor (p, p->switch_shape_at_level, &anc);
+    t8_dpyramid_parent (&anc, &anc);
+    if (level == anc.pyramid.level) {
       /* We have already reached the desired level and can return. */
-      return type_at_level;
+      return anc.pyramid.type;
     }
     else {
-      /* The shape may switch, we can use t8_dpyramid_is_inside_tet, to find out when. */
-      T8_ASSERT (type_at_level == 0 || type_at_level == 3);
-      T8_ASSERT (current_level > level);
-      t8_dpyramid_t       last_tet;
-      t8_dpyramid_t       first_pyra;
-      t8_dpyramid_t       tmp_pyra;
-      t8_dpyramid_copy (p, &tmp_pyra);
-      tmp_pyra.pyramid.type = type_at_level;
-      tmp_pyra.pyramid.level = current_level;
-      /* Compute the last level where the shape is a tetrahedron. If last_tet_level == 0
-       * then the parent is already a pyramid. */
-      int                 last_tet_level =
-        t8_dpyramid_is_inside_tet (&tmp_pyra, current_level, &last_tet);
-      if (last_tet_level != 0) {
-        /* last_tet was calculated by t8_dpyramid_is_inside_tet */
-        current_level = SC_MAX (last_tet_level, level);
-        if (current_level > last_tet_level) {
-          t8_dtet_ancestor (&(p->pyramid), current_level,
-                            &(last_tet.pyramid));
-        }
-        type_at_level = last_tet.pyramid.type;
-      }
-      else {
-        /* last_tet_level is the current_level */
-        t8_dtet_ancestor (&(p->pyramid), current_level, &(last_tet.pyramid));
-        type_at_level = last_tet.pyramid.type;
-      }
-      /* At this point the shape switches. */
-      if (current_level > level) {
-        current_level--;
-        first_pyra.pyramid.type = t8_dpyramid_tetparent_type (&last_tet);
-        type_at_level = first_pyra.pyramid.type;
-      }
-      /* The shape is now a pyramid, and won't switch anymore. */
-      while (current_level > level) {
-        T8_ASSERT (type_at_level == T8_DPYRAMID_FIRST_TYPE ||
-                   type_at_level == T8_DPYRAMID_SECOND_TYPE);
-        current_level--;
-        type_at_level =
-          compute_type_same_shape_ext (p, current_level, type_at_level,
-                                       current_level + 1);
-      }
-      T8_ASSERT (level == current_level);
-      return type_at_level;
+      return compute_type_same_shape (&anc, level);
     }
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -129,6 +129,113 @@ t8_dpyramid_cut_coordinates (t8_dpyramid_t *p, const int shift)
 }
 
 /**
+ * Compute if the tetrahedron \a tet lies inside a pyramid  with coordinates given by \a check.
+ * Both pyramids of type 6 and 7 are tested, hence the type of \a check does not have to be set.
+ * 
+ * \param tet     Input pyramid in the shape of a tetrahedron 
+ * \param check   Input pyramid, candidate where \a tet could lie in.
+ * \return int    the type of the pyramid where tet is inside, or 0 if it does not lie in a pyramid given by the coordinates of \a check.
+ */
+static int
+t8_dpyramid_is_inside_pyra (const t8_dpyramid_t *tet,
+                            const t8_dpyramid_t *check)
+{
+  t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (check->pyramid.level);
+  t8_dpyramid_coord_t diff = tet->pyramid.z - check->pyramid.z;
+  T8_ASSERT (t8_dpyramid_shape (tet) == T8_ECLASS_TET);
+
+  T8_ASSERT (0 <= tet->pyramid.level
+             && tet->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
+
+  /* test if tet is inside the pyramids with coordinates given by check and type 6 */
+  if (((check->pyramid.x + diff) <= tet->pyramid.x
+       && tet->pyramid.x < (check->pyramid.x + length))
+      && ((check->pyramid.y + diff) <= tet->pyramid.y
+          && tet->pyramid.y < (check->pyramid.y + length))
+      && (check->pyramid.z <= tet->pyramid.z
+          && tet->pyramid.z < (check->pyramid.z + length))) {
+    if ((check->pyramid.x + diff == tet->pyramid.x
+         && (tet->pyramid.type == 3 || tet->pyramid.type == 1))
+        || (check->pyramid.y + diff == tet->pyramid.y
+            && (tet->pyramid.type == 0 || tet->pyramid.type == 2))) {
+      /*tet touches face of pyra but is outside of pyra */
+      return 0;
+    }
+    else {
+      /*tet is inside pyra of type 6 */
+      return T8_DPYRAMID_FIRST_TYPE;
+    }
+  }
+  /* test if tet is inside the pyramids with coordinates given by check and type 7 */
+  else
+    if ((check->pyramid.x <= tet->pyramid.x
+         && tet->pyramid.x <= (check->pyramid.x + diff))
+        && (check->pyramid.y <= tet->pyramid.y
+            && tet->pyramid.y <= (check->pyramid.y + diff))
+        && (check->pyramid.z <= tet->pyramid.z
+            && tet->pyramid.z < (check->pyramid.z + length))) {
+    if ((check->pyramid.x + diff == tet->pyramid.x
+         && (tet->pyramid.type == 0 || tet->pyramid.type == 2))
+        || (check->pyramid.y + diff == tet->pyramid.y
+            && (tet->pyramid.type == 3 || tet->pyramid.type == 1))) {
+      /*tet touches face of pyra, but is outside of pyra */
+      return 0;
+    }
+    else {
+      /*tet is inside pyra of type 7 */
+      return T8_DPYRAMID_SECOND_TYPE;
+    }
+  }
+  else {
+    /*tet is inside tet */
+    return 0;
+  }
+}
+
+/**
+ * The i first bits give the anchor coordinate for a possible ancestor of level i
+ * for tet.
+ * We can store the last tetrahedra ancestor in anc.
+ * \param[in] tet     Inpute pyramid in the shape of a tet
+ * \param[in] level   the maximal level to check whether \a tet lies in a pyramid
+ * \param[in] anc     Can be NULL or an allocated element. If allocated, it will be filled with the data of the last tetrahedral ancestor 
+ * \return      0, if the pyramid is insed of a tetrahedron*/
+static int
+t8_dpyramid_is_inside_tet (const t8_dpyramid_t *tet, const int level,
+                           t8_dpyramid_t *anc)
+{
+  T8_ASSERT (t8_dpyramid_shape (tet) == T8_ECLASS_TET);
+  T8_ASSERT (tet->pyramid.type == 0 || tet->pyramid.type == 3);
+  int                 i;
+  t8_dpyramid_coord_t coord_at_level;
+  /*the tet is initialized, the ancestor will be computed */
+  t8_dpyramid_t       pyra_at_level;    /* Candidate pyramid, where the tet could lie in. */
+  pyra_at_level.pyramid.x = 0;
+  pyra_at_level.pyramid.y = 0;
+  pyra_at_level.pyramid.z = 0;
+  for (i = 1; i < level; i++) {
+    /*Update the coordinate of tet to i first bits */
+    coord_at_level = (1 << (T8_DPYRAMID_MAXLEVEL - i));
+    pyra_at_level.pyramid.x =
+      pyra_at_level.pyramid.x | (tet->pyramid.x & coord_at_level);
+    pyra_at_level.pyramid.y =
+      pyra_at_level.pyramid.y | (tet->pyramid.y & coord_at_level);
+    pyra_at_level.pyramid.z =
+      pyra_at_level.pyramid.z | (tet->pyramid.z & coord_at_level);
+    pyra_at_level.pyramid.level = i;
+    if (t8_dpyramid_is_inside_pyra (tet, &pyra_at_level) == 0) {
+      /*tet is inside a tet */
+      if (anc != NULL) {
+        t8_dtet_ancestor (&(tet->pyramid), i, &(anc->pyramid));
+      }
+      return i;
+    }
+  }
+  /*No matching tet-ancestor was found, the parent is a pyramid */
+  return 0;
+}
+
+/**
  * Smallest level at which an anc of \a tet has the shape of a tetrahedron
  * 
  * \param[in] tet The input element
@@ -166,7 +273,16 @@ t8_dpyramid_compute_switch_shape_at_level (const t8_dpyramid_t *tet)
   }
 }
 
-void
+/**
+ * Sets the field switch_shape_at_level for \a p. \a p has to have the shape
+ * of a tetrahedron. 
+ * switch_shape_at_level is set to the lowest level at which the ancestor of \a p
+ * still has the shape of a tetrahedron. switch_shape_at_level is set to -1 for
+ * pyramidal shaped elements.
+ * 
+ * \param p       Input element, whose switch_shape_at_level will be set.
+ */
+static void
 t8_dpyramid_set_switch_shape_at_level (t8_dpyramid_t *p)
 {
   if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
@@ -175,7 +291,6 @@ t8_dpyramid_set_switch_shape_at_level (t8_dpyramid_t *p)
   else {
     p->switch_shape_at_level = -1;
   }
-
 }
 
 int
@@ -677,6 +792,22 @@ t8_dpyramid_face_neighbour (const t8_dpyramid_t *p, const int face,
       /*tet touches tet */
       return t8_dtet_face_neighbour (&(p->pyramid), face, &(neigh->pyramid));
     }
+  }
+}
+
+/** Compute the pyramid-parent-type of a tetrahedron
+ * \param [in] p        Input pyramid
+ * \return              The type of the parent.
+ */
+static int
+t8_dpyramid_tetparent_type (const t8_dpyramid_t *p)
+{
+  T8_ASSERT (t8_dpyramid_shape (p) == T8_ECLASS_TET);
+  if ((p->pyramid.z >> (T8_DPYRAMID_MAXLEVEL - p->pyramid.level)) % 2 == 0) {
+    return T8_DPYRAMID_FIRST_TYPE;
+  }
+  else {
+    return T8_DPYRAMID_SECOND_TYPE;
   }
 }
 
@@ -1469,124 +1600,6 @@ t8_dpyramid_get_face_corner (const t8_dpyramid_t *pyra, int face, int corner)
     int                 corner_number = t8_dpyramid_face_corner[face][corner];
     T8_ASSERT (0 <= corner_number && corner_number < T8_DPYRAMID_FACES);
     return corner_number;
-  }
-}
-
-/**
- * Compute if the tetrahedron \a tet lies inside a pyramid  with coordinates given by \a check.
- * Both pyramids of type 6 and 7 are tested, hence the type of \a check does not have to be set.
- * 
- * \param tet     Input pyramid in the shape of a tetrahedron 
- * \param check   Input pyramid, candidate where \a tet could lie in.
- * \return int    the type of the pyramid where tet is inside, or 0 if it does not lie in a pyramid given by the coordinates of \a check.
- */
-int
-t8_dpyramid_is_inside_pyra (const t8_dpyramid_t *tet,
-                            const t8_dpyramid_t *check)
-{
-  t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (check->pyramid.level);
-  t8_dpyramid_coord_t diff = tet->pyramid.z - check->pyramid.z;
-  T8_ASSERT (t8_dpyramid_shape (tet) == T8_ECLASS_TET);
-
-  T8_ASSERT (0 <= tet->pyramid.level
-             && tet->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
-
-  /* test if tet is inside the pyramids with coordinates given by check and type 6 */
-  if (((check->pyramid.x + diff) <= tet->pyramid.x
-       && tet->pyramid.x < (check->pyramid.x + length))
-      && ((check->pyramid.y + diff) <= tet->pyramid.y
-          && tet->pyramid.y < (check->pyramid.y + length))
-      && (check->pyramid.z <= tet->pyramid.z
-          && tet->pyramid.z < (check->pyramid.z + length))) {
-    if ((check->pyramid.x + diff == tet->pyramid.x
-         && (tet->pyramid.type == 3 || tet->pyramid.type == 1))
-        || (check->pyramid.y + diff == tet->pyramid.y
-            && (tet->pyramid.type == 0 || tet->pyramid.type == 2))) {
-      /*tet touches face of pyra but is outside of pyra */
-      return 0;
-    }
-    else {
-      /*tet is inside pyra of type 6 */
-      return T8_DPYRAMID_FIRST_TYPE;
-    }
-  }
-  /* test if tet is inside the pyramids with coordinates given by check and type 7 */
-  else
-    if ((check->pyramid.x <= tet->pyramid.x
-         && tet->pyramid.x <= (check->pyramid.x + diff))
-        && (check->pyramid.y <= tet->pyramid.y
-            && tet->pyramid.y <= (check->pyramid.y + diff))
-        && (check->pyramid.z <= tet->pyramid.z
-            && tet->pyramid.z < (check->pyramid.z + length))) {
-    if ((check->pyramid.x + diff == tet->pyramid.x
-         && (tet->pyramid.type == 0 || tet->pyramid.type == 2))
-        || (check->pyramid.y + diff == tet->pyramid.y
-            && (tet->pyramid.type == 3 || tet->pyramid.type == 1))) {
-      /*tet touches face of pyra, but is outside of pyra */
-      return 0;
-    }
-    else {
-      /*tet is inside pyra of type 7 */
-      return T8_DPYRAMID_SECOND_TYPE;
-    }
-  }
-  else {
-    /*tet is inside tet */
-    return 0;
-  }
-}
-
-/**
- * The i first bits give the anchor coordinate for a possible ancestor of level i
- * for tet.
- * We can store the last tetrahedra ancestor in anc.
- * \param[in] tet     Inpute pyramid in the shape of a tet
- * \param[in] level   the maximal level to check whether \a tet lies in a pyramid
- * \param[in] anc     Can be NULL or an allocated element. If allocated, it will be filled with the data of the last tetrahedral ancestor */
-int
-t8_dpyramid_is_inside_tet (const t8_dpyramid_t *tet, const int level,
-                           t8_dpyramid_t *anc)
-{
-  T8_ASSERT (t8_dpyramid_shape (tet) == T8_ECLASS_TET);
-  T8_ASSERT (tet->pyramid.type == 0 || tet->pyramid.type == 3);
-  int                 i;
-  t8_dpyramid_coord_t coord_at_level;
-  /*the tet is initialized, the ancestor will be computed */
-  t8_dpyramid_t       pyra_at_level;    /* Candidate pyramid, where the tet could lie in. */
-  pyra_at_level.pyramid.x = 0;
-  pyra_at_level.pyramid.y = 0;
-  pyra_at_level.pyramid.z = 0;
-  for (i = 1; i < level; i++) {
-    /*Update the coordinate of tet to i first bits */
-    coord_at_level = (1 << (T8_DPYRAMID_MAXLEVEL - i));
-    pyra_at_level.pyramid.x =
-      pyra_at_level.pyramid.x | (tet->pyramid.x & coord_at_level);
-    pyra_at_level.pyramid.y =
-      pyra_at_level.pyramid.y | (tet->pyramid.y & coord_at_level);
-    pyra_at_level.pyramid.z =
-      pyra_at_level.pyramid.z | (tet->pyramid.z & coord_at_level);
-    pyra_at_level.pyramid.level = i;
-    if (t8_dpyramid_is_inside_pyra (tet, &pyra_at_level) == 0) {
-      /*tet is inside a tet */
-      if (anc != NULL) {
-        t8_dtet_ancestor (&(tet->pyramid), i, &(anc->pyramid));
-      }
-      return i;
-    }
-  }
-  /*No matching tet-ancestor was found, the parent is a pyramid */
-  return 0;
-}
-
-int
-t8_dpyramid_tetparent_type (const t8_dpyramid_t *p)
-{
-  T8_ASSERT (t8_dpyramid_shape (p) == T8_ECLASS_TET);
-  if ((p->pyramid.z >> (T8_DPYRAMID_MAXLEVEL - p->pyramid.level)) % 2 == 0) {
-    return T8_DPYRAMID_FIRST_TYPE;
-  }
-  else {
-    return T8_DPYRAMID_SECOND_TYPE;
   }
 }
 

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -129,10 +129,53 @@ t8_dpyramid_cut_coordinates (t8_dpyramid_t *p, const int shift)
   p->pyramid.z = (p->pyramid.z >> shift) << shift;
 }
 
+/**
+ * Smallest level at which an anc of \a tet has the shape of a tetrahedron
+ * 
+ * \param[in] tet The input element
+ * \return The level of the last ancestor with the shape of a tetrahedron  
+ */
+static int
+t8_dpyramid_compute_switch_shape_at_level (const t8_dpyramid_t *tet)
+{
+  T8_ASSERT (t8_dpyramid_shape (tet) == T8_ECLASS_TET);
+  t8_dpyramid_type_t  type_at_level = tet->pyramid.type;
+  int                 level = tet->pyramid.level;
+  int                 last_tet_level;
+  t8_dpyramid_t       tmp_tet;
+
+  /* A tetrahedron that has not type 0 or type 3 can not switch the shape, because
+   * the tetrahedral children of a pyramid only have type 0 or type 3.*/
+  while (type_at_level != 0 && type_at_level != 3) {
+    level--;
+    type_at_level =
+      compute_type_same_shape_ext (tet, level, type_at_level, level + 1);
+  }
+  T8_ASSERT (type_at_level == 0 || type_at_level == 3);
+  t8_dpyramid_copy (tet, &tmp_tet);
+  tmp_tet.pyramid.type = type_at_level;
+  tmp_tet.pyramid.level = level;
+  /* t8_pyramid_is_inside computes the level where the shape switches for 
+   * tets of type 0 or 3. */
+  last_tet_level = t8_dpyramid_is_inside_tet (&tmp_tet, level, NULL);
+  if (last_tet_level != 0) {
+    return last_tet_level;
+  }
+  else {
+    /* The parent of tmp_tet is a pyramid, hence we return the current level. */
+    return level;
+  }
+}
+
 void
 t8_dpyramid_set_switch_shape_at_level (t8_dpyramid_t *p)
 {
-  T8_ASSERT (t8_dpyramid_shape (p) == T8_ECLASS_TET);
+  if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
+    p->switch_shape_at_level = t8_dpyramid_compute_switch_shape_at_level (p);
+  }
+  else {
+    p->switch_shape_at_level = -1;
+  }
 
 }
 
@@ -408,10 +451,13 @@ t8_dpyramid_init_linear_id (t8_dpyramid_t *p, const int level,
       /* Ensure that a valid tet is used in init_linear_id_with_level */
       p->pyramid.type = type;
       p->pyramid.level = i;
+      p->switch_shape_at_level = i - 1;
 #if T8_ENABLE_DEBUG
       ((t8_dtet_t *) p)->eclass_int8 = T8_ECLASS_TET;
 #endif
       t8_dtet_init_linear_id_with_level (&(p->pyramid), id, i, level, type);
+      T8_ASSERT (p->switch_shape_at_level ==
+                 t8_dpyramid_compute_switch_shape_at_level (p));
       return;
     }
     /* The local index depends on the alternating number of predecessors
@@ -432,6 +478,15 @@ t8_dpyramid_init_linear_id (t8_dpyramid_t *p, const int level,
   }
   T8_ASSERT (id == 0);
   p->pyramid.type = type;
+  /* All ancestors are pyramids, the shape does not change. */
+  if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
+    p->switch_shape_at_level = level;
+    T8_ASSERT (p->switch_shape_at_level ==
+               t8_dpyramid_compute_switch_shape_at_level (p));
+  }
+  else {
+    p->switch_shape_at_level = -1;
+  }
 }
 
 int
@@ -615,7 +670,6 @@ t8_dpyramid_face_neighbour (const t8_dpyramid_t *p, const int face,
       neigh->pyramid.z +=
         ((p->pyramid.type == T8_DPYRAMID_FIRST_TYPE) ? -length : length);
     }
-
     return t8_dpyramid_type_face_to_nface[p->pyramid.type -
                                           T8_DPYRAMID_FIRST_TYPE][face];
   }
@@ -894,9 +948,15 @@ t8_dpyramid_face_neighbor_inside (const t8_dpyramid_t *p,
 {
   T8_ASSERT (0 <= p->pyramid.level
              && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
+  int                 is_inside;
   /*Compute the face-neighbor, then check if it is inside root */
   *neigh_face = t8_dpyramid_face_neighbour (p, face, neigh);
-  return t8_dpyramid_is_inside_root (neigh);
+
+  is_inside = t8_dpyramid_is_inside_root (neigh);
+  if (is_inside) {
+    t8_dpyramid_set_switch_shape_at_level (neigh);
+  }
+  return is_inside;
 }
 
 void
@@ -910,6 +970,7 @@ t8_dpyramid_first_descendant (const t8_dpyramid_t *p, t8_dpyramid_t *desc,
     /*The first descendant of a pyramid has the same anchor coords, but another level */
     t8_dpyramid_copy (p, desc);
     desc->pyramid.level = level;
+    desc->switch_shape_at_level = -1;
   }
   else {
     id = t8_dpyramid_linear_id (p, level);
@@ -1225,6 +1286,7 @@ t8_dpyramid_extrude_face (const t8_element_t *face, t8_dpyramid_t *p,
     p->pyramid.z = 0;
     p->pyramid.type = T8_DPYRAMID_ROOT_TPYE;
     p->pyramid.level = q->level;
+    p->switch_shape_at_level = -1;
     return root_face;
   }
   else {
@@ -1265,6 +1327,7 @@ t8_dpyramid_extrude_face (const t8_element_t *face, t8_dpyramid_t *p,
     if ((t->y == (t->x & t->y)) && t->type == 0) {
       /*type zero in a pyramid extend to a pyramid */
       p->pyramid.type = T8_DPYRAMID_FIRST_TYPE;
+      p->switch_shape_at_level = -1;
       extruded_face = root_face;
     }
     else {
@@ -1273,6 +1336,7 @@ t8_dpyramid_extrude_face (const t8_element_t *face, t8_dpyramid_t *p,
         t8_dpyramid_tritype_rootface_to_tettype[t->type][root_face];
       extruded_face =
         t8_dpyramid_tritype_rootface_to_face[t->type][root_face];
+      t8_dpyramid_set_switch_shape_at_level (p);
     }
   }
   T8_ASSERT (0 <= p->pyramid.level
@@ -1341,6 +1405,7 @@ t8_dpyramid_child (const t8_dpyramid_t *elem, const int child_id,
   if (t8_dpyramid_shape (elem) == T8_ECLASS_TET) {
     /*Todo: Set switch_shape_at_level */
     t8_dtet_child (&(elem->pyramid), child_id, &(child->pyramid));
+    child->switch_shape_at_level = elem->switch_shape_at_level;
   }
   else {
     /* Compute the cube id and shift the coordinates accordingly */
@@ -1353,6 +1418,12 @@ t8_dpyramid_child (const t8_dpyramid_t *elem, const int child_id,
     child->pyramid.z = elem->pyramid.z + ((cube_id & 0x04) ? length : 0);
     child->pyramid.type =
       t8_dpyramid_parenttype_Iloc_to_type[elem->pyramid.type][child_id];
+    if (t8_dpyramid_shape (child) == T8_ECLASS_TET) {
+      child->switch_shape_at_level = elem->pyramid.level + 1;
+    }
+    else {
+      child->switch_shape_at_level = -1;
+    }
   }
   T8_ASSERT (child->pyramid.type >= 0);
 }
@@ -1387,8 +1458,8 @@ t8_dpyramid_children_at_face (const t8_dpyramid_t *p, const int face,
     t8_dtet_children_at_face (&(p->pyramid), face, tet_children, num_children,
                               child_indices);
     for (i = 0; i < T8_DTET_FACE_CHILDREN; i++) {
-      /* TODO: set switch_shape_at_level */
       t8_dtet_copy (tet_children[i], &(children[i]->pyramid));
+      children[i]->switch_shape_at_level = p->switch_shape_at_level;
       T8_FREE (tet_children[i]);
     }
     T8_FREE (tet_children);
@@ -1603,18 +1674,21 @@ t8_dpyramid_parent (const t8_dpyramid_t *p, t8_dpyramid_t *parent)
     parent->pyramid.z = p->pyramid.z & ~length;
     T8_ASSERT (parent->pyramid.type >= 0);
     parent->pyramid.level = p->pyramid.level - 1;
+    parent->switch_shape_at_level = -1;
   }
   else if (p->pyramid.type != 0 && p->pyramid.type != 3) {
     /* The direct tet-child of a pyra has type 0 or type 3, therefore
      * in this case the parent is a tetrahedron*/
-    /*TODO: Set switch_type_at_level */
+
     t8_dtet_parent (&(p->pyramid), &(parent->pyramid));
+    parent->switch_shape_at_level = p->switch_shape_at_level;
   }
   else if (t8_dpyramid_is_inside_tet (p, p->pyramid.level, NULL) != 0) {
     /*Pyramid- / tetparent detection */
     /*If a tetrahedron does not reach a "significant point" its parent is a tet */
     /*Tetcase */ ;
     t8_dtet_parent (&(p->pyramid), &(parent->pyramid));
+    parent->switch_shape_at_level = p->switch_shape_at_level;
   }
   else {
     /*p does not lie in larger tet => parent is pyra */
@@ -1623,6 +1697,7 @@ t8_dpyramid_parent (const t8_dpyramid_t *p, t8_dpyramid_t *parent)
     parent->pyramid.y = p->pyramid.y & ~length;
     parent->pyramid.z = p->pyramid.z & ~length;
     parent->pyramid.level = p->pyramid.level - 1;
+    parent->switch_shape_at_level = -1;
   }
   T8_ASSERT (parent->pyramid.level >= 0);
 }
@@ -1737,43 +1812,6 @@ t8_dpyramid_vertex_reference_coords (const t8_dpyramid_t *elem,
 }
 
 /**
- * Smallest level at which an anc of \a tet has the shape of a tetrahedron
- * 
- * \param[in] tet The input element
- * \return The level of the last ancestor with the shape of a tetrahedron  
- */
-static int
-t8_dpyramid_switches_type_at_level (const t8_dpyramid_t *tet)
-{
-  T8_ASSERT (t8_dpyramid_shape (tet) == T8_ECLASS_TET);
-  t8_dpyramid_type_t  type_at_level = tet->pyramid.type;
-  int                 level = tet->pyramid.level;
-  int                 last_tet_level;
-  t8_dpyramid_t       tmp_tet;
-  /* A tetrahedron that has not type 0 or type 3 can not switch the shape, because
-   * the tetrahedral children of a pyramid only have type 0 or type 3.*/
-  while (type_at_level != 0 && type_at_level != 3) {
-    level--;
-    type_at_level =
-      compute_type_same_shape_ext (tet, level, type_at_level, level + 1);
-  }
-  T8_ASSERT (type_at_level == 0 || type_at_level == 3);
-  t8_dpyramid_copy (tet, &tmp_tet);
-  tmp_tet.pyramid.type = type_at_level;
-  tmp_tet.pyramid.level = level;
-  /* t8_pyramid_is_inside computes the level where the shape switches for 
-   * tets of type 0 or 3. */
-  last_tet_level = t8_dpyramid_is_inside_tet (&tmp_tet, level, NULL);
-  if (last_tet_level != 0) {
-    return last_tet_level;
-  }
-  else {
-    /* The parent of tmp_tet is a pyramid, hence we return the current level. */
-    return level;
-  }
-}
-
-/**
  * Compute the ancestor of \a pyra on level \a level.
  * 
  * \param[in]       pyra    Input pyramid
@@ -1799,6 +1837,12 @@ t8_dpyramid_ancestor (const t8_dpyramid_t *pyra, const int level,
   t8_dpyramid_cut_coordinates (anc, T8_DPYRAMID_MAXLEVEL - level);
   anc->pyramid.level = level;
   anc->pyramid.type = t8_dpyramid_type_at_level (pyra, level);
+  if (t8_dpyramid_shape (anc) == T8_ECLASS_TET) {
+    anc->switch_shape_at_level = pyra->switch_shape_at_level;
+  }
+  else {
+    anc->switch_shape_at_level = -1;
+  }
 }
 
 void
@@ -1811,15 +1855,16 @@ t8_dpyramid_nearest_common_ancestor (const t8_dpyramid_t *pyra1,
   if (t8_dpyramid_shape (pyra1) == T8_ECLASS_PYRAMID &&
       t8_dpyramid_shape (pyra2) == T8_ECLASS_TET) {
     t8_dpyramid_t       first_pyramid_anc;
-    int                 level;
 
-    level = t8_dpyramid_switches_type_at_level (pyra2);
-    t8_dtet_ancestor (&(pyra2->pyramid), level, &(first_pyramid_anc.pyramid));
+    t8_dtet_ancestor (&(pyra2->pyramid), pyra2->switch_shape_at_level,
+                      &(first_pyramid_anc.pyramid));
     first_pyramid_anc.pyramid.type =
       t8_dpyramid_tetparent_type (&(first_pyramid_anc));
     t8_dpyramid_cut_coordinates (&first_pyramid_anc,
-                                 T8_DPYRAMID_MAXLEVEL - (level - 1));
-    first_pyramid_anc.pyramid.level = level - 1;
+                                 T8_DPYRAMID_MAXLEVEL -
+                                 (pyra2->switch_shape_at_level - 1));
+    first_pyramid_anc.pyramid.level = pyra2->switch_shape_at_level - 1;
+    first_pyramid_anc.switch_shape_at_level = -1;
 
     /* pyra1 and first_pyramid_anc have the shape of a pyramid now, 
      * we can call the nca again.
@@ -1830,15 +1875,16 @@ t8_dpyramid_nearest_common_ancestor (const t8_dpyramid_t *pyra1,
   else if (t8_dpyramid_shape (pyra1) == T8_ECLASS_TET &&
            t8_dpyramid_shape (pyra2) == T8_ECLASS_PYRAMID) {
     t8_dpyramid_t       first_pyramid_anc;
-    int                 level;
 
-    level = t8_dpyramid_switches_type_at_level (pyra1);
-    t8_dtet_ancestor (&(pyra1->pyramid), level, &(first_pyramid_anc.pyramid));
+    t8_dtet_ancestor (&(pyra1->pyramid), pyra1->switch_shape_at_level,
+                      &(first_pyramid_anc.pyramid));
     first_pyramid_anc.pyramid.type =
       t8_dpyramid_tetparent_type (&first_pyramid_anc);
     t8_dpyramid_cut_coordinates (&first_pyramid_anc,
-                                 T8_DPYRAMID_MAXLEVEL - (level - 1));
-    first_pyramid_anc.pyramid.level = level - 1;
+                                 T8_DPYRAMID_MAXLEVEL -
+                                 (pyra1->switch_shape_at_level - 1));
+    first_pyramid_anc.pyramid.level = pyra1->switch_shape_at_level - 1;
+    first_pyramid_anc.switch_shape_at_level = -1;
     /* pyra2 and first_pyramid_anc have the shape of a pyramid now, 
      * we can call the nca again.
      */
@@ -1922,25 +1968,27 @@ t8_dpyramid_nearest_common_ancestor (const t8_dpyramid_t *pyra1,
                          (int) SC_MIN (pyra1->pyramid.level,
                                        pyra2->pyramid.level));
     real_level = cube_level;
-
-    /* Get the levels where the elements switch from a tet-shape to a pyra-shape. */
-    int                 level_switch_pyra1 =
-      t8_dpyramid_switches_type_at_level (pyra1);
-    int                 level_switch_pyra2 =
-      t8_dpyramid_switches_type_at_level (pyra2);
     t8_dpyramid_ancestor (pyra1, real_level, &pyra1_anc);
     t8_dpyramid_ancestor (pyra2, real_level, &pyra2_anc);
 
     p1_type_at_level = pyra1_anc.pyramid.type;
     p2_type_at_level = pyra2_anc.pyramid.type;
+    T8_ASSERT (pyra1->switch_shape_at_level ==
+               t8_dpyramid_compute_switch_shape_at_level (pyra1));
+    T8_ASSERT (pyra2->switch_shape_at_level ==
+               t8_dpyramid_compute_switch_shape_at_level (pyra2));
 
     /* We iterate over the levels and check if the types of both tets match and 
      * stop at that level.
      * The loop is interupted, if we get to a level where one element switches 
      * the shape.*/
-    while (p1_type_at_level != p2_type_at_level &&
-           real_level >= level_switch_pyra1 &&
-           real_level >= level_switch_pyra2) {
+    T8_ASSERT (0 < pyra1->switch_shape_at_level
+               && pyra1->switch_shape_at_level <= T8_DPYRAMID_MAXLEVEL);
+    T8_ASSERT (0 < pyra2->switch_shape_at_level
+               && pyra2->switch_shape_at_level <= T8_DPYRAMID_MAXLEVEL);
+    while (p1_type_at_level != p2_type_at_level
+           && real_level >= pyra1->switch_shape_at_level
+           && real_level >= pyra2->switch_shape_at_level) {
       real_level--;
       p1_type_at_level =
         compute_type_same_shape_ext (pyra1, real_level, p1_type_at_level,
@@ -1949,34 +1997,38 @@ t8_dpyramid_nearest_common_ancestor (const t8_dpyramid_t *pyra1,
         compute_type_same_shape_ext (pyra2, real_level, p2_type_at_level,
                                      real_level + 1);
     }
-    if (real_level < level_switch_pyra1) {
+    if (real_level < pyra1->switch_shape_at_level) {
       /* The first element switches the shape. The type is computed using 
        * assuming a pyramid-parent.pyramid.*/
       t8_dpyramid_t       first_pyra1;
-      t8_dtet_ancestor (&(pyra1->pyramid), level_switch_pyra1,
+      t8_dtet_ancestor (&(pyra1->pyramid), pyra1->switch_shape_at_level,
                         &(last_tet1.pyramid));
-      t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (level_switch_pyra1);
+      t8_dpyramid_coord_t length =
+        T8_DPYRAMID_LEN (pyra1->switch_shape_at_level);
       first_pyra1.pyramid.x = last_tet1.pyramid.x & ~length;
       first_pyra1.pyramid.y = last_tet1.pyramid.y & ~length;
       first_pyra1.pyramid.z = last_tet1.pyramid.z & ~length;
       first_pyra1.pyramid.type = t8_dpyramid_tetparent_type (&last_tet1);
-      first_pyra1.pyramid.level = level_switch_pyra1 - 1;
+      first_pyra1.pyramid.level = pyra1->switch_shape_at_level - 1;
+      first_pyra1.switch_shape_at_level = -1;
       t8_dpyramid_nearest_common_ancestor (&first_pyra1, pyra2, nca);
       return;
     }
-    else if (real_level < level_switch_pyra2) {
+    else if (real_level < pyra2->switch_shape_at_level) {
 
       /* The second element switches the shape. The type is computed using 
        * assuming a pyramid-parent.pyramid.*/
       t8_dpyramid_t       first_pyra2;
-      t8_dtet_ancestor (&(pyra2->pyramid), level_switch_pyra2,
+      t8_dtet_ancestor (&(pyra2->pyramid), pyra2->switch_shape_at_level,
                         &(last_tet2.pyramid));
-      t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (level_switch_pyra2);
+      t8_dpyramid_coord_t length =
+        T8_DPYRAMID_LEN (pyra2->switch_shape_at_level);
       first_pyra2.pyramid.x = last_tet2.pyramid.x & ~length;
       first_pyra2.pyramid.y = last_tet2.pyramid.y & ~length;
       first_pyra2.pyramid.z = last_tet2.pyramid.z & ~length;
       first_pyra2.pyramid.type = t8_dpyramid_tetparent_type (&last_tet2);
-      first_pyra2.pyramid.level = level_switch_pyra2 - 1;
+      first_pyra2.pyramid.level = pyra2->switch_shape_at_level - 1;
+      first_pyra2.switch_shape_at_level = -1;
       t8_dpyramid_nearest_common_ancestor (&first_pyra2, pyra1, nca);
       return;
     }
@@ -1985,6 +2037,9 @@ t8_dpyramid_nearest_common_ancestor (const t8_dpyramid_t *pyra1,
       T8_ASSERT (p1_type_at_level == p2_type_at_level);
       T8_ASSERT (p1_type_at_level < T8_DPYRAMID_FIRST_TYPE);
       t8_dtet_ancestor (&(pyra1->pyramid), real_level, &(nca->pyramid));
+      T8_ASSERT (pyra1->switch_shape_at_level ==
+                 pyra2->switch_shape_at_level);
+      nca->switch_shape_at_level = pyra1->switch_shape_at_level;
       return;
     }
   }
@@ -2018,6 +2073,13 @@ t8_dpyramid_is_valid (const t8_dpyramid_t *p)
   if (p->pyramid.level == 0) {
     is_valid = is_valid && (p->pyramid.type == T8_DPYRAMID_ROOT_TPYE);
   }
+  if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
+    is_valid = is_valid && (p->switch_shape_at_level > 0);
+    is_valid = is_valid && (p->switch_shape_at_level <= T8_DPYRAMID_MAXLEVEL);
+  }
+  else {
+    is_valid = is_valid && (p->switch_shape_at_level < 0);
+  }
 
   return is_valid;
 }
@@ -2025,6 +2087,8 @@ t8_dpyramid_is_valid (const t8_dpyramid_t *p)
 void
 t8_dpyramid_debug_print (const t8_dpyramid_t *p)
 {
-  t8_debugf ("x: %i, y: %i, z: %i, type %i, level: %i\n", p->pyramid.x,
-             p->pyramid.y, p->pyramid.z, p->pyramid.type, p->pyramid.level);
+  t8_debugf
+    ("x: %i, y: %i, z: %i, type %i, level: %i, switches_shape_at_level: %i\n",
+     p->pyramid.x, p->pyramid.y, p->pyramid.z, p->pyramid.type,
+     p->pyramid.level, p->switch_shape_at_level);
 }

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -712,16 +712,15 @@ t8_dpyramid_face_parent_face (const t8_dpyramid_t *elem, const int face)
   }
   else {
     child_id = t8_dpyramid_child_id (elem);
-    t8_dpyramid_parent (elem, &parent);
     /*Parent is also a tet, we can call the tet-routine */
-    if (t8_dpyramid_shape (&parent) == T8_ECLASS_TET) {
+    if (elem->pyramid.level > elem->switch_shape_at_level) {
       return t8_dtet_face_parent_face (&(elem->pyramid), face);
     }
     /*tet with a pyramid-parent */
     else {
+      t8_dpyramid_type_t  parent_type = t8_dpyramid_tetparent_type (elem);
       /*Only tets of type 0 or 3 have a pyra-parent.pyramid. Parent can have type 6 or 7 */
-      if (elem->pyramid.type == 0
-          && parent.pyramid.type == T8_DPYRAMID_FIRST_TYPE) {
+      if (elem->pyramid.type == 0 && parent_type == T8_DPYRAMID_FIRST_TYPE) {
         if (child_id == 3 && face == 1) {
           return 0;
         }
@@ -732,7 +731,7 @@ t8_dpyramid_face_parent_face (const t8_dpyramid_t *elem, const int face)
           return -1;
       }
       else if (elem->pyramid.type == 3
-               && parent.pyramid.type == T8_DPYRAMID_FIRST_TYPE) {
+               && parent_type == T8_DPYRAMID_FIRST_TYPE) {
         if (child_id == 1 && face == 1) {
           return 2;
         }
@@ -743,7 +742,7 @@ t8_dpyramid_face_parent_face (const t8_dpyramid_t *elem, const int face)
           return -1;
       }
       else if (elem->pyramid.type == 0
-               && parent.pyramid.type == T8_DPYRAMID_SECOND_TYPE) {
+               && parent_type == T8_DPYRAMID_SECOND_TYPE) {
         if (child_id == 1 && face == 3) {
           return 1;
         }
@@ -754,7 +753,7 @@ t8_dpyramid_face_parent_face (const t8_dpyramid_t *elem, const int face)
           return -1;
       }
       else if (elem->pyramid.type == 3
-               && parent.pyramid.type == T8_DPYRAMID_SECOND_TYPE) {
+               && parent_type == T8_DPYRAMID_SECOND_TYPE) {
         if (child_id == 2 && face == 3) {
           return 3;
         }

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
@@ -51,6 +51,18 @@ int                 t8_dpyramid_get_level (const t8_dpyramid_t *p);
 void                t8_dpyramid_copy (const t8_dpyramid_t *source,
                                       t8_dpyramid_t *dest);
 
+/**
+ * Sets the field switch_shape_at_level for \a p. \a p has to have the shape
+ * of a tetrahedron. 
+ * switch_shape_at_level is set to the lowest level at which the ancestor of \a p
+ * still has the shape of a tetrahedron. switch_shape_at_level is undefined for an
+ * element in the shape of a pyramid and therefore this function should not be called
+ * for a pyramidal shaped element.
+ * 
+ * \param p       Input element, whose switch_shape_at_level will be set.
+ */
+void                t8_dpyramid_set_switch_shape_at_level (t8_dpyramid_t *p);
+
 /** Computes the linear position of a pyramid in an uniform grid.
  * \param [in] p          pyramid whose id will be computed.
  * \param [in] level      The level on which the linear-id should be computed.
@@ -215,7 +227,7 @@ int                 t8_dpyramid_is_inside_root (const t8_dpyramid_t *p);
 int                 t8_dpyramid_is_inside_pyra (const t8_dpyramid_t *p,
                                                 const t8_dpyramid_t *check);
 
-/** Check, if the input pyramid with shape of a tet is inside of a tetrahedron up to level \a level
+/** Check, if the input pyramid with shape of a tet with type 0 or 3 is inside of a tetrahedron up to level \a level
  * \param [in] p        pyramid with tet shape
  * \param [in] level    The lowest level to check
  * \param [in] anc      If not set to NULL the last ancestor in the shape of a tet is computed.
@@ -303,10 +315,9 @@ void                t8_dpyramid_compute_coords (const t8_dpyramid_t *p,
 
 /** Compute the pyramid-parent-type of a tetrahedron
  * \param [in] p        Input pyramid
- * \param [out] parent  The parent whose type has to be computed.
+ * \return              The type of the parent.
  */
-void                t8_dpyramid_tetparent_type (const t8_dpyramid_t *p,
-                                                t8_dpyramid_t *parent);
+int                 t8_dpyramid_tetparent_type (const t8_dpyramid_t *p);
 
 /** Compute the parent of a given pyramid
  * \param [in] p        Input pyramid.

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
@@ -51,17 +51,6 @@ int                 t8_dpyramid_get_level (const t8_dpyramid_t *p);
 void                t8_dpyramid_copy (const t8_dpyramid_t *source,
                                       t8_dpyramid_t *dest);
 
-/**
- * Sets the field switch_shape_at_level for \a p. \a p has to have the shape
- * of a tetrahedron. 
- * switch_shape_at_level is set to the lowest level at which the ancestor of \a p
- * still has the shape of a tetrahedron. switch_shape_at_level is set to -1 for
- * pyramidal shaped elements.
- * 
- * \param p       Input element, whose switch_shape_at_level will be set.
- */
-void                t8_dpyramid_set_switch_shape_at_level (t8_dpyramid_t *p);
-
 /** Computes the linear position of a pyramid in an uniform grid.
  * \param [in] p          pyramid whose id will be computed.
  * \param [in] level      The level on which the linear-id should be computed.
@@ -200,21 +189,6 @@ int                 t8_dpyramid_child_id (const t8_dpyramid_t *p);
  \returns 0 if p is inside root, 1, ow*/
 int                 t8_dpyramid_is_inside_root (const t8_dpyramid_t *p);
 
-/** Check, if a given pyramid is inside another pyramid
- * \param[in] p     Pyramid to check
- * \param[in] check The outer pyramid in which \a p might lay*/
-int                 t8_dpyramid_is_inside_pyra (const t8_dpyramid_t *p,
-                                                const t8_dpyramid_t *check);
-
-/** Check, if the input pyramid with shape of a tet with type 0 or 3 is inside of a tetrahedron up to level \a level
- * \param [in] p        pyramid with tet shape
- * \param [in] level    The lowest level to check
- * \param [in] anc      If not set to NULL the last ancestor in the shape of a tet is computed.
- * \return      0, if the pyramid is insed of a tetrahedron
- */
-int                 t8_dpyramid_is_inside_tet (const t8_dpyramid_t *p,
-                                               int level, t8_dpyramid_t *anc);
-
 /** Check, if a tet of type 0 or 3 has a common face with its pyramid-ancestor
  * \param [in] p      input pyramid
  * \param [in] face   A face of \a p.
@@ -291,12 +265,6 @@ void                t8_dpyramid_last_descendant_face (const t8_dpyramid_t *p,
 void                t8_dpyramid_compute_coords (const t8_dpyramid_t *p,
                                                 const int vertex,
                                                 int coords[]);
-
-/** Compute the pyramid-parent-type of a tetrahedron
- * \param [in] p        Input pyramid
- * \return              The type of the parent.
- */
-int                 t8_dpyramid_tetparent_type (const t8_dpyramid_t *p);
 
 /** Compute the parent of a given pyramid
  * \param [in] p        Input pyramid.

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
@@ -189,32 +189,12 @@ int                 t8_dpyramid_face_neighbor_inside (const t8_dpyramid_t *p,
                                                       const int face,
                                                       int *neigh_face);
 
-/** Compute the child_id of a pyramid with an unknown parent. Returns -1 if
- * p->level == 0.
- * \param[in] p     Input pyramid
- * \param[in, out] parent An uninitialized but allocated pyramid to compute the
- *                   parent of p
- * \return          The child-id of p */
-int                 t8_dpyramid_child_id_unknown_parent (const t8_dpyramid_t
-                                                         *p,
-                                                         t8_dpyramid_t
-                                                         *parent);
-
 /** Compute the position of the ancestor of this child at level \a level within
  * its siblings.
  * \param [in] p  pyramid to be considered.
  * \return Returns its child id in 0..9
  */
 int                 t8_dpyramid_child_id (const t8_dpyramid_t *p);
-
-/** Compute the position of the ancestor of this child at level \a level within
- * its siblings. The parent of p is known.
- * \param [in] p  pyramid to be considered.
- * \param [in] parent The parent of \a p.
- * \return Returns its child id in 0..9
- */
-int                 t8_dpyramid_child_id_known_parent (const t8_dpyramid_t *p,
-                                                       t8_dpyramid_t *parent);
 
 /** Returns zero if p is not inside root, 1 ow
  \param[in] p       Pyramid to check

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
@@ -55,9 +55,8 @@ void                t8_dpyramid_copy (const t8_dpyramid_t *source,
  * Sets the field switch_shape_at_level for \a p. \a p has to have the shape
  * of a tetrahedron. 
  * switch_shape_at_level is set to the lowest level at which the ancestor of \a p
- * still has the shape of a tetrahedron. switch_shape_at_level is undefined for an
- * element in the shape of a pyramid and therefore this function should not be called
- * for a pyramidal shaped element.
+ * still has the shape of a tetrahedron. switch_shape_at_level is set to -1 for
+ * pyramidal shaped elements.
  * 
  * \param p       Input element, whose switch_shape_at_level will be set.
  */


### PR DESCRIPTION
**_Describe your changes here:_**

This PR introduces a new field 'switch_shape_at_level' for pyramid elements.
Everytime a pyramid is constructed we set this variable. If the shape of the constructed element is a pyramid, it is set to -1. Otherwise (the shape is a tetrahedron) we set it to the level of last ancestor in the shape of a tetrahedron.
This variable is then used in every other algorithm that needs information about ancestors and speeds up the computation significantly. First tests showed a speed-up around 20% for adapt and balance algorithms, without any changes in the other high-level algorithms.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] New tests use the Google Test framework
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
