### PR TITLE
Tree indexing documentation

### DIFF
--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -596,6 +596,7 @@ t8_eclass_t         t8_cmesh_get_ghost_class (t8_cmesh_t cmesh,
  *                              If \a local_id < cmesh.num_local_trees then it is
  *                              a tree, otherwise a ghost.
  * \return                      The global id of the tree/ghost.
+ * \see https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
  */
 t8_gloidx_t         t8_cmesh_get_global_id (t8_cmesh_t cmesh,
                                             t8_locidx_t local_id);
@@ -610,6 +611,7 @@ t8_gloidx_t         t8_cmesh_get_global_id (t8_cmesh_t cmesh,
  *                              if \a global_id corresponds to a ghost trees,
  *                              or negative if \a global_id neither matches a local
  *                              nor a ghost tree.
+ * \see https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
  */
 t8_locidx_t         t8_cmesh_get_local_id (t8_cmesh_t cmesh,
                                            t8_gloidx_t global_id);

--- a/src/t8_cmesh/t8_cmesh_types.h
+++ b/src/t8_cmesh/t8_cmesh_types.h
@@ -136,8 +136,9 @@ typedef struct t8_cmesh
 
   t8_cmesh_trees_t    trees; /**< structure that holds all local trees and ghosts */
 
-  t8_gloidx_t         first_tree; /**< The global index of the first local tree
-                                       on this process. Zero if the cmesh is not partitioned. -1 if this processor is empty. */
+  t8_gloidx_t         first_tree; /**< The global index of the first local tree on this process. 
+                                       Zero if the cmesh is not partitioned. -1 if this processor is empty.
+                                       See also https://github.com/DLR-AMR/t8code/wiki/Tree-indexing */
   int8_t              first_tree_shared;/**< If partitioned true if the first tree on this process is also the last tree on the next process.
                                              Always zero if num_local_trees = 0 */
 

--- a/src/t8_forest.h
+++ b/src/t8_forest.h
@@ -439,6 +439,7 @@ t8_eclass_t         t8_forest_get_eclass (t8_forest_t forest,
  * \param [in]      gtreeid The global id of a tree.
  * \return                 The tree's local id in \a forest, if it is a local tree.
  *                         A negative number if not.
+ * \see https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
  */
 t8_locidx_t         t8_forest_get_local_id (t8_forest_t forest,
                                             t8_gloidx_t gtreeid);
@@ -450,6 +451,7 @@ t8_locidx_t         t8_forest_get_local_id (t8_forest_t forest,
  * \return  The local id of the tree in the cmesh associated with the forest.
  * \a forest must be committed before calling this function.
  * \note For forest local trees, this is the inverse function of \ref t8_forest_cmesh_ltreeid_to_ltreeid.
+ * \see https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
  */
 t8_locidx_t         t8_forest_ltreeid_to_cmesh_ltreeid (t8_forest_t forest,
                                                         t8_locidx_t ltreeid);
@@ -461,6 +463,7 @@ t8_locidx_t         t8_forest_ltreeid_to_cmesh_ltreeid (t8_forest_t forest,
  * \return  The local id of the tree in the forest. -1 if the tree is not forest local.
  * \a forest must be committed before calling this function.
  * \note For forest local trees, this is the inverse function of \ref t8_forest_ltreeid_to_cmesh_ltreeid.
+ * \see https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
  */
 t8_locidx_t         t8_forest_cmesh_ltreeid_to_ltreeid (t8_forest_t forest,
                                                         t8_locidx_t lctreeid);
@@ -681,6 +684,7 @@ t8_gloidx_t         t8_forest_get_num_global_trees (t8_forest_t forest);
  *                              specifying a local tree or ghost tree.
  * \return          The global id corresponding to the tree with local id \a ltreeid.
  * \a forest must be committed before calling this function.
+ * \see https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
  */
 t8_gloidx_t         t8_forest_global_tree_id (t8_forest_t forest,
                                               t8_locidx_t ltreeid);

--- a/src/t8_forest/t8_forest_ghost.h
+++ b/src/t8_forest/t8_forest_ghost.h
@@ -88,6 +88,7 @@ t8_element_array_t *t8_forest_ghost_get_tree_elements (t8_forest_t forest,
  *                        the ghost->ghost_trees array of the tree.
  *                        Otherwise a negative number.
  * \a forest must be committed before calling this function.
+ * \see https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
  */
 t8_locidx_t         t8_forest_ghost_get_ghost_treeid (t8_forest_t forest,
                                                       t8_gloidx_t gtreeid);
@@ -96,6 +97,13 @@ t8_locidx_t         t8_forest_ghost_get_ghost_treeid (t8_forest_t forest,
 t8_eclass_t         t8_forest_ghost_get_tree_class (t8_forest_t forest,
                                                     t8_locidx_t lghost_tree);
 
+/** Given a local ghost tree compute the global tree id of it.
+ * \param [in]  forest    The forest. Ghost layer must exist.
+ * \param [in]  lghost_tree The ghost tree id of a ghost tree.
+ * \return                The global id of the local ghost tree \a lghost_tree.
+ * \a forest must be committed before calling this function.
+ * \see https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
+ */
 t8_gloidx_t         t8_forest_ghost_get_global_treeid (t8_forest_t forest,
                                                        t8_locidx_t
                                                        lghost_tree);

--- a/src/t8_forest/t8_forest_types.h
+++ b/src/t8_forest/t8_forest_types.h
@@ -108,8 +108,12 @@ typedef struct t8_forest
   int                 mpisize;          /**< Number of MPI processes. */
   int                 mpirank;          /**< Number of this MPI process. */
 
-  t8_gloidx_t         first_local_tree;
-  t8_gloidx_t         last_local_tree;
+  t8_gloidx_t         first_local_tree; /**< The global index of the first local tree on this process. 
+                                             If first_local_tree is larger than last_local_tree then 
+                                             this processor/forest is empty.
+                                             See https://github.com/DLR-AMR/t8code/wiki/Tree-indexing */
+  t8_gloidx_t         last_local_tree;  /**< The global index of the last local tree on this process.
+                                             -1 if this processor is empty. */
   t8_gloidx_t         global_num_trees; /**< The total number of global trees */
   sc_array_t         *trees;
   t8_forest_ghost_t   ghosts;           /**< If not NULL, the ghost elements. \see t8_forest_ghost.h */


### PR DESCRIPTION
**_Describe your changes here:_**
Since questions about the variable `t8_gloidx_t  first_local_tree` came up at least twice in Mattermost, I extended the documentation a bit.
Changes to the code itself did not take place.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] New tests use the Google Test framework
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
