### PR TITLE
Reworked arguments of naca tutorial

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,7 @@ AC_CONFIG_LINKS([test/testfiles/test_msh_file_vers2_bin.msh:test/testfiles/test_
 AC_CONFIG_LINKS([test/testfiles/test_msh_file_vers4_ascii.msh:test/testfiles/test_msh_file_vers4_ascii.msh])
 AC_CONFIG_LINKS([test/testfiles/test_msh_file_vers4_bin.msh:test/testfiles/test_msh_file_vers4_bin.msh])
 AC_CONFIG_LINKS([example/IO/cmesh/gmsh/circlesquare_hybrid_hole.msh:example/IO/cmesh/gmsh/circlesquare_hybrid_hole.msh])
-AC_CONFIG_LINKS([tutorials/features/t8_features_curved_meshes_generate_cmesh.geo:tutorials/features/t8_features_curved_meshes_generate_cmesh.geo])
+AC_CONFIG_FILES([tutorials/features/t8_features_curved_meshes_generate_cmesh.geo:tutorials/features/t8_features_curved_meshes_generate_cmesh.geo])
 
 # Print summary.
 

--- a/tutorials/features/t8_features_curved_meshes.cxx
+++ b/tutorials/features/t8_features_curved_meshes.cxx
@@ -384,7 +384,8 @@ main (int argc, char **argv)
                          "Maximum distance an element can have from the plane to still be refined. Default: 0.1");
   sc_options_add_int (opt, 't', "timesteps", &steps, 10,
                       "How many steps the plane takes to move through the airfoil. Default: 10");
-  sc_options_add_switch (opt, 'o', "occ", &occ, "Use the occ geometry.");
+  sc_options_add_switch (opt, 'o', "occ", &occ, "Use the occ geometry. "
+                         "In the surface mode this is enabled automatically.");
   parsed =
     sc_options_parse (t8_get_package_id (), SC_LP_ERROR, opt, argc, argv);
   if (helpme) {

--- a/tutorials/features/t8_features_curved_meshes.cxx
+++ b/tutorials/features/t8_features_curved_meshes.cxx
@@ -331,7 +331,10 @@ main (int argc, char **argv)
 
   /* brief help message */
   snprintf (usage, BUFSIZ, "\t%s <OPTIONS>\n\t%s -h\t"
-            "for a brief overview of all options.",
+            "for a brief overview of all options. \n"
+            "\t%s -p\tfor a refinement plane moving through the mesh. \n"
+            "\t%s -s\tfor a refinement of elements touching certain surfaces.\n",
+            basename (argv[0]), basename (argv[0]),
             basename (argv[0]), basename (argv[0]));
 
   /* long help message */
@@ -339,6 +342,7 @@ main (int argc, char **argv)
                       "Demonstrates the some of the geometry capabitlities of t8code.\n"
                       "You can read in a msh and brep file of a naca profile and refine elements touching certain surfaces, \n"
                       "or advance a refinement plane through that NACA profile mesh.\n"
+                      "The brep and msh have to be generated with the gmsh software, using the .geo file in this directory.\n"
                       "Usage: %s\n", usage);
 
   if (sreturn >= BUFSIZ) {
@@ -365,11 +369,12 @@ main (int argc, char **argv)
   opt = sc_options_new (argv[0]);
   sc_options_add_switch (opt, 'h', "help", &helpme,
                          "Display a short help message.");
-  sc_options_add_string (opt, 'f', "fileprefix", &fileprefix, NULL,
-                         "Fileprefix of the msh and brep files.");
+  sc_options_add_string (opt, 'f', "fileprefix", &fileprefix, "./naca6412",
+                         "Fileprefix of the msh and brep files. Default: \"./naca6412\"");
   sc_options_add_switch (opt, 's', "surface", &surface,
                          "Refine the forest based on the surfaces the elements lie on. "
-                         "Only viable with curved meshes. Therefore the -o option is enabled automatically. Cannot be combined with '-p'.");
+                         "Only viable with curved meshes. Therefore, the -o option is enabled automatically. "
+                         "Cannot be combined with '-p'.");
   sc_options_add_int (opt, 'l', "level", &level, 0,
                       "The uniform refinement level of the mesh. Default: 0");
   sc_options_add_int (opt, 'd', "dorsal", &rlevel_dorsal, 3,
@@ -377,7 +382,8 @@ main (int argc, char **argv)
   sc_options_add_int (opt, 'v', "ventral", &rlevel_ventral, 2,
                       "The refinement level of the ventral side of the naca profile. Default: 2");
   sc_options_add_switch (opt, 'p', "plane", &plane,
-                         "Move a plane through the forest and refine elements close to the plane. Cannot be combined with '-s'.");
+                         "Move a plane through the forest and refine elements close to the plane. "
+                         "Cannot be combined with '-s'.");
   sc_options_add_int (opt, 'r', "plane_level", &rlevel, 3,
                       "The refinement level of the plane. Default: 3");
   sc_options_add_double (opt, 'x', "distance", &dist, 0.1,
@@ -396,7 +402,13 @@ main (int argc, char **argv)
   else if (parsed == 0 || fileprefix == NULL ||
            (!plane && !surface) || (plane && surface)) {
     /* wrong usage */
-    t8_global_productionf ("\n\tERROR: Wrong usage.\n\n");
+    if (!plane && !surface) {
+      t8_global_productionf ("%s\n", help);
+      t8_global_productionf
+        ("\n\tERROR: Wrong usage.\n"
+         "\tPlease specify either the '-p' or the '-s' option as described above.\n\n");
+    }
+    else t8_global_productionf ("\n\tERROR: Wrong usage.\n\n");
     sc_options_print_usage (t8_get_package_id (), SC_LP_ERROR, opt, NULL);
   }
   else {

--- a/tutorials/features/t8_features_curved_meshes.cxx
+++ b/tutorials/features/t8_features_curved_meshes.cxx
@@ -369,7 +369,7 @@ main (int argc, char **argv)
                          "Fileprefix of the msh and brep files.");
   sc_options_add_switch (opt, 's', "surface", &surface,
                          "Refine the forest based on the surfaces the elements lie on. "
-                         "Only viable with curved meshes. Therefore the -o option is enabled automatically.");
+                         "Only viable with curved meshes. Therefore the -o option is enabled automatically. Cannot be combined with '-p'.");
   sc_options_add_int (opt, 'l', "level", &level, 0,
                       "The uniform refinement level of the mesh. Default: 0");
   sc_options_add_int (opt, 'd', "dorsal", &rlevel_dorsal, 3,
@@ -377,7 +377,7 @@ main (int argc, char **argv)
   sc_options_add_int (opt, 'v', "ventral", &rlevel_ventral, 2,
                       "The refinement level of the ventral side of the naca profile. Default: 2");
   sc_options_add_switch (opt, 'p', "plane", &plane,
-                         "Move a plane through the forest and refine elements close to the plane.");
+                         "Move a plane through the forest and refine elements close to the plane. Cannot be combined with '-s'.");
   sc_options_add_int (opt, 'r', "plane_level", &rlevel, 3,
                       "The refinement level of the plane. Default: 3");
   sc_options_add_double (opt, 'x', "distance", &dist, 0.1,


### PR DESCRIPTION
**_Describe your changes here:_**
The arguments of the NACA tutorial were quite confusing. I fixed that. The [wiki article](https://github.com/DLR-AMR/t8code/wiki/Feature---Curved-meshes) will also be updated in s short time.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [x] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] New Datatypes are added to t8indent_custom_datatypes.txt
- [x] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] New tests use the Google Test framework
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.
