### PR TITLE
remove outdated TODO comment

### DIFF
--- a/src/t8_cmesh/t8_cmesh_commit.c
+++ b/src/t8_cmesh/t8_cmesh_commit.c
@@ -257,9 +257,6 @@ t8_cmesh_commit_partitioned_new (t8_cmesh_t cmesh, sc_MPI_Comm comm)
 
   num_hashs = cmesh->num_local_trees > 0 ? cmesh->num_local_trees : 10;
   ghost_facejoin_mempool = sc_mempool_new (sizeof (t8_ghost_facejoin_t));
-  /* TODO: There could be a mayor bug here, since the mempool given to
-   * sc_hash_new should actually allocate sc_link_t objects and not the
-   * data objects. */
   ghost_ids = sc_hash_new (t8_ghost_hash, t8_ghost_facejoin_equal,
                            &num_hashs, NULL);
 


### PR DESCRIPTION
**_Describe your changes here:_**
Remove outdated comment.
The ghost_facejoin_mempool is not actually given to sc_hash_new, it is used for other purposes. sc_hash_new gets a NULL pointer, so it allocates its own mempool


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] New Datatypes are added to t8indent_custom_datatypes.txt
- [x] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] New tests use the Google Test framework
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.
