### PR TITLE
Replace non-standard u_int64_t by t8_linearidx_t

### DIFF
--- a/doc/author_schlottke-lakemper.txt
+++ b/doc/author_schlottke-lakemper.txt
@@ -1,0 +1,1 @@
+I hereby place my contributions to t8code under the FreeBSD license. Michael Schlottke-Lakemper <m.schlottke-lakemper@acom.rwth-aachen.de>

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -386,7 +386,7 @@ t8_default_scheme_prism_c::t8_element_set_linear_id (t8_element_t *elem,
                                                      int level, uint64_t id)
 {
   T8_ASSERT (0 <= level && level <= T8_DPRISM_MAXLEVEL);
-  T8_ASSERT (0 <= id && id < ((uint64_t) 1) << 3 * level);
+  T8_ASSERT (0 <= id && id < ((t8_linearidx_t) 1) << 3 * level);
 
   t8_dprism_init_linear_id ((t8_default_prism_t *) elem, level, id);
 
@@ -483,7 +483,7 @@ t8_default_scheme_prism_c::t8_element_general_function (const t8_element_t
   T8_ASSERT (*((int8_t *) outdata) == ((const t8_dprism_t *) elem)->tri.type);
 }
 
-uint64_t
+t8_linearidx_t
   t8_default_scheme_prism_c::t8_element_get_linear_id (const t8_element_t
                                                        *elem, int level)
 {

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -386,7 +386,7 @@ t8_default_scheme_prism_c::t8_element_set_linear_id (t8_element_t *elem,
                                                      int level, uint64_t id)
 {
   T8_ASSERT (0 <= level && level <= T8_DPRISM_MAXLEVEL);
-  T8_ASSERT (0 <= id && id < ((u_int64_t) 1) << 3 * level);
+  T8_ASSERT (0 <= id && id < ((uint64_t) 1) << 3 * level);
 
   t8_dprism_init_linear_id ((t8_default_prism_t *) elem, level, id);
 
@@ -483,7 +483,7 @@ t8_default_scheme_prism_c::t8_element_general_function (const t8_element_t
   T8_ASSERT (*((int8_t *) outdata) == ((const t8_dprism_t *) elem)->tri.type);
 }
 
-u_int64_t
+uint64_t
   t8_default_scheme_prism_c::t8_element_get_linear_id (const t8_element_t
                                                        *elem, int level)
 {

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -53,7 +53,7 @@ int
 t8_dprism_compare (const t8_dprism_t *p1, const t8_dprism_t *p2)
 {
   int                 maxlvl;
-  uint64_t            id1, id2;
+  t8_linearidx_t            id1, id2;
   T8_ASSERT (p1->line.level == p1->tri.level);
   T8_ASSERT (p2->line.level == p2->tri.level);
 

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -53,7 +53,7 @@ int
 t8_dprism_compare (const t8_dprism_t *p1, const t8_dprism_t *p2)
 {
   int                 maxlvl;
-  u_int64_t           id1, id2;
+  uint64_t            id1, id2;
   T8_ASSERT (p1->line.level == p1->tri.level);
   T8_ASSERT (p2->line.level == p2->tri.level);
 

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -53,7 +53,7 @@ int
 t8_dprism_compare (const t8_dprism_t *p1, const t8_dprism_t *p2)
 {
   int                 maxlvl;
-  t8_linearidx_t            id1, id2;
+  t8_linearidx_t      id1, id2;
   T8_ASSERT (p1->line.level == p1->tri.level);
   T8_ASSERT (p2->line.level == p2->tri.level);
 

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.c
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.c
@@ -59,7 +59,7 @@ static int
 t8_default_tet_compare (const t8_element_t *elem1, const t8_element_t *elem2)
 {
   int                 maxlvl;
-  u_int64_t           id1, id2;
+  uint64_t            id1, id2;
 
   /* Compute the bigger level of the two */
   maxlvl = SC_MAX (t8_default_tet_level (elem1),

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.c
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.c
@@ -59,7 +59,7 @@ static int
 t8_default_tet_compare (const t8_element_t *elem1, const t8_element_t *elem2)
 {
   int                 maxlvl;
-  t8_linearidx_t            id1, id2;
+  t8_linearidx_t      id1, id2;
 
   /* Compute the bigger level of the two */
   maxlvl = SC_MAX (t8_default_tet_level (elem1),

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.c
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.c
@@ -59,7 +59,7 @@ static int
 t8_default_tet_compare (const t8_element_t *elem1, const t8_element_t *elem2)
 {
   int                 maxlvl;
-  uint64_t            id1, id2;
+  t8_linearidx_t            id1, id2;
 
   /* Compute the bigger level of the two */
   maxlvl = SC_MAX (t8_default_tet_level (elem1),


### PR DESCRIPTION
**_Describe your changes here:_**
In some locations (to be exact: 4), the non-standard type `u_int64_t` was used, which prevents compiling t8code on some platforms (e.g., Linux with musl instead of glibc). This PR fixes this by using the standardized type `uint64_t`.

cc @jmark


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [x] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] New tests use the Google Test framework
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.
