### PR TITLE
Fix issue 412

### DIFF
--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -272,8 +272,9 @@ public:
 
   /** Query whether a given set of elements is a family or not.
    * \param [in] fam      An array of as many elements as an element of class
-   *                      \b ts has children.
+   *                      \b ts has siblings.
    * \return              Zero if \b fam is not a family, nonzero if it is.
+   * \note level 0 elements do not form a family.
    */
   virtual int         t8_element_is_family (t8_element_t **fam) = 0;
 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -243,8 +243,9 @@ public:
 
   /** Query whether a given set of elements is a family or not.
    * \param [in] fam      An array of as many elements as an element of class
-   *                      \b ts has children.
+   *                      \b ts has siblings.
    * \return              Zero if \b fam is not a family, nonzero if it is.
+   * \note level 0 elements do not form a family.
    */
   virtual int         t8_element_is_family (t8_element_t **fam);
 

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
@@ -254,8 +254,9 @@ public:
 
   /** Query whether a given set of elements is a family or not.
    * \param [in] fam      An array of as many elements as an element of class
-   *                      \b ts has children.
+   *                      \b ts has siblings.
    * \return              Zero if \b fam is not a family, nonzero if it is.
+   * \note level 0 elements do not form a family.
    */
   virtual int         t8_element_is_family (t8_element_t **fam);
 

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
@@ -213,7 +213,7 @@ t8_dline_is_familypv (const t8_dline_t *f[])
   const int8_t        level = f[0]->level;
   t8_dline_coord_t    len = T8_DLINE_LEN (level);
 
-  /*Check the level */
+  /* Check the level */
   if (level == 0 || level != f[1]->level) {
     return 0;
   }                             /* Check the parent */
@@ -222,7 +222,7 @@ t8_dline_is_familypv (const t8_dline_t *f[])
     return 0;
   }
 
