### PR TITLE
Feature puma patches [2/x] add element ref coords interface

### DIFF
--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -605,6 +605,20 @@ public:
                                                           double coords[])
     const = 0;
 
+  /** Convert a point in the reference space of an element to a point in the
+   *  reference space of the tree.
+   * 
+   * \param [in] t            The element.
+   * \param [in] coords_input The coordinates of the point in the reference space of the element.
+   * \param [in] user_data    User data.
+   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   */
+  virtual void        t8_element_reference_coords (const t8_element_t *t,
+                                                   const double *ref_coords,
+                                                   const void *user_data,
+                                                   double *out_coords)
+    const = 0;
+
   /* TODO: deactivate */
   /** Return a pointer to a t8_element in an array indexed by a size_t.
    * \param [in] array    The \ref sc_array storing \t t8_element_t pointers.

--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -608,12 +608,12 @@ public:
   /** Convert a point in the reference space of an element to a point in the
    *  reference space of the tree.
    * 
-   * \param [in] t            The element.
+   * \param [in] elem         The element.
    * \param [in] coords_input The coordinates of the point in the reference space of the element.
    * \param [in] user_data    User data.
    * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
    */
-  virtual void        t8_element_reference_coords (const t8_element_t *t,
+  virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
                                                    const void *user_data,
                                                    double *out_coords)

--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
@@ -100,24 +100,24 @@ public:
    * elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and 
    * L the maximum refinement level. 
    * All element vertices have integer coordinates in this cube.
-   *   \param [in] t      The element to be considered.
+   *   \param [in] elem   The element.
    *   \param [in] vertex The id of the vertex whose coordinates shall be computed.
    *   \param [out] coords An array of at least as many integers as the element's dimension
    *                      whose entries will be filled with the coordinates of \a vertex.
    */
-  virtual void        t8_element_vertex_coords (const t8_element_t *t,
+  virtual void        t8_element_vertex_coords (const t8_element_t *elem,
                                                 int vertex,
                                                 int coords[]) const = 0;
 
   /** Convert a point in the reference space of an element to a point in the
    *  reference space of the tree.
    * 
-   * \param [in] t            The element.
+   * \param [in] elem         The element.
    * \param [in] coords_input The coordinates of the point in the reference space of the element.
    * \param [in] user_data    User data.
    * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
    */
-  virtual void        t8_element_reference_coords (const t8_element_t *t,
+  virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
                                                    const void *user_data,
                                                    double *out_coords)

--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
@@ -100,8 +100,8 @@ public:
    * elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and 
    * L the maximum refinement level. 
    * All element vertices have integer coordinates in this cube.
-   *   \param [in] elem   The element.
-   *   \param [in] vertex The id of the vertex whose coordinates shall be computed.
+   *   \param [in] elem    The element.
+   *   \param [in] vertex  The id of the vertex whose coordinates shall be computed.
    *   \param [out] coords An array of at least as many integers as the element's dimension
    *                      whose entries will be filled with the coordinates of \a vertex.
    */

--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
@@ -109,6 +109,20 @@ public:
                                                 int vertex,
                                                 int coords[]) const = 0;
 
