### PR TITLE
quality improvements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,13 @@ You can also find the documentation of our releases on the [t8code website](http
   
   An (incomplete) list of publications related to t8code:
     
-  [1] **Overview Paper**: Holke, Johannes and Burstedde, Carsten and Knapp, David and Dreyer, Lukas and Elsweijer, Sandro and Ünlü, Veli and Markert, Johannes and Lilikakis, Ioannis and Böing, Niklas and Ponnusamy, Prasanna and Basermann, Achim  (2023) *t8code v. 1.0 - Modular Adaptive Mesh Refinement in the Exascale Era*. SIAM International Meshing Round Table 2023, 06.03.2023 - 09.03.2023, Amsterdam, Niederlande. 
+  [1] **Overview Paper**: 
+  Holke, Johannes and Burstedde, Carsten and Knapp, David and Dreyer, Lukas and Elsweijer, Sandro and Ünlü, Veli and Markert, Johannes and Lilikakis, Ioannis and Böing, Niklas and Ponnusamy, Prasanna and Basermann, Achim  (2023) *t8code v. 1.0 - Modular Adaptive Mesh Refinement in the Exascale Era*. SIAM International Meshing Round Table 2023, 06.03.2023 - 09.03.2023, Amsterdam, Niederlande. 
   [Full text available](https://elib.dlr.de/194377/1/t8code_overview_IMR2023.pdf)
   
     
-  [2] **Original PhD thesis**: Johannes Holke, *Scalable algorithms for parallel tree-based adaptive mesh refinement with general element types*, PhD thesis at University of Bonn, 2018,
+  [2] **Original PhD thesis**: 
+  Johannes Holke, *Scalable algorithms for parallel tree-based adaptive mesh refinement with general element types*, PhD thesis at University of Bonn, 2018,
       [Full text available](https://bonndoc.ulb.uni-bonn.de/xmlui/handle/20.500.11811/7661)
    
       
@@ -174,30 +176,37 @@ You can also find the documentation of our releases on the [t8code website](http
   Knapp, David (2020) *A space-filling curve for pyramidal adaptive mesh refinement*. Master's thesis, Rheinische Friedrich-Wilhems-Universität Bonn.
   
    
-  [C] **DG solver based on t8code**: Dreyer, Lukas (2021) *The local discontinuous galerkin method for the advection-diffusion equation on adaptive meshes*.  Master's thesis, Rheinische Friedrich-Wilhems-Universität Bonn.
+  [C] **DG solver based on t8code**: 
+  Dreyer, Lukas (2021) *The local discontinuous galerkin method for the advection-diffusion equation on adaptive meshes*.  Master's thesis, Rheinische Friedrich-Wilhems-Universität Bonn.
   [Full text available] (https://elib.dlr.de/143969/1/masterthesis_dreyer.pdf) 
   
   
-  [D] **Geometry controlled refinement for hexahedra (Part 1)**: Elsweijer, Sandro (2021) *Curved Domain Adaptive Mesh Refinement with Hexahedra*.  Tech report, Hochschule Bonn-Rhein-Sieg.
+  [D] **Geometry controlled refinement for hexahedra (Part 1)**: 
+  Elsweijer, Sandro (2021) *Curved Domain Adaptive Mesh Refinement with Hexahedra*.  Tech report, Hochschule Bonn-Rhein-Sieg.
   [Full text available] (https://elib.dlr.de/186571/1/masterprojekt-2_elsweijer_ABGABEVERSION_TITEL.pdf)
   
 
-  [E] **Subelement and resolving hanging faces in 2D**: Becker, Florian (2021) *Removing hanging faces from tree-based adaptive meshes for numerical simulation*, Master's thesis, Universität zu Köln.
+  [E] **Subelement and resolving hanging faces in 2D**: 
+  Becker, Florian (2021) *Removing hanging faces from tree-based adaptive meshes for numerical simulation*, Master's thesis, Universität zu Köln.
   [Full text available](https://elib.dlr.de/187499/1/RemovingHangingFacesFromTreeBasedAMR.pdf)
   
   
-  [F] **Coarsening as post-processing to reduce simulation file size**: Spataro, Luca  (2021) *Lossy data compression for atmospheric chemistry using adaptive mesh coarsening*.  Master's thesis, Technische Universität München.
+  [F] **Coarsening as post-processing to reduce simulation file size**: 
+  Spataro, Luca  (2021) *Lossy data compression for atmospheric chemistry using adaptive mesh coarsening*.  Master's thesis, Technische Universität München.
   [Full text available](https://elib.dlr.de/144997/1/master-thesis-final-spataro.pdf)
  
   
-  [G] **Geometry controlled refinement for hexahedra (Part 2)**: Elsweijer, Sandro (2022) *Evaluation and generic application scenarios for curved hexahedral adaptive mesh refinement*.  Master's thesis, Hochschule Bonn-Rhein-Sieg.  [10.13140/RG.2.2.34714.11203](<https://doi.org/10.13140/RG.2.2.34714.11203>) [Full text available](https://elib.dlr.de/186561/1/sandro_elsweijer-evaluation_and_generic_application_scenarios_for_curved_hexahedral_adaptive_mesh_refinement.pdf)
+  [G] **Geometry controlled refinement for hexahedra (Part 2)**: 
+  Elsweijer, Sandro (2022) *Evaluation and generic application scenarios for curved hexahedral adaptive mesh refinement*.  Master's thesis, Hochschule Bonn-Rhein-Sieg.  [10.13140/RG.2.2.34714.11203](<https://doi.org/10.13140/RG.2.2.34714.11203>) [Full text available](https://elib.dlr.de/186561/1/sandro_elsweijer-evaluation_and_generic_application_scenarios_for_curved_hexahedral_adaptive_mesh_refinement.pdf)
   
   
-  [H] **Multigrid and other preconditioners for DG**: Böing, Niklas  (2022) *Evaluation of preconditioners for implicit solvers of local DG for the advection-diffusion equation* (*Untersuchung von Präkonditionierern für implizite Löser für das Local DG-Verfahren zur Lösung der Advektions-Diffusionsgleichung*).  Master's thesis, Universität zu Köln.
+  [H] **Multigrid and other preconditioners for DG**: 
+  Böing, Niklas  (2022) *Evaluation of preconditioners for implicit solvers of local DG for the advection-diffusion equation* (*Untersuchung von Präkonditionierern für implizite Löser für das Local DG-Verfahren zur Lösung der Advektions-Diffusionsgleichung*).  Master's thesis, Universität zu Köln.
 [Full text available](https://elib.dlr.de/186347/1/Untersuchung%20von%20Pr%C3%A4konditionierern%20f%C3%BCr%20implizite%20L%C3%B6ser%20f%C3%BCr%20das%20Local%20DG-Verfahren%20zur%20L%C3%B6sung%20der%20Advektions-Diffusionsgleichung.pdf)
   
 
-  [I] **Removing elements from the mesh (cutting holes)**: Lilikakis, Ioannis  (2022) *Algorithms for tree-based adaptive meshes with incomplete trees*.  Master's thesis, Universität zu Köln.    
+  [I] **Removing elements from the mesh (cutting holes)**: 
+  Lilikakis, Ioannis  (2022) *Algorithms for tree-based adaptive meshes with incomplete trees*.  Master's thesis, Universität zu Köln.    
  [Full text may be available in future](https://elib.dlr.de/191968/)
  
 

--- a/README.md
+++ b/README.md
@@ -144,20 +144,20 @@ You can also find the documentation of our releases on the [t8code website](http
   
     
   [2] **Original PhD thesis**: 
-  Johannes Holke, *Scalable algorithms for parallel tree-based adaptive mesh refinement with general element types*, PhD thesis at University of Bonn, 2018,
+  Holke, Johannes *Scalable algorithms for parallel tree-based adaptive mesh refinement with general element types*, PhD thesis at University of Bonn, 2018,
       [Full text available](https://bonndoc.ulb.uni-bonn.de/xmlui/handle/20.500.11811/7661)
    
       
   [3] **Tetrahedral and triangular Space-filling curve**:
-  Carsten Burstedde and Johannes Holke, *A Tetrahedral Space-Filling Curve for Nonconforming Adaptive Meshes*, SIAM Journal on Scientific Computing, 2016, [10.1137/15M1040049](https://epubs.siam.org/doi/10.1137/15M1040049)
+  Burstedde, Carsten and Holke, Johannes *A Tetrahedral Space-Filling Curve for Nonconforming Adaptive Meshes*, SIAM Journal on Scientific Computing, 2016, [10.1137/15M1040049](https://epubs.siam.org/doi/10.1137/15M1040049)
   
   
   [4] **Coarse mesh partitioning**:
-  Carsten Burstedde and Johannes Holke, *Coarse mesh partitioning for tree-based AMR*, SIAM Journal on Scientific Computing, 2017, [10.1137/16M1103518](https://epubs.siam.org/doi/10.1137/16M1103518)
+  Burstedde, Carsten and Holke, Johannes *Coarse mesh partitioning for tree-based AMR*, SIAM Journal on Scientific Computing, 2017, [10.1137/16M1103518](https://epubs.siam.org/doi/10.1137/16M1103518)
   
   
   [5] **Ghost computation**:
-  Johannes Holke and David Knapp and Carsten Burstedde, *An Optimized, Parallel Computation of the Ghost Layer for Adaptive Hybrid Forest Meshes*, SIAM Journal on Scientific Computing, 2021, [10.1137/20M1383033](https://epubs.siam.org/doi/abs/10.1137/20M1383033)
+  Holke, Johannes and Knapp, David and Burstedde, Carsten *An Optimized, Parallel Computation of the Ghost Layer for Adaptive Hybrid Forest Meshes*, SIAM Journal on Scientific Computing, 2021, [10.1137/20M1383033](https://epubs.siam.org/doi/abs/10.1137/20M1383033)
  
   
   [6] **Geometry controlled refinement for hexahedra**:


### PR DESCRIPTION
**_Describe your changes here:_**

- Unifty first/last name order in references
- Add line breaks


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
