### PR TITLE
Fix issue 352

### DIFF
--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -1774,7 +1774,7 @@ t8_cmesh_from_msh_file (const char *fileprefix, int partition,
                                                 &occ_geometry);
   if (!registered_geom_success) {
     /* Registering failed */
-    t8_debugf ("OCC is not linked. Cannot use OCC geometry.\n");
+    t8_errorf ("OCC is not linked. Cannot use OCC geometry.\n");
     t8_cmesh_destroy (&cmesh);
     return NULL;
   }

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -954,10 +954,10 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp,
         /* *INDENT-OFF* */
 
         /* Calculate the parametric geometries of the tree */
-        const t8_geometry_c *occ_geometry_base = t8_cmesh_get_tree_geometry (cmesh, tree_count);
         if (use_occ_geometry)
         {
 #if T8_WITH_OCC
+          const t8_geometry_c *occ_geometry_base = t8_cmesh_get_tree_geometry (cmesh, tree_count);
           T8_ASSERT (t8_geom_is_occ(occ_geometry_base));
           const t8_geometry_occ_c *occ_geometry = dynamic_cast<const t8_geometry_occ_c *> (occ_geometry_base);
           /* Check for right element class */

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -829,7 +829,7 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp,
       }
     }
     else {
-      for (tree_loop = 0; tree_loop < num_ele_in_block; tree_loop++) {
+      for (tree_loop = 0; tree_loop < num_ele_in_block; tree_loop++, tree_count++) {
         /* Read the next line containing tree information */
         retval = t8_cmesh_msh_read_next_line (&line, &linen, fp);
         if (retval < 0) {
@@ -1400,8 +1400,6 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp,
           SC_ABORTF ("OCC not linked");
 #endif /* T8_WITH_OCC */
         }
-        /* advance the tree counter */
-        tree_count++;
         /* *INDENT-ON* */
 
       }

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -954,11 +954,12 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp,
         /* *INDENT-OFF* */
 
         /* Calculate the parametric geometries of the tree */
-        const t8_geometry_c *occ_geometry = t8_cmesh_get_tree_geometry (cmesh, tree_count);
+        const t8_geometry_c *occ_geometry_base = t8_cmesh_get_tree_geometry (cmesh, tree_count);
         if (use_occ_geometry)
         {
 #if T8_WITH_OCC
-          T8_ASSERT (t8_geom_is_occ(occ_geometry));
+          T8_ASSERT (t8_geom_is_occ(occ_geometry_base));
+          const t8_geometry_occ_c *occ_geometry = dynamic_cast<const t8_geometry_occ_c *> (occ_geometry_base);
           /* Check for right element class */
           if (eclass != T8_ECLASS_HEX)
           {

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -1744,7 +1744,7 @@ t8_cmesh_from_msh_file (const char *fileprefix, int partition,
                                                 fileprefix);
   if (!registered_geom_success) {
     /* Registering failed */
-    t8_debugf ("Occ is not linked. Cannot use occ geometry.\n");
+    t8_debugf ("OCC is not linked. Cannot use OCC geometry.\n");
     t8_cmesh_destroy (&cmesh);
     return NULL;
   }

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -529,7 +529,7 @@ die_node:
  * If vertex_indices is not NULL, it is allocated and will store
  * for each tree the indices of its vertices.
  * They are stored as arrays of long ints. */
-int
+static int
 t8_cmesh_msh_file_2_read_eles (t8_cmesh_t cmesh, FILE *fp,
                                sc_hash_t * vertices,
                                sc_array_t **vertex_indices, int dim)

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -829,7 +829,8 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp,
       }
     }
     else {
-      for (tree_loop = 0; tree_loop < num_ele_in_block; tree_loop++, tree_count++) {
+      for (tree_loop = 0; tree_loop < num_ele_in_block;
+           tree_loop++, tree_count++) {
         /* Read the next line containing tree information */
         retval = t8_cmesh_msh_read_next_line (&line, &linen, fp);
         if (retval < 0) {

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -1839,27 +1839,9 @@ t8_cmesh_from_msh_file (const char *fileprefix, int partition,
     case 4:
       vertices =
         t8_msh_file_4_read_nodes (file, &num_vertices, &node_mempool);
-      if (use_occ_geometry) {
-#if T8_WITH_OCC
-        t8_cmesh_msh_file_4_read_eles (cmesh, file, vertices, &vertex_indices,
-                                       dim, linear_geometry, 1, occ_geometry);
-#else /* !T8_WITH_OCC */
-        fclose (file);
-        t8_debugf ("Occ is not linked. Cannot use occ geometry.\n");
-        t8_cmesh_destroy (&cmesh);
-        if (partition) {
-          /* Communicate to the other processes that reading failed. */
-          main_proc_read_successful = 0;
-          sc_MPI_Bcast (&main_proc_read_successful, 1, sc_MPI_INT, main_proc,
-                        comm);
-        }
-        return NULL;
-#endif /* T8_WITH_OCC */
-      }
-      else {
-        t8_cmesh_msh_file_4_read_eles (cmesh, file, vertices, &vertex_indices,
-                                       dim, linear_geometry, 0, NULL);
-      }
+      t8_cmesh_msh_file_4_read_eles (cmesh, file, vertices, &vertex_indices,
+                                     dim, linear_geometry, use_occ_geometry,
+                                     occ_geometry);
       break;
 
     default:

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -1740,7 +1740,7 @@ t8_cmesh_from_msh_file (const char *fileprefix, int partition,
   sc_hash_t          *vertices = NULL;
   t8_locidx_t         num_vertices;
   sc_mempool_t       *node_mempool = NULL;
-  sc_array_t         *vertex_indices;
+  sc_array_t         *vertex_indices = NULL;
   long               *indices_entry;
   char                current_file[BUFSIZ];
   FILE               *file;

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -1680,7 +1680,7 @@ T8_EXTERN_C_BEGIN ();
  * It should be called by all processes of the cmesh.
  * Returns 1 on success, 0 on OCC usage error: use_occ_geometry true, but occ not linked.
  */
-static void
+static int
 t8_cmesh_from_msh_file_register_geometries (t8_cmesh_t cmesh,
                                             const int use_occ_geometry,
                                             const int dim,
@@ -1717,12 +1717,8 @@ t8_cmesh_from_msh_file (const char *fileprefix, int partition,
   char                current_file[BUFSIZ];
   FILE               *file;
   t8_gloidx_t         num_trees, first_tree, last_tree = -1;
-  t8_geometry        *geometry = NULL;
   int                 main_proc_read_successful = 0;
   int                 msh_version;
-#if T8_WITH_OCC
-  t8_geometry_occ    *geometry_occ;
-#endif /* T8_WITH_OCC */
 
   mpiret = sc_MPI_Comm_size (comm, &mpisize);
   SC_CHECK_MPI (mpiret);
@@ -1747,7 +1743,6 @@ t8_cmesh_from_msh_file (const char *fileprefix, int partition,
                                                 fileprefix);
   if (!registered_geom_success) {
     /* Registering failed */
-    fclose (file);
     t8_debugf ("Occ is not linked. Cannot use occ geometry.\n");
     t8_cmesh_destroy (&cmesh);
     return NULL;

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -1747,8 +1747,8 @@ t8_cmesh_from_msh_file (const char *fileprefix, int partition,
   t8_gloidx_t         num_trees, first_tree, last_tree = -1;
   int                 main_proc_read_successful = 0;
   int                 msh_version;
-  const t8_geometry_c *occ_geometry;
-  const t8_geometry_c *linear_geometry;
+  const t8_geometry_c *occ_geometry = NULL;
+  const t8_geometry_c *linear_geometry = NULL;
 
   mpiret = sc_MPI_Comm_size (comm, &mpisize);
   SC_CHECK_MPI (mpiret);

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
@@ -728,7 +728,7 @@ t8_geometry_occ_destroy (t8_geometry_occ_c ** geom)
 int
 t8_geom_is_occ (const t8_geometry_c *geometry)
 {
-  /* Try to dynamic cast the geometry into linear geometry. This is only successful if
+  /* Try to dynamic cast the geometry into occ geometry. This is only successful if
    * geometry points to a t8_geometry_occ.
    * If successful, then is_occ_geom will be true.
    */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
@@ -724,6 +724,21 @@ t8_geometry_occ_destroy (t8_geometry_occ_c ** geom)
   *geom = NULL;
 }
 
+#if T8_ENABLE_DEBUG
+int
+t8_geom_is_occ (const t8_geometry_occ * geometry)
+{
+  /* Try to dynamic cast the geometry into linear geometry. This is only successful if
+   * geometry pointed to a t8_geometry_occ.
+   * If successful, then is_occ_geom will be true.
+   */
+  const int           is_occ_geom =
+    (dynamic_cast < const t8_geometry_occ * >(geometry) != NULL);
+
+  return is_occ_geom;
+}
+#endif
+
 T8_EXTERN_C_END ();
 
 #endif /* T8_WITH_OCC */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
@@ -726,7 +726,7 @@ t8_geometry_occ_destroy (t8_geometry_occ_c ** geom)
 
 #if T8_ENABLE_DEBUG
 int
-t8_geom_is_occ (const t8_geometry_occ * geometry)
+t8_geom_is_occ (const t8_geometry_c * geometry)
 {
   /* Try to dynamic cast the geometry into linear geometry. This is only successful if
    * geometry pointed to a t8_geometry_occ.

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
@@ -729,7 +729,7 @@ int
 t8_geom_is_occ (const t8_geometry_c *geometry)
 {
   /* Try to dynamic cast the geometry into linear geometry. This is only successful if
-   * geometry pointed to a t8_geometry_occ.
+   * geometry points to a t8_geometry_occ.
    * If successful, then is_occ_geom will be true.
    */
   const int           is_occ_geom =

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
@@ -726,7 +726,7 @@ t8_geometry_occ_destroy (t8_geometry_occ_c ** geom)
 
 #if T8_ENABLE_DEBUG
 int
-t8_geom_is_occ (const t8_geometry_c * geometry)
+t8_geom_is_occ (const t8_geometry_c *geometry)
 {
   /* Try to dynamic cast the geometry into linear geometry. This is only successful if
    * geometry pointed to a t8_geometry_occ.

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.h
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.h
@@ -70,7 +70,7 @@ void                t8_geometry_occ_destroy (t8_geometry_occ_c ** geom);
  * \return     True (non-zero) if and only if the geometry is of type \ref t8_geometry_occ_c.
  * \note       This function is currently only available in debug mode.
  */
-int                 t8_geom_is_occ (const t8_geometry_c * geometry);
+int                 t8_geom_is_occ (const t8_geometry_c *geometry);
 #endif
 
 T8_EXTERN_C_END ();

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.h
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.h
@@ -64,6 +64,15 @@ t8_geometry_occ_c  *t8_geometry_occ_new (int dimension,
  */
 void                t8_geometry_occ_destroy (t8_geometry_occ_c ** geom);
 
+#if T8_ENABLE_DEBUG
+/** Query whether a given geometry is \ref t8_geometry_occ_c.
+ * \param [in] geometry   A geometry.
+ * \return     True (non-zero) if and only if the geometry is of type \ref t8_geometry_occ_c.
+ * \note       This function is currently only available in debug mode.
+ */
+int                 t8_geom_is_occ (const t8_geometry_occ_c * geometry);
+#endif
+
 T8_EXTERN_C_END ();
 
 #endif /* !T8_GEOMETRY_OCC_H! */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.h
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.h
@@ -70,7 +70,7 @@ void                t8_geometry_occ_destroy (t8_geometry_occ_c ** geom);
  * \return     True (non-zero) if and only if the geometry is of type \ref t8_geometry_occ_c.
  * \note       This function is currently only available in debug mode.
  */
-int                 t8_geom_is_occ (const t8_geometry_occ_c * geometry);
+int                 t8_geom_is_occ (const t8_geometry_c * geometry);
 #endif
 
 T8_EXTERN_C_END ();


### PR DESCRIPTION
**_Describe your changes here:_**

Fixes #352
The ./t8_load_and_refine_square_w_hole example did not work in parallel since the geometries were not registered in parallel in the cmesh msh file reader.
Fixed it by registering the geometries on every rank.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [x] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] New tests use the Google Test framework
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [x] Testing of this template: If you feel something is missing from this list, contact the developers
