### PR TITLE
Add a debug function that prints the trees of the cmesh

### DIFF
--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -644,7 +644,7 @@ void                t8_cmesh_print_profile (t8_cmesh_t cmesh);
 
 /** Return a pointer to the vertex coordinates of a tree.
  * \param [in]    cmesh         The cmesh.
- * \param [in]    ltreeid       The id of a loca tree.
+ * \param [in]    ltreeid       The id of a local tree.
  * \return    If stored, a pointer to the vertex coordinates of \a tree.
  *            If no coordinates for this tree are found, NULL.
  */
@@ -769,6 +769,17 @@ void                t8_cmesh_new_translate_vertices_to_attributes (t8_locidx_t
                                                                    *attr_vertices,
                                                                    int
                                                                    num_vertices);
+
+/**
+ * \warning This function is only available in debug-modus and should only 
+ * be used in debug-modus.
+ * 
+ * Prints the vertices of each tree of each process
+ * 
+ * \param[in] cmesh   Source-cmesh, which trees get printed.
+ */
+void                t8_cmesh_debug_print_trees (const t8_cmesh_t cmesh,
+                                                sc_MPI_Comm comm);
 T8_EXTERN_C_END ();
 
 #endif /* !T8_CMESH_H */

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -1610,7 +1610,6 @@ t8_cmesh_debug_print_trees (const t8_cmesh_t cmesh, sc_MPI_Comm comm)
   T8_ASSERT (t8_cmesh_is_committed (cmesh));
   if (t8_cmesh_is_partitioned (cmesh)) {
     /* The cmesh is partitioned */
-    /* Use Barrier to prevent mixed up output. */
     int                 rank;
     int                 size;
     int                 mpiret;

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -28,6 +28,7 @@
 #include <t8_refcount.h>
 #include <t8_data/t8_shmem.h>
 #include <t8_vec.h>
+#include <t8_eclass.h>
 #ifdef T8_WITH_METIS
 #include <metis.h>
 
@@ -1565,4 +1566,88 @@ t8_cmesh_coords_axb (const double *coords_in, double *coords_out,
   for (i = 0; i < num_vertices; i++) {
     t8_vec_axpyz (coords_in + i * 3, b, coords_out + i * 3, alpha);
   }
+}
+
+/**
+ * \warning This function is only available in debug-modus and should only 
+ * be used in debug-modus.
+ * 
+ * Prints the vertices of each local tree. 
+ * 
+ * \param[in] cmesh   source-cmesh, which trees get printed.
+ */
+static void
+t8_cmesh_print_local_trees (const t8_cmesh_t cmesh)
+{
+#ifdef T8_ENABLE_DEBUG
+  const t8_locidx_t   num_local_trees = t8_cmesh_get_num_local_trees (cmesh);
+  for (t8_locidx_t itree = 0; itree < num_local_trees; itree++) {
+    double             *vertices = t8_cmesh_get_tree_vertices (cmesh, itree);
+    const t8_eclass_t   tree_class = t8_cmesh_get_tree_class (cmesh, itree);
+    const int           num_vertices = t8_eclass_num_vertices[tree_class];
+    const t8_gloidx_t   gtree = t8_cmesh_get_global_id (cmesh, itree);
+    for (int ivertex = 0; ivertex < num_vertices; ivertex++) {
+      const int           vert_x = 3 * ivertex;
+      const int           vert_y = 3 * ivertex + 1;
+      const int           vert_z = 3 * ivertex + 2;
+      t8_debugf
+        ("[Global_tree: %li, local_tree: %i, vertex: %i] eclass: %s\t %f, %f, %f\n",
+         gtree, itree, ivertex, t8_eclass_to_string[tree_class],
+         vertices[vert_x], vertices[vert_y], vertices[vert_z]);
+    }
+    t8_debugf ("\n");
+  }
+#else
+  t8_global_errorf
+    ("Do not call t8_cmesh_print_local_trees if t8code is not compiled with --enable-debug.\n");
+#endif
+}
+
+void
+t8_cmesh_debug_print_trees (const t8_cmesh_t cmesh, sc_MPI_Comm comm)
+{
+#ifdef T8_ENABLE_DEBUG
+  /* This function is probably rather slow, linear in the number of processes and therefore
+   * only available if the debug-modus is enabled. */
+  T8_ASSERT (cmesh != NULL);
+  T8_ASSERT (t8_cmesh_is_committed (cmesh));
+  if (t8_cmesh_is_partitioned (cmesh)) {
+    /* The cmesh is partitioned */
+    /* Use Barrier to prevent mixed up output. */
+    int                 rank;
+    int                 size;
+    int                 mpiret;
+    mpiret = sc_MPI_Comm_rank (comm, &rank);
+    SC_CHECK_MPI (mpiret);
+    mpiret = sc_MPI_Comm_size (comm, &size);
+    SC_CHECK_MPI (mpiret);
+    const int           send_rank = (rank + 1) % size;
+    const int           recv_rank = rank - 1;
+    /* Print the local trees in process-order. */
+    if (rank != 0) {
+      int                 source_rank;
+      /* Send the rank as an additional check */
+      mpiret =
+        sc_MPI_Recv (&source_rank, 1, sc_MPI_INT, recv_rank, 0, comm,
+                     sc_MPI_STATUS_IGNORE);
+      SC_CHECK_MPI (mpiret);
+      T8_ASSERT (source_rank == (rank - 1));
+    }
+    t8_cmesh_print_local_trees (cmesh);
+    if (rank != (size - 1)) {
+      mpiret = sc_MPI_Send (&rank, 1, sc_MPI_INT, send_rank, 0, comm);
+      SC_CHECK_MPI (mpiret);
+    }
+  }
+  else {
+    /* The cmesh is not partitioned, only one rank prints the trees. */
+    if (cmesh->mpirank == 0) {
+      t8_cmesh_print_local_trees (cmesh);
+    }
+  }
+
+#else
+  t8_global_errorf
+    ("Do not call t8_cmesh_debug_print_trees if t8code is not compiled with --enable-debug.\n");
+#endif /* T8_ENABLE_DEBUG */
 }

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -1568,6 +1568,7 @@ t8_cmesh_coords_axb (const double *coords_in, double *coords_out,
   }
 }
 
