### PR TITLE
Revert all ubuntu versions of github action to 20.04

### DIFF
--- a/.github/workflows/add_release_documentation.yml
+++ b/.github/workflows/add_release_documentation.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   add_release_doc:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     timeout-minutes: 10
     steps:

--- a/.github/workflows/check_indentation.yml
+++ b/.github/workflows/check_indentation.yml
@@ -47,7 +47,7 @@ on:
 
 jobs:
   indent:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci_playground.yml
+++ b/.github/workflows/ci_playground.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   test_vars:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       SC_DEBUG: ../sc/build_debug
       P4EST_DEBUG: ../p4est/build_debug
@@ -73,7 +73,7 @@ jobs:
         run: echo $IF_VAR2
 
   test_cache:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: define sc var

--- a/.github/workflows/mattermost.yml
+++ b/.github/workflows/mattermost.yml
@@ -39,7 +39,7 @@ on:
   
 jobs:
   send_mm_message:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: merge
         uses: Mitigram/gh-action-mattermost@main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     timeout-minutes: 90
     steps:

--- a/.github/workflows/update_documentation.yml
+++ b/.github/workflows/update_documentation.yml
@@ -37,7 +37,7 @@ on:
 jobs:
   update_dev_doc:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
**_Describe your changes here:_**

Why? Before it was ubuntu-latest.
On December 1 github switched from Ubuntu 20.04 to 22.04.
This broke our tests, since the test script does not compile under the
new ubuntu (note that this does not mean that t8code does not run on
22.04).
Until the issue is resolved we revert manually back to 20.04.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] New tests use the Google Test framework
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