-  /*Check the coordinate */
+  /* Check the coordinate */
   return (f[0]->x + len == f[1]->x);
 }
 

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
@@ -211,8 +211,6 @@ int
 t8_dline_is_familypv (const t8_dline_t *f[])
 {
   const int8_t        level = f[0]->level;
-  t8_dline_coord_t    len = T8_DLINE_LEN (level);
-
   /* Check the level */
   if (level == 0 || level != f[1]->level) {
     return 0;
@@ -222,6 +220,7 @@ t8_dline_is_familypv (const t8_dline_t *f[])
     return 0;
   }
 
+  const t8_dline_coord_t len = T8_DLINE_LEN (level);
   /* Check the coordinate */
   return (f[0]->x + len == f[1]->x);
 }

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
@@ -251,8 +251,9 @@ public:
 
   /** Query whether a given set of elements is a family or not.
    * \param [in] fam      An array of as many elements as an element of class
-   *                      \b ts has children.
+   *                      \b ts has siblings.
    * \return              Zero if \b fam is not a family, nonzero if it is.
+   * \note level 0 elements do not form a family.
    */
   virtual int         t8_element_is_family (t8_element_t **fam);
 

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -129,12 +129,11 @@ t8_dprism_child_id (const t8_dprism_t *p)
 int
 t8_dprism_is_familypv (t8_dprism_t **fam)
 {
-  int                 i, j;
   t8_dtri_t         **tri_fam = T8_ALLOC (t8_dtri_t *, T8_DTRI_CHILDREN);
   t8_dline_t        **line_fam = T8_ALLOC (t8_dline_t *, T8_DLINE_CHILDREN);
 
-  for (i = 0; i < T8_DLINE_CHILDREN; i++) {
-    for (j = 0; j < T8_DTRI_CHILDREN; j++) {
+  for (int i = 0; i < T8_DLINE_CHILDREN; i++) {
+    for (int j = 0; j < T8_DTRI_CHILDREN; j++) {
       tri_fam[j] = &fam[j + i * T8_DTRI_CHILDREN]->tri;
     }
     if (!t8_dtri_is_familypv ((const t8_dtri_t **) tri_fam)) {
@@ -144,8 +143,8 @@ t8_dprism_is_familypv (t8_dprism_t **fam)
     }
   }
 
-  for (i = 0; i < T8_DTRI_CHILDREN; i++) {
-    for (j = 0; j < T8_DLINE_CHILDREN; j++) {
+  for (int i = 0; i < T8_DTRI_CHILDREN; i++) {
+    for (int j = 0; j < T8_DLINE_CHILDREN; j++) {
       line_fam[j] = &fam[j * T8_DTRI_CHILDREN + i]->line;
     }
     /* Proof for line_family and equality of triangles in both planes */
@@ -160,7 +159,7 @@ t8_dprism_is_familypv (t8_dprism_t **fam)
     }
   }
 
-  for (i = 0; i < T8_DPRISM_CHILDREN; i++) {
+  for (int i = 0; i < T8_DPRISM_CHILDREN; i++) {
     if (fam[i]->line.level != fam[i]->tri.level) {
       T8_FREE (tri_fam);
       T8_FREE (line_fam);

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -148,7 +148,7 @@ t8_dprism_is_familypv (t8_dprism_t **fam)
     for (j = 0; j < T8_DLINE_CHILDREN; j++) {
       line_fam[j] = &fam[j * T8_DTRI_CHILDREN + i]->line;
     }
-    /*Proof for line_family and equality of triangles in both planes */
+    /* Proof for line_family and equality of triangles in both planes */
     if (!(t8_dline_is_familypv ((const t8_dline_t **) line_fam)
           && (fam[i]->tri.level == fam[i + T8_DTRI_CHILDREN]->tri.level)
           && (fam[i]->tri.type == fam[i + T8_DTRI_CHILDREN]->tri.type)

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
@@ -263,8 +263,9 @@ public:
 
   /** Query whether a given set of elements is a family or not.
    * \param [in] fam      An array of as many elements as an element of class
-   *                      \b ts has children.
+   *                      \b ts has siblings.
    * \return              Zero if \b fam is not a family, nonzero if it is.
+   * \note level 0 elements do not form a family.
    */
   virtual int         t8_element_is_family (t8_element_t **fam);
 

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -303,17 +303,14 @@ t8_dpyramid_ancestor_id (const t8_dpyramid_t *p, const int level)
 int
 t8_dpyramid_is_family (t8_dpyramid_t **fam)
 {
-
   const int           level = fam[0]->pyramid.level;
-  t8_dpyramid_coord_t inc = T8_DPYRAMID_LEN (level), x_inc, y_inc;
   if (t8_dpyramid_shape (fam[0]) == T8_ECLASS_TET) {
-    int                 is_family;
     t8_dtet_t         **tet_fam = T8_ALLOC (t8_dtet_t *, T8_DTET_CHILDREN);
     for (int i = 0; i < T8_DTET_CHILDREN; i++) {
       tet_fam[i] = &fam[i]->pyramid;
     }
-
-    is_family = t8_dtet_is_familypv ((const t8_dtet_t **) tet_fam);
+    const int           is_family =
+      t8_dtet_is_familypv ((const t8_dtet_t **) tet_fam);
     T8_FREE (tet_fam);
     return is_family;
   }
@@ -337,6 +334,7 @@ t8_dpyramid_is_family (t8_dpyramid_t **fam)
       }
     }
 
+    t8_dpyramid_coord_t inc = T8_DPYRAMID_LEN (level), x_inc, y_inc;
     x_inc = fam[0]->pyramid.x + inc;
     y_inc = fam[0]->pyramid.y + inc;
     /* Check the coordinates of the anchor-coordinate */

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -321,16 +321,16 @@ t8_dpyramid_is_family (t8_dpyramid_t **fam)
     if (level == 0) {
       return 0;
     }
-    /*The type of parent is the type of the first child in z-curve-order */
+    /* The type of parent is the type of the first child in z-curve-order */
     const int           type_of_first = fam[0]->pyramid.type;
     T8_ASSERT (type_of_first == T8_DPYRAMID_FIRST_TYPE
                || type_of_first == T8_DPYRAMID_SECOND_TYPE);
     for (int i = 1; i < T8_DPYRAMID_CHILDREN; i++) {
-      /*All elements must have the same level to be a family */
+      /* All elements must have the same level to be a family */
       if (fam[i]->pyramid.level != level) {
         return 0;
       }
-      /*Check if every family-member has the correct type */
+      /* Check if every family-member has the correct type */
       if (t8_dpyramid_parenttype_Iloc_to_type[type_of_first][i] !=
           fam[i]->pyramid.type) {
         return 0;
@@ -339,7 +339,7 @@ t8_dpyramid_is_family (t8_dpyramid_t **fam)
 
     x_inc = fam[0]->pyramid.x + inc;
     y_inc = fam[0]->pyramid.y + inc;
-    /*Check the coordinates of the anchor-coordinate */
+    /* Check the coordinates of the anchor-coordinate */
     if (type_of_first == T8_DPYRAMID_FIRST_TYPE) {
       return fam[0]->pyramid.z == fam[1]->pyramid.z
         && fam[0]->pyramid.z == fam[2]->pyramid.z

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -281,8 +281,9 @@ public:
 
   /** Query whether a given set of elements is a family or not.
    * \param [in] fam      An array of as many elements as an element of class
-   *                      \b ts has children.
+   *                      \b ts has siblings.
    * \return              Zero if \b fam is not a family, nonzero if it is.
+   * \note level 0 elements do not form a family.
    */
   virtual int         t8_element_is_family (t8_element_t **fam);
 

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
@@ -242,8 +242,9 @@ public:
 
   /** Query whether a given set of elements is a family or not.
    * \param [in] fam      An array of as many elements as an element of class
-   *                      \b ts has children.
+   *                      \b ts has siblings.
    * \return              Zero if \b fam is not a family, nonzero if it is.
+   * \note level 0 elements do not form a family.
    */
   virtual int         t8_element_is_family (t8_element_t **fam);
 

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.c
@@ -27,13 +27,6 @@ int
 t8_dtet_is_familypv (const t8_dtri_t *f[])
 {
   const int8_t        level = f[0]->level;
-  t8_dtet_coord_t     coords0[T8_DTET_CHILDREN];
-  t8_dtet_coord_t     coords1[T8_DTET_CHILDREN];
-  t8_dtet_coord_t     coords2[T8_DTET_CHILDREN];
-  t8_dtet_coord_t     inc;
-  int                 local_ind, type;
-  int                 dir1, dir2, dir3;
-
   if (level == 0 || level != f[1]->level ||
       level != f[2]->level || level != f[3]->level
       || level != f[4]->level || level != f[5]->level ||
@@ -41,8 +34,8 @@ t8_dtet_is_familypv (const t8_dtri_t *f[])
     return 0;
   }
   /* check whether the types are correct */
-  type = f[0]->type;
-  for (local_ind = 1; local_ind < T8_DTET_CHILDREN - 1; local_ind++) {
+  const int           type = f[0]->type;
+  for (int local_ind = 1; local_ind < T8_DTET_CHILDREN - 1; local_ind++) {
     if (f[local_ind]->type != t8_dtet_type_of_child_morton[type][local_ind]) {
       return 0;
     }
@@ -62,10 +55,13 @@ t8_dtet_is_familypv (const t8_dtri_t *f[])
    *   plus the element length.
    * - The coordinate dir3 of tet 7 is coordinate dir3 of tet 0
    */
-  dir1 = type / 2;
-  dir2 = 2 - type % 3;
-  dir3 = ((type + 3) % 6) / 2;
-  inc = T8_DTET_LEN (level);
+  const int           dir1 = type / 2;
+  const int           dir2 = 2 - type % 3;
+  const int           dir3 = ((type + 3) % 6) / 2;
+  const t8_dtet_coord_t inc = T8_DTET_LEN (level);
+  t8_dtet_coord_t     coords0[T8_DTET_CHILDREN];
+  t8_dtet_coord_t     coords1[T8_DTET_CHILDREN];
+  t8_dtet_coord_t     coords2[T8_DTET_CHILDREN];
   coords0[0] = f[0]->x;
   coords0[1] = f[0]->y;
   coords0[2] = f[0]->z;

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
@@ -238,8 +238,9 @@ public:
 
   /** Query whether a given set of elements is a family or not.
    * \param [in] fam      An array of as many elements as an element of class
-   *                      \b ts has children.
+   *                      \b ts has siblings.
    * \return              Zero if \b fam is not a family, nonzero if it is.
+   * \note level 0 elements do not form a family.
    */
   virtual int         t8_element_is_family (t8_element_t **fam);
 

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
@@ -520,18 +520,12 @@ int
 t8_dtri_is_familypv (const t8_dtri_t *f[])
 {
   const int8_t        level = f[0]->level;
-  t8_dtri_coord_t     coords0[T8_DTRI_CHILDREN];
-  t8_dtri_coord_t     coords1[T8_DTRI_CHILDREN];
-  t8_dtri_coord_t     inc;
-  int                 type;
-  int                 dir1;
-
   if (level == 0 || level != f[1]->level ||
       level != f[2]->level || level != f[3]->level) {
     return 0;
   }
   /* check whether the types are correct */
-  type = f[0]->type;
+  const int           type = f[0]->type;
   if (f[1]->type != 0 && f[2]->type != 1 && f[3]->type != type) {
     return 0;
   }
@@ -540,8 +534,10 @@ t8_dtri_is_familypv (const t8_dtri_t *f[])
   if (f[1]->x != f[2]->x || f[1]->y != f[2]->y) {
     return 0;
   }
-  dir1 = type;
-  inc = T8_DTRI_LEN (level);
+  const int           dir1 = type;
+  const t8_dtri_coord_t inc = T8_DTRI_LEN (level);
+  t8_dtri_coord_t     coords0[T8_DTRI_CHILDREN];
+  t8_dtri_coord_t     coords1[T8_DTRI_CHILDREN];
   coords0[0] = f[0]->x;
   coords0[1] = f[0]->y;
   coords1[0] = f[1]->x;

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
@@ -241,8 +241,9 @@ public:
 
   /** Query whether a given set of elements is a family or not.
    * \param [in] fam      An array of as many elements as an element of class
-   *                      \b ts has children.
+   *                      \b ts has siblings.
    * \return              Zero if \b fam is not a family, nonzero if it is.
+   * \note level 0 elements do not form a family.
    */
   virtual int         t8_element_is_family (t8_element_t **fam);
 

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.c
@@ -103,8 +103,8 @@ t8_dvertex_childrenpv (const t8_dvertex_t *v,
 int
 t8_dvertex_is_familypv (const t8_dvertex_t *f[])
 {
-  /* A vertex is always a family */
-  return 1;
+  /* A vertex with level greater 0 is always a family */
+  return f[0]->level > 0;
 }
 
 int


### PR DESCRIPTION
**_Describe your changes here:_**
Fixed issue #412 
Every ```t8_element_is_family (fam)``` check returns 0 if the input has a level 0 element.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] New tests use the Google Test framework
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
