### PR TITLE
Fixed bug y reflection

### DIFF
--- a/doc/author_goldberg.txt
+++ b/doc/author_goldberg.txt
@@ -1,0 +1,1 @@
+I place my contributions to t8code under the FreeBSD license. Sven Goldberg (sven.goldberg@t-online.de)

--- a/example/mptrac/t8_mptrac_interpolate.cxx
+++ b/example/mptrac/t8_mptrac_interpolate.cxx
@@ -222,14 +222,9 @@ t8_mptrac_coords_to_lonlatpressure (const t8_mptrac_context_t * context,
   /* Interpolate lat coordinate */
   const int           max_lat_idx = meteo1->ny;
   T8_ASSERT (max_lat_idx >= 1);
-  /* Note that we switch max and min for latitude.
-   * We do this since meteo1->lat[0] = 90, meteo1->lat[max_lat_idx - 1] = -90 in the standard case.
-   * But, we want our interpolation to go in positive y axis, not negative.
-   * Thus, we need to switch them around.
-   */
-  t8_mptrac_interpol_helper (point[1],
-                             meteo1->lat[max_lat_idx - 1],
-                             meteo1->lat[0], lat);
+
+  t8_mptrac_interpol_helper (point[1], meteo1->lat[0],
+                             meteo1->lat[max_lat_idx - 1], lat);
 
   t8_debugf ("Interpolate (%f,%f) lon range (%f,%f) lat range (%f,%f)\n",
              point[0], point[1], meteo1->lon[0], meteo1->lon[max_lon_idx - 1],


### PR DESCRIPTION
**_Describe your changes here:_**
There was a bug within the interpolation of the y-coordinate (latitude) when using MPTRAC. The interpolation boundaries were swapped as it was assumed before the discretization was the other way round.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] New Datatypes are added to t8indent_custom_datatypes.txt
- [x] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] New tests use the Google Test framework
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [x] Testing of this template: If you feel something is missing from this list, contact the developers
