### PR TITLE
Made the parameter vertex a const-parameter for all elements.

### DIFF
--- a/src/t8_element_c_interface.cxx
+++ b/src/t8_element_c_interface.cxx
@@ -410,7 +410,7 @@ t8_element_root_len (t8_eclass_scheme_c *ts, const t8_element_t *elem)
 
 void
 t8_element_vertex_reference_coords (t8_eclass_scheme_c *ts,
-                                    const t8_element_t *t, int vertex,
+                                    const t8_element_t *t, const int vertex,
                                     double coords[])
 {
   T8_ASSERT (ts != NULL);

--- a/src/t8_element_c_interface.h
+++ b/src/t8_element_c_interface.h
@@ -615,7 +615,7 @@ int                 t8_element_root_len (t8_eclass_scheme_c *ts,
 void                t8_element_vertex_reference_coords (t8_eclass_scheme_c
                                                         *ts,
                                                         const t8_element_t *t,
-                                                        int vertex,
+                                                        const int vertex,
                                                         double coords[]);
 
 /* TODO: deactivate */

--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -579,7 +579,8 @@ public:
    *                      whose entries will be filled with the coordinates of \a vertex.
    */
   virtual void        t8_element_vertex_reference_coords (const t8_element_t
-                                                          *t, int vertex,
+                                                          *t,
+                                                          const int vertex,
                                                           double coords[]) =
     0;
 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -676,7 +676,7 @@ t8_default_scheme_hex_c::t8_element_vertex_coords (const t8_element_t *t,
 void
 t8_default_scheme_hex_c::t8_element_vertex_reference_coords (const
                                                              t8_element_t *t,
-                                                             int vertex,
+                                                             const int vertex,
                                                              double coords[])
 {
   T8_ASSERT (t8_element_is_valid (t));

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -552,7 +552,8 @@ public:
    *                      whose entries will be filled with the coordinates of \a vertex.
    */
   virtual void        t8_element_vertex_reference_coords (const t8_element_t
-                                                          *t, int vertex,
+                                                          *t,
+                                                          const int vertex,
                                                           double coords[]);
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
@@ -352,7 +352,8 @@ t8_default_scheme_line_c::t8_element_vertex_coords (const t8_element_t *t,
 void
 t8_default_scheme_line_c::t8_element_vertex_reference_coords (const
                                                               t8_element_t *t,
-                                                              int vertex,
+                                                              const int
+                                                              vertex,
                                                               double coords[])
 {
   T8_ASSERT (t8_element_is_valid (t));

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
@@ -570,7 +570,8 @@ public:
    *                      whose entries will be filled with the coordinates of \a vertex.
    */
   virtual void        t8_element_vertex_reference_coords (const t8_element_t
-                                                          *t, int vertex,
+                                                          *t,
+                                                          const int vertex,
                                                           double coords[]);
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
@@ -325,7 +325,8 @@ t8_dline_last_descendant (const t8_dline_t *l, t8_dline_t *s, int level)
 }
 
 void
-t8_dline_vertex_coords (const t8_dline_t *elem, int vertex, int coords[])
+t8_dline_vertex_coords (const t8_dline_t *elem, const int vertex,
+                        int coords[])
 {
   T8_ASSERT (vertex == 0 || vertex == 1);
   if (vertex == 0) {
@@ -337,7 +338,7 @@ t8_dline_vertex_coords (const t8_dline_t *elem, int vertex, int coords[])
 }
 
 void
-t8_dline_vertex_ref_coords (const t8_dline_t *elem, int vertex,
+t8_dline_vertex_ref_coords (const t8_dline_t *elem, const int vertex,
                             double coordinates[1])
 {
   /* we need to set and initial value to prevent compiler warning. */

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
@@ -228,7 +228,7 @@ void                t8_dline_last_descendant (const t8_dline_t *l,
  * \param [out] coords   The coordinates of the computed vertex
  */
 void                t8_dline_vertex_coords (const t8_dline_t *elem,
-                                            int vertex, int coords[]);
+                                            const int vertex, int coords[]);
 
 /** Compute the coordinates of a vertex of a line when the 
  * tree (level 0 line) is embedded in [0,1]^1.
@@ -238,7 +238,7 @@ void                t8_dline_vertex_coords (const t8_dline_t *elem,
  * 		     will be filled with the reference coordinates of the vertex.
  */
 void                t8_dline_vertex_ref_coords (const t8_dline_t *elem,
-                                                int vertex,
+                                                const int vertex,
                                                 double coordinates[1]);
 
 /** Computes the linear position of a line in an uniform grid.

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -461,7 +461,8 @@ void
 t8_default_scheme_prism_c::t8_element_vertex_reference_coords (const
                                                                t8_element_t
                                                                *elem,
-                                                               int vertex,
+                                                               const int
+                                                               vertex,
                                                                double
                                                                coords[])
 {

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
@@ -579,7 +579,8 @@ public:
    *                      whose entries will be filled with the coordinates of \a vertex.
    */
   virtual void        t8_element_vertex_reference_coords (const t8_element_t
-                                                          *t, int vertex,
+                                                          *t,
+                                                          const int vertex,
                                                           double coords[]);
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -555,7 +555,8 @@ t8_dprism_corner_descendant (const t8_dprism_t *p, t8_dprism_t *s,
 }
 
 void
-t8_dprism_vertex_coords (const t8_dprism_t *p, int vertex, int coords[3])
+t8_dprism_vertex_coords (const t8_dprism_t *p, const int vertex,
+                         int coords[3])
 {
   T8_ASSERT (vertex >= 0 && vertex < 6);
   T8_ASSERT (p->line.level == p->tri.level);
@@ -569,7 +570,7 @@ t8_dprism_vertex_coords (const t8_dprism_t *p, int vertex, int coords[3])
 }
 
 void
-t8_dprism_vertex_ref_coords (const t8_dprism_t *p, int vertex,
+t8_dprism_vertex_ref_coords (const t8_dprism_t *p, const int vertex,
                              double coords[3])
 {
   int                 coords_int[3];

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -451,7 +451,8 @@ void
 t8_default_scheme_pyramid_c::t8_element_vertex_reference_coords (const
                                                                  t8_element_t
                                                                  *elem,
-                                                                 int vertex,
+                                                                 const int
+                                                                 vertex,
                                                                  double
                                                                  coords[])
 {

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
@@ -597,7 +597,8 @@ public:
    *                      whose entries will be filled with the coordinates of \a vertex.
    */
   virtual void        t8_element_vertex_reference_coords (const t8_element_t
-                                                          *t, int vertex,
+                                                          *t,
+                                                          const int vertex,
                                                           double coords[]);
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -1602,7 +1602,7 @@ t8_dpyramid_compute_coords (const t8_dpyramid_t *p, const int vertex,
 
 void
 t8_dpyramid_vertex_reference_coords (const t8_dpyramid_t *elem,
-                                     int vertex, double coords[])
+                                     const int vertex, double coords[])
 {
   int                 coords_int[3];
   T8_ASSERT (0 <= vertex && vertex < T8_DPYRAMID_CORNERS);

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
@@ -406,7 +406,8 @@ void                t8_dpyramid_successor (const t8_dpyramid_t *elem,
  * 		     will be filled with the reference coordinates of the vertex.
  */
 void                t8_dpyramid_vertex_reference_coords (const t8_dpyramid_t
-                                                         *elem, int vertex,
+                                                         *elem,
+                                                         const int vertex,
                                                          double coords[]);
 
 /**

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -803,7 +803,8 @@ t8_default_scheme_quad_c::t8_element_vertex_coords (const t8_element_t *t,
 void
 t8_default_scheme_quad_c::t8_element_vertex_reference_coords (const
                                                               t8_element_t *t,
-                                                              int vertex,
+                                                              const int
+                                                              vertex,
                                                               double coords[])
 {
   T8_ASSERT (t8_element_is_valid (t));

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -590,7 +590,8 @@ public:
    *                      whose entries will be filled with the coordinates of \a vertex.
    */
   virtual void        t8_element_vertex_reference_coords (const t8_element_t
-                                                          *t, int vertex,
+                                                          *t,
+                                                          const int vertex,
                                                           double coords[]);
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
@@ -546,7 +546,7 @@ t8_default_scheme_tet_c::t8_element_general_function (const t8_element_t
 void
 t8_default_scheme_tet_c::t8_element_vertex_reference_coords (const
                                                              t8_element_t *t,
-                                                             int vertex,
+                                                             const int vertex,
                                                              double coords[])
 {
   T8_ASSERT (t8_element_is_valid (t));

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
@@ -544,7 +544,8 @@ public:
    *                      whose entries will be filled with the coordinates of \a vertex.
    */
   virtual void        t8_element_vertex_coords (const t8_element_t *t,
-                                                int vertex, int coords[]);
+                                                const int vertex,
+                                                int coords[]);
 
   /** The tetrahedron schemes uses the general function to return the type of
    * a tetrahedron.
@@ -565,7 +566,8 @@ public:
    *                      whose entries will be filled with the coordinates of \a vertex.
    */
   virtual void        t8_element_vertex_reference_coords (const t8_element_t
-                                                          *t, int vertex,
+                                                          *t,
+                                                          const int vertex,
                                                           double coords[]);
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
@@ -565,7 +565,7 @@ t8_default_scheme_tri_c::t8_element_general_function (const t8_element_t
 void
 t8_default_scheme_tri_c::t8_element_vertex_reference_coords (const
                                                              t8_element_t *t,
-                                                             int vertex,
+                                                             const int vertex,
                                                              double coords[])
 {
   T8_ASSERT (t8_element_is_valid (t));

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
@@ -558,7 +558,8 @@ public:
    *                      whose entries will be filled with the coordinates of \a vertex.
    */
   virtual void        t8_element_vertex_reference_coords (const t8_element_t
-                                                          *t, int vertex,
+                                                          *t,
+                                                          const int vertex,
                                                           double coords[]);
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
@@ -288,7 +288,7 @@ t8_dtri_ancestor (const t8_dtri_t *t, int level, t8_dtri_t *ancestor)
 
 /* Compute the coordinates of a given vertex of a triangle/tet */
 void
-t8_dtri_compute_coords (const t8_dtri_t *t, int vertex,
+t8_dtri_compute_coords (const t8_dtri_t *t, const int vertex,
                         t8_dtri_coord_t coordinates[T8_DTRI_DIM])
 {
   t8_dtri_type_t      type;
@@ -336,7 +336,7 @@ t8_dtri_compute_coords (const t8_dtri_t *t, int vertex,
 }
 
 void
-t8_dtri_compute_ref_coords (const t8_dtri_t *t, int vertex,
+t8_dtri_compute_ref_coords (const t8_dtri_t *t, const int vertex,
                             double coordinates[T8_DTRI_DIM])
 {
   int                 coords_int[T8_DTRI_DIM];

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
@@ -71,7 +71,8 @@ void                t8_dtri_ancestor (const t8_dtri_t *t, int level,
  * 		     will be filled with the coordinates of the vertex.
  * \param [in] vertex The number of the vertex.
  */
-void                t8_dtri_compute_coords (const t8_dtri_t *t, int vertex,
+void                t8_dtri_compute_coords (const t8_dtri_t *t,
+                                            const int vertex,
                                             t8_dtri_coord_t coordinates[2]);
 
 /** Compute the reference coordinates of a vertex of a triangle when the 
@@ -82,7 +83,7 @@ void                t8_dtri_compute_coords (const t8_dtri_t *t, int vertex,
  * 		     will be filled with the reference coordinates of the vertex.
  */
 void                t8_dtri_compute_ref_coords (const t8_dtri_t *t,
-                                                int vertex,
+                                                const int vertex,
                                                 double coordinates[2]);
 
 /** Compute the coordinates of the four vertices of a triangle.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
@@ -303,7 +303,8 @@ void
 t8_default_scheme_vertex_c::t8_element_vertex_reference_coords (const
                                                                 t8_element_t
                                                                 *elem,
-                                                                int vertex,
+                                                                const int
+                                                                vertex,
                                                                 double
                                                                 coords[])
 {

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
@@ -598,7 +598,8 @@ public:
    *                      whose entries will be filled with the coordinates of \a vertex.
    */
   virtual void        t8_element_vertex_reference_coords (const t8_element_t
-                                                          *t, int vertex,
+                                                          *t,
+                                                          const int vertex,
                                                           double coords[]);
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.c
@@ -156,7 +156,8 @@ t8_dvertex_last_descendant (const t8_dvertex_t *v, t8_dvertex_t *s, int level)
 }
 
 void
-t8_dvertex_vertex_coords (const t8_dvertex_t *elem, int vertex, int coords[])
+t8_dvertex_vertex_coords (const t8_dvertex_t *elem, const int vertex,
+                          int coords[])
 {
   T8_ASSERT (vertex == 0);
 
@@ -164,7 +165,7 @@ t8_dvertex_vertex_coords (const t8_dvertex_t *elem, int vertex, int coords[])
 }
 
 void
-t8_dvertex_vertex_ref_coords (const t8_dvertex_t *elem, int vertex,
+t8_dvertex_vertex_ref_coords (const t8_dvertex_t *elem, const int vertex,
                               double coords[])
 {
   T8_ASSERT (vertex == 0);


### PR DESCRIPTION
The parameter identifying the vertex should be a const, since it should not change during the computation. This changes it. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] New tests use the Google Test framework
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [x] Testing of this template: If you feel something is missing from this list, contact the developers
