### PR TITLE
Clearify, which corner defines the face-orientation

### DIFF
--- a/src/t8_cmesh/t8_cmesh_types.h
+++ b/src/t8_cmesh/t8_cmesh_types.h
@@ -186,16 +186,16 @@ t8_cghost_struct_t;
  * ttf % F is the face number and ttf / F is the orientation. (\ref t8_eclass_max_num_faces)
  * The orientation is determined as follows.  Let my_face and other_face
  * be the two face numbers of the connecting trees.
- * We chose a master_face from them as follows: Either both trees have the same
- * element class, then the face with the lower face number is the master_face or
+ * We chose a main_face from them as follows: Either both trees have the same
+ * element class, then the face with the lower face number is the main_face or
  * the trees belong to different classes in which case the face belonging to the
  * tree with the lower class according to the ordering
  * triangle < square,
  * hex < tet < prism < pyramid,
- * is the master_face.
- * Then the first face corner of the master_face connects to a face
+ * is the main_face.
+ * Then the first face corner of the main_face connects to a face
  * corner in the other face.  The face
- * orientation is defined as the number of this corner.
+ * orientation is defined as the number of the corner of the other face.
  * If the classes are equal and my_face == other_face, treating
  * either of both faces as the master_face leads to the same result.
  */


### PR DESCRIPTION
The documentation was a little ambiguous there. Please double check, that I updated the documentation correct. See https://arxiv.org/pdf/1611.02929.pdf page 5 for the correct definition of the orientation



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] New tests use the Google Test framework
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.
