### PR TITLE
Replace all uint64_t by t8_linearidx_t for the default-schemes

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -383,7 +383,8 @@ t8_default_scheme_prism_c::t8_element_face_neighbor_inside (const t8_element_t
 
 void
 t8_default_scheme_prism_c::t8_element_set_linear_id (t8_element_t *elem,
-                                                     int level, uint64_t id)
+                                                     int level,
+                                                     t8_linearidx_t id)
 {
   T8_ASSERT (0 <= level && level <= T8_DPRISM_MAXLEVEL);
   T8_ASSERT (0 <= id && id < ((u_int64_t) 1) << 3 * level);

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -53,7 +53,7 @@ int
 t8_dprism_compare (const t8_dprism_t *p1, const t8_dprism_t *p2)
 {
   int                 maxlvl;
-  u_int64_t           id1, id2;
+  t8_linearidx_t      id1, id2;
   T8_ASSERT (p1->line.level == p1->tri.level);
   T8_ASSERT (p2->line.level == p2->tri.level);
 
@@ -72,10 +72,10 @@ t8_dprism_compare (const t8_dprism_t *p1, const t8_dprism_t *p2)
 }
 
 void
-t8_dprism_init_linear_id (t8_dprism_t *p, int level, uint64_t id)
+t8_dprism_init_linear_id (t8_dprism_t *p, int level, t8_linearidx_t id)
 {
-  uint64_t            tri_id = 0;
-  uint64_t            line_id = 0;
+  t8_linearidx_t      tri_id = 0;
+  t8_linearidx_t      line_id = 0;
   int                 i;
   int                 triangles_of_size_i = 1;
 
@@ -512,7 +512,7 @@ t8_dprism_first_descendant (const t8_dprism_t *p, t8_dprism_t *s, int level)
   t8_dline_first_descendant (&p->line, &s->line, level);
 #ifdef T8_ENABLE_DEBUG
   {
-    uint64_t            id;
+    t8_linearidx_t      id;
     id = t8_dprism_linear_id (p, level);
     T8_ASSERT (t8_dprism_linear_id (s, level) == id);
   }
@@ -580,18 +580,18 @@ t8_dprism_vertex_ref_coords (const t8_dprism_t *p, const int vertex,
   coords[2] = coords_int[2] / (double) T8_DPRISM_ROOT_LEN;
 }
 
-uint64_t
+t8_linearidx_t
 t8_dprism_linear_id (const t8_dprism_t *p, int level)
 {
-  uint64_t            id = 0;
-  uint64_t            tri_id;
-  uint64_t            line_id;
+  t8_linearidx_t      id = 0;
+  t8_linearidx_t      tri_id;
+  t8_linearidx_t      line_id;
   int                 i;
-  uint64_t            prisms_of_size_i = 1;
+  t8_linearidx_t      prisms_of_size_i = 1;
   /*line_level = Num_of_Line_children ^ (level - 1) */
-  uint64_t            line_level;
+  t8_linearidx_t      line_level;
   /*prism_shift = Num_of_Prism_children / Num_of_line-Children * 8 ^ (level - 1) */
-  uint64_t            prism_shift;
+  t8_linearidx_t      prism_shift;
   T8_ASSERT (0 <= level && level <= T8_DPRISM_MAXLEVEL);
   T8_ASSERT (p->line.level == p->tri.level);
   /*id = 0 for root element */
@@ -621,7 +621,7 @@ t8_dprism_linear_id (const t8_dprism_t *p, int level)
     /*The number to add to the id computed via the tri_id is 4*8^(level-i)
      *for each plane in a prism of size i*/
     id += line_id / line_level * prism_shift;
-    line_id = (uint64_t) (line_id % line_level);
+    line_id = (t8_linearidx_t) (line_id % line_level);
     prism_shift /= T8_DPRISM_CHILDREN;
     line_level /= T8_DLINE_CHILDREN;
   }

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -588,8 +588,8 @@ t8_dprism_linear_id (const t8_dprism_t *p, int level)
   t8_linearidx_t      line_id;
   int                 i;
   t8_linearidx_t      prisms_of_size_i = 1;
-  /*line_level = Num_of_Line_children ^ (level - 1) */
-  t8_linearidx_t      line_level;
+  /*lines_at_level = Num_of_Line_children ^ (level - 1) */
+  t8_linearidx_t      lines_at_level;
   /*prism_shift = Num_of_Prism_children / Num_of_line-Children * 8 ^ (level - 1) */
   t8_linearidx_t      prism_shift;
   T8_ASSERT (0 <= level && level <= T8_DPRISM_MAXLEVEL);
@@ -599,7 +599,7 @@ t8_dprism_linear_id (const t8_dprism_t *p, int level)
     return 0;
   }
 
-  line_level = sc_intpow64u (T8_DLINE_CHILDREN, level - 1);
+  lines_at_level = sc_intpow64u (T8_DLINE_CHILDREN, level - 1);
   /* *INDENT-OFF* */
   prism_shift =
     (T8_DPRISM_CHILDREN / T8_DLINE_CHILDREN) *
@@ -620,10 +620,10 @@ t8_dprism_linear_id (const t8_dprism_t *p, int level)
   for (i = level - 1; i >= 0; i--) {
     /*The number to add to the id computed via the tri_id is 4*8^(level-i)
      *for each plane in a prism of size i*/
-    id += line_id / line_level * prism_shift;
-    line_id = (t8_linearidx_t) (line_id % line_level);
+    id += line_id / lines_at_level * prism_shift;
+    line_id = (line_id % lines_at_level);
     prism_shift /= T8_DPRISM_CHILDREN;
-    line_level /= T8_DLINE_CHILDREN;
+    lines_at_level /= T8_DLINE_CHILDREN;
   }
 
   return id;

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
@@ -61,7 +61,7 @@ int                 t8_dprism_compare (const t8_dprism_t *p1,
  * \param [in] level  level of uniform grid to be considered.
  */
 void                t8_dprism_init_linear_id (t8_dprism_t *p, int level,
-                                              uint64_t id);
+                                              t8_linearidx_t id);
 
 /** Computes the successor of a prism in a uniform grid of level \a level.
  * \param [in] p  prism whose id will be computed.
@@ -318,7 +318,7 @@ void                t8_dprism_vertex_ref_coords (const t8_dprism_t *p,
  * \param [in] p  Prism whose id will be computed.
  * \return Returns the linear position of this prism on a grid.
  */
-uint64_t            t8_dprism_linear_id (const t8_dprism_t *p, int level);
+t8_linearidx_t      t8_dprism_linear_id (const t8_dprism_t *p, int level);
 
 /** Query whether all entries of a prism are in valid ranges.
  * A prism is valid if and only if its triangle and line member are valid.

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -286,7 +286,8 @@ t8_default_scheme_pyramid_c::t8_element_root_len (const t8_element_t *elem)
 
 void
 t8_default_scheme_pyramid_c::t8_element_set_linear_id (t8_element_t *elem,
-                                                       int level, uint64_t id)
+                                                       int level,
+                                                       t8_linearidx_t id)
 {
   t8_dpyramid_init_linear_id ((t8_dpyramid_t *) elem, level, id);
   T8_ASSERT (t8_element_is_valid (elem));

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.c
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.c
@@ -28,8 +28,8 @@ typedef t8_dtet_t   t8_default_tet_t;
 
 /* This function is used by other element functions and we thus need to
  * declare it up here */
-static uint64_t     t8_default_tet_get_linear_id (const t8_element_t *elem,
-                                                  int level);
+static t8_linearidx_t t8_default_tet_get_linear_id (const t8_element_t *elem,
+                                                    int level);
 
 static size_t
 t8_default_tet_size (void)
@@ -133,15 +133,16 @@ t8_default_tet_nca (const t8_element_t *elem1,
 }
 
 static void
-t8_default_tet_set_linear_id (t8_element_t *elem, int level, uint64_t id)
+t8_default_tet_set_linear_id (t8_element_t *elem, int level,
+                              t8_linearidx_t id)
 {
   T8_ASSERT (0 <= level && level <= T8_DTET_MAXLEVEL);
-  T8_ASSERT (0 <= id && id < ((uint64_t) 1) << 3 * level);
+  T8_ASSERT (0 <= id && id < ((t8_linearidx_t) 1) << 3 * level);
 
   t8_dtet_init_linear_id ((t8_default_tet_t *) elem, id, level);
 }
 
-static uint64_t
+static              t8_linearidx_t
 t8_default_tet_get_linear_id (const t8_element_t *elem, int level)
 {
   T8_ASSERT (0 <= level && level <= T8_DTET_MAXLEVEL);


### PR DESCRIPTION
Thanks to #473 I found several other cases where a ```uint64_t``` was used instead of ```t8_linearidx_t```. 
This PR fixes it.



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] New tests use the Google Test framework
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.