+  /** Convert a point in the reference space of an element to a point in the
+   *  reference space of the tree.
+   * 
+   * \param [in] t            The element.
+   * \param [in] coords_input The coordinates of the point in the reference space of the element.
+   * \param [in] user_data    User data.
+   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   */
+  virtual void        t8_element_reference_coords (const t8_element_t *t,
+                                                   const double *ref_coords,
+                                                   const void *user_data,
+                                                   double *out_coords)
+    const = 0;
+
   /** Get the integer coordinates of the anchor node of an element.
    * The default scheme implements the Morton type SFCs. In these SFCs the
    * elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -658,7 +658,8 @@ t8_default_scheme_hex_c::t8_element_vertex_reference_coords (const
 }
 
 void
-t8_default_scheme_hex_c::t8_element_reference_coords (const t8_element_t *t,
+t8_default_scheme_hex_c::t8_element_reference_coords (const t8_element_t
+                                                      *elem,
                                                       const double
                                                       *ref_coords,
                                                       const void *user_data,

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -657,6 +657,17 @@ t8_default_scheme_hex_c::t8_element_vertex_reference_coords (const
   coords[2] /= (double) P8EST_ROOT_LEN;
 }
 
+void
+t8_default_scheme_hex_c::t8_element_reference_coords (const t8_element_t *t,
+                                                      const double
+                                                      *ref_coords,
+                                                      const void *user_data,
+                                                      double *out_coords)
+  const
+{
+  SC_ABORTF ("Not implemented\n");
+}
+
 int
 t8_default_scheme_hex_c::t8_element_refines_irregular () const
 {

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -567,6 +567,20 @@ public:
                                                           double coords[])
     const;
 
+  /** Convert a point in the reference space of an element to a point in the
+   *  reference space of the tree.
+   * 
+   * \param [in] t            The element.
+   * \param [in] coords_input The coordinates of the point in the reference space of the element.
+   * \param [in] user_data    User data.
+   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   */
+  virtual void        t8_element_reference_coords (const t8_element_t *t,
+                                                   const double *ref_coords,
+                                                   const void *user_data,
+                                                   double *out_coords)
+    const;
+
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.
    * * \return           0, because hexs refine regularly

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -570,12 +570,12 @@ public:
   /** Convert a point in the reference space of an element to a point in the
    *  reference space of the tree.
    * 
-   * \param [in] t            The element.
+   * \param [in] elem         The element.
    * \param [in] coords_input The coordinates of the point in the reference space of the element.
    * \param [in] user_data    User data.
    * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
    */
-  virtual void        t8_element_reference_coords (const t8_element_t *t,
+  virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
                                                    const void *user_data,
                                                    double *out_coords)

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
@@ -367,6 +367,17 @@ t8_default_scheme_line_c::t8_element_vertex_reference_coords (const
   t8_dline_vertex_ref_coords ((const t8_dline_t *) elem, vertex, coords);
 }
 