+#ifdef T8_ENABLE_DEBUG
 /**
  * \warning This function is only available in debug-modus and should only 
  * be used in debug-modus.
@@ -1579,7 +1580,6 @@ t8_cmesh_coords_axb (const double *coords_in, double *coords_out,
 static void
 t8_cmesh_print_local_trees (const t8_cmesh_t cmesh)
 {
-#ifdef T8_ENABLE_DEBUG
   const t8_locidx_t   num_local_trees = t8_cmesh_get_num_local_trees (cmesh);
   for (t8_locidx_t itree = 0; itree < num_local_trees; itree++) {
     double             *vertices = t8_cmesh_get_tree_vertices (cmesh, itree);
@@ -1597,11 +1597,8 @@ t8_cmesh_print_local_trees (const t8_cmesh_t cmesh)
     }
     t8_debugf ("\n");
   }
-#else
-  t8_global_errorf
-    ("Do not call t8_cmesh_print_local_trees if t8code is not compiled with --enable-debug.\n");
-#endif
 }
+#endif
 
 void
 t8_cmesh_debug_print_trees (const t8_cmesh_t cmesh, sc_MPI_Comm comm)


### PR DESCRIPTION
This adds a function to print the vertices of each local tree of each cmesh.
If the cmesh is not partitioned, only process 0 prints the vertices of the cmesh. 
Otherwise the processes send their rank in a round-robin style, and after a process has received its message it prints the local trees and sends the next message. 

Why is this function necessary? I have a bug that mixes up the vertices and hope to find the source of the problem with this function. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] New tests use the Google Test framework
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [x] Testing of this template: If you feel something is missing from this list, contact the developers