+void
+t8_default_scheme_line_c::t8_element_reference_coords (const t8_element_t *t,
+                                                       const double
+                                                       *ref_coords,
+                                                       const void *user_data,
+                                                       double *out_coords)
+  const
+{
+  SC_ABORTF ("Not implemented\n");
+}
+
 int
 t8_default_scheme_line_c::t8_element_root_len (const t8_element_t *elem) const
 {

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
@@ -368,7 +368,8 @@ t8_default_scheme_line_c::t8_element_vertex_reference_coords (const
 }
 
 void
-t8_default_scheme_line_c::t8_element_reference_coords (const t8_element_t *t,
+t8_default_scheme_line_c::t8_element_reference_coords (const t8_element_t
+                                                       *elem,
                                                        const double
                                                        *ref_coords,
                                                        const void *user_data,

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
@@ -587,6 +587,20 @@ public:
                                                           double coords[])
     const;
 
+  /** Convert a point in the reference space of an element to a point in the
+   *  reference space of the tree.
+   * 
+   * \param [in] t            The element.
+   * \param [in] coords_input The coordinates of the point in the reference space of the element.
+   * \param [in] user_data    User data.
+   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   */
+  virtual void        t8_element_reference_coords (const t8_element_t *t,
+                                                   const double *ref_coords,
+                                                   const void *user_data,
+                                                   double *out_coords)
+    const;
+
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.
    * * \return           0, because lines refine regularly

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
@@ -590,12 +590,12 @@ public:
   /** Convert a point in the reference space of an element to a point in the
    *  reference space of the tree.
    * 
-   * \param [in] t            The element.
+   * \param [in] elem         The element.
    * \param [in] coords_input The coordinates of the point in the reference space of the element.
    * \param [in] user_data    User data.
    * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
    */
-  virtual void        t8_element_reference_coords (const t8_element_t *t,
+  virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
                                                    const void *user_data,
                                                    double *out_coords)

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -481,6 +481,17 @@ t8_default_scheme_prism_c::t8_element_vertex_reference_coords (const
 }
 
 void
+t8_default_scheme_prism_c::t8_element_reference_coords (const t8_element_t *t,
+                                                        const double
+                                                        *ref_coords,
+                                                        const void *user_data,
+                                                        double *out_coords)
+  const
+{
+  SC_ABORTF ("Not implemented\n");
+}
+
+void
 t8_default_scheme_prism_c::t8_element_general_function (const t8_element_t
                                                         *elem,
                                                         const void *indata,

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -481,7 +481,8 @@ t8_default_scheme_prism_c::t8_element_vertex_reference_coords (const
 }
 
 void
-t8_default_scheme_prism_c::t8_element_reference_coords (const t8_element_t *t,
+t8_default_scheme_prism_c::t8_element_reference_coords (const t8_element_t
+                                                        *elem,
                                                         const double
                                                         *ref_coords,
                                                         const void *user_data,

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
@@ -599,12 +599,12 @@ public:
   /** Convert a point in the reference space of an element to a point in the
    *  reference space of the tree.
    * 
-   * \param [in] t            The element.
+   * \param [in] elem         The element.
    * \param [in] coords_input The coordinates of the point in the reference space of the element.
    * \param [in] user_data    User data.
    * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
    */
-  virtual void        t8_element_reference_coords (const t8_element_t *t,
+  virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
                                                    const void *user_data,
                                                    double *out_coords)

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
@@ -596,6 +596,20 @@ public:
                                                           double coords[])
     const;
 
+  /** Convert a point in the reference space of an element to a point in the
+   *  reference space of the tree.
+   * 
+   * \param [in] t            The element.
+   * \param [in] coords_input The coordinates of the point in the reference space of the element.
+   * \param [in] user_data    User data.
+   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   */
+  virtual void        t8_element_reference_coords (const t8_element_t *t,
+                                                   const double *ref_coords,
+                                                   const void *user_data,
+                                                   double *out_coords)
+    const;
+
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.
    * * \return           0, because prisms refine regularly

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -475,6 +475,19 @@ t8_default_scheme_pyramid_c::t8_element_vertex_reference_coords (const
                                        vertex, coords);
 }
 
+void
+t8_default_scheme_pyramid_c::t8_element_reference_coords (const t8_element_t
+                                                          *t,
+                                                          const double
+                                                          *ref_coords,
+                                                          const void
+                                                          *user_data,
+                                                          double *out_coords)
+  const
+{
+  SC_ABORTF ("Not implemented\n");
+}
+
 int
 t8_default_scheme_pyramid_c::t8_element_refines_irregular () const
 {

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -477,7 +477,7 @@ t8_default_scheme_pyramid_c::t8_element_vertex_reference_coords (const
 
 void
 t8_default_scheme_pyramid_c::t8_element_reference_coords (const t8_element_t
-                                                          *t,
+                                                          *elem,
                                                           const double
                                                           *ref_coords,
                                                           const void

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
@@ -618,12 +618,12 @@ public:
   /** Convert a point in the reference space of an element to a point in the
    *  reference space of the tree.
    * 
-   * \param [in] t            The element.
+   * \param [in] elem         The element.
    * \param [in] coords_input The coordinates of the point in the reference space of the element.
    * \param [in] user_data    User data.
    * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
    */
-  virtual void        t8_element_reference_coords (const t8_element_t *t,
+  virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
                                                    const void *user_data,
                                                    double *out_coords)

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
@@ -615,6 +615,20 @@ public:
                                                           double coords[])
     const;
 
+  /** Convert a point in the reference space of an element to a point in the
+   *  reference space of the tree.
+   * 
+   * \param [in] t            The element.
+   * \param [in] coords_input The coordinates of the point in the reference space of the element.
+   * \param [in] user_data    User data.
+   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   */
+  virtual void        t8_element_reference_coords (const t8_element_t *t,
+                                                   const double *ref_coords,
+                                                   const void *user_data,
+                                                   double *out_coords)
+    const;
+
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.
    * * \return           1, because pyramids refine irregularly

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -791,7 +791,8 @@ t8_default_scheme_quad_c::t8_element_vertex_reference_coords (const
 }
 
 void
-t8_default_scheme_quad_c::t8_element_reference_coords (const t8_element_t *t,
+t8_default_scheme_quad_c::t8_element_reference_coords (const t8_element_t
+                                                       *elem,
                                                        const double
                                                        *ref_coords,
                                                        const void *user_data,

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -791,6 +791,17 @@ t8_default_scheme_quad_c::t8_element_vertex_reference_coords (const
 }
 
 void
+t8_default_scheme_quad_c::t8_element_reference_coords (const t8_element_t *t,
+                                                       const double
+                                                       *ref_coords,
+                                                       const void *user_data,
+                                                       double *out_coords)
+  const
+{
+  SC_ABORTF ("Not implemented\n");
+}
+
+void
 t8_default_scheme_quad_c::t8_element_new (int length, t8_element_t **elem) const
 {
   /* allocate memory for a quad */

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -600,6 +600,20 @@ public:
                                                           double coords[])
     const;
 
+  /** Convert a point in the reference space of an element to a point in the
+   *  reference space of the tree.
+   * 
+   * \param [in] t            The element.
+   * \param [in] coords_input The coordinates of the point in the reference space of the element.
+   * \param [in] user_data    User data.
+   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   */
+  virtual void        t8_element_reference_coords (const t8_element_t *t,
+                                                   const double *ref_coords,
+                                                   const void *user_data,
+                                                   double *out_coords)
+    const;
+
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.
    * * \return           0, because quads refine regularly

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -603,12 +603,12 @@ public:
   /** Convert a point in the reference space of an element to a point in the
    *  reference space of the tree.
    * 
-   * \param [in] t            The element.
+   * \param [in] elem         The element.
    * \param [in] coords_input The coordinates of the point in the reference space of the element.
    * \param [in] user_data    User data.
    * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
    */
-  virtual void        t8_element_reference_coords (const t8_element_t *t,
+  virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
                                                    const void *user_data,
                                                    double *out_coords)

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
@@ -556,6 +556,17 @@ t8_default_scheme_tet_c::t8_element_vertex_reference_coords (const
                                      coords);
 }
 
+void
+t8_default_scheme_tet_c::t8_element_reference_coords (const t8_element_t *t,
+                                                      const double
+                                                      *ref_coords,
+                                                      const void *user_data,
+                                                      double *out_coords)
+  const
+{
+  SC_ABORTF ("Not implemented\n");
+}
+
 /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
  * Returns false otherwise.
  */

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
@@ -557,7 +557,8 @@ t8_default_scheme_tet_c::t8_element_vertex_reference_coords (const
 }
 
 void
-t8_default_scheme_tet_c::t8_element_reference_coords (const t8_element_t *t,
+t8_default_scheme_tet_c::t8_element_reference_coords (const t8_element_t
+                                                      *elem,
                                                       const double
                                                       *ref_coords,
                                                       const void *user_data,

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
@@ -582,6 +582,20 @@ public:
                                                           double coords[])
     const;
 
+  /** Convert a point in the reference space of an element to a point in the
+   *  reference space of the tree.
+   * 
+   * \param [in] t            The element.
+   * \param [in] coords_input The coordinates of the point in the reference space of the element.
+   * \param [in] user_data    User data.
+   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   */
+  virtual void        t8_element_reference_coords (const t8_element_t *t,
+                                                   const double *ref_coords,
+                                                   const void *user_data,
+                                                   double *out_coords)
+    const;
+
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.
    * * \return           0, because tets refine regularly

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
@@ -585,12 +585,12 @@ public:
   /** Convert a point in the reference space of an element to a point in the
    *  reference space of the tree.
    * 
-   * \param [in] t            The element.
+   * \param [in] elem         The element.
    * \param [in] coords_input The coordinates of the point in the reference space of the element.
    * \param [in] user_data    User data.
    * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
    */
-  virtual void        t8_element_reference_coords (const t8_element_t *t,
+  virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
                                                    const void *user_data,
                                                    double *out_coords)

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
@@ -576,7 +576,8 @@ t8_default_scheme_tri_c::t8_element_vertex_reference_coords (const
 }
 
 void
-t8_default_scheme_tri_c::t8_element_reference_coords (const t8_element_t *t,
+t8_default_scheme_tri_c::t8_element_reference_coords (const t8_element_t
+                                                      *elem,
                                                       const double
                                                       *ref_coords,
                                                       const void *user_data,

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
@@ -575,6 +575,17 @@ t8_default_scheme_tri_c::t8_element_vertex_reference_coords (const
                                      coords);
 }
 
+void
+t8_default_scheme_tri_c::t8_element_reference_coords (const t8_element_t *t,
+                                                      const double
+                                                      *ref_coords,
+                                                      const void *user_data,
+                                                      double *out_coords)
+  const
+{
+  SC_ABORTF ("Not implemented\n");
+}
+
 int
 t8_default_scheme_tri_c::t8_element_refines_irregular () const
 {

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
@@ -575,6 +575,20 @@ public:
                                                           double coords[])
     const;
 
+  /** Convert a point in the reference space of an element to a point in the
+   *  reference space of the tree.
+   * 
+   * \param [in] t            The element.
+   * \param [in] coords_input The coordinates of the point in the reference space of the element.
+   * \param [in] user_data    User data.
+   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   */
+  virtual void        t8_element_reference_coords (const t8_element_t *t,
+                                                   const double *ref_coords,
+                                                   const void *user_data,
+                                                   double *out_coords)
+    const;
+
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.
    * * \return           0, because tris refine regularly

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
@@ -578,12 +578,12 @@ public:
   /** Convert a point in the reference space of an element to a point in the
    *  reference space of the tree.
    * 
-   * \param [in] t            The element.
+   * \param [in] elem         The element.
    * \param [in] coords_input The coordinates of the point in the reference space of the element.
    * \param [in] user_data    User data.
    * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
    */
-  virtual void        t8_element_reference_coords (const t8_element_t *t,
+  virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
                                                    const void *user_data,
                                                    double *out_coords)

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
@@ -322,7 +322,7 @@ t8_default_scheme_vertex_c::t8_element_vertex_reference_coords (const
 
 void
 t8_default_scheme_vertex_c::t8_element_reference_coords (const t8_element_t
-                                                         *t,
+                                                         *elem,
                                                          const double
                                                          *ref_coords,
                                                          const void

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
@@ -320,6 +320,19 @@ t8_default_scheme_vertex_c::t8_element_vertex_reference_coords (const
   t8_dvertex_vertex_ref_coords ((const t8_dvertex_t *) elem, vertex, coords);
 }
 
+void
+t8_default_scheme_vertex_c::t8_element_reference_coords (const t8_element_t
+                                                         *t,
+                                                         const double
+                                                         *ref_coords,
+                                                         const void
+                                                         *user_data,
+                                                         double *out_coords)
+  const
+{
+  SC_ABORTF ("Not implemented\n");
+}
+
 #ifdef T8_ENABLE_DEBUG
 /* *INDENT-OFF* */
 /* indent bug, indent adds a second "const" modifier */

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
@@ -618,12 +618,12 @@ public:
   /** Convert a point in the reference space of an element to a point in the
    *  reference space of the tree.
    * 
-   * \param [in] t            The element.
+   * \param [in] elem         The element.
    * \param [in] coords_input The coordinates of the point in the reference space of the element.
    * \param [in] user_data    User data.
    * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
    */
-  virtual void        t8_element_reference_coords (const t8_element_t *t,
+  virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
                                                    const void *user_data,
                                                    double *out_coords)

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
@@ -615,6 +615,20 @@ public:
                                                           double coords[])
     const;
 
+  /** Convert a point in the reference space of an element to a point in the
+   *  reference space of the tree.
+   * 
+   * \param [in] t            The element.
+   * \param [in] coords_input The coordinates of the point in the reference space of the element.
+   * \param [in] user_data    User data.
+   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   */
+  virtual void        t8_element_reference_coords (const t8_element_t *t,
+                                                   const double *ref_coords,
+                                                   const void *user_data,
+                                                   double *out_coords)
+    const;
+
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.
    * * \return           0, because vertices refine regularly


### PR DESCRIPTION
**_Describe your changes here:_**
The interface for the coming element ref coord functions. The function gets a set of reference coordinates inside an element $[0, 1]^d$ and maps these coordinates to the reference coordinates of the tree $[0, 1]^d$, regarding the anchor coordinate, level and orientation. This way, we can evaluate the geometry of arbitrary points inside an element. Before, we could only evaluate the vertices of the elements.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] New tests use the Google Test framework
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.
