### PR TITLE
Add preprocessor macros for documentation

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2204,7 +2204,12 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = @PACKAGE_PREFIX@_DOXYGEN
+PREDEFINED             = @PACKAGE_PREFIX@_DOXYGEN \
+                         T8_ENABL_DEBUG \
+                         T8_WITH_VTK \
+                         T8_WITH_OCC \
+                         T8_WITH_NETCDF \
+                         T8_WITH_NETCDF_PAR
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2205,7 +2205,7 @@ INCLUDE_FILE_PATTERNS  =
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             = @PACKAGE_PREFIX@_DOXYGEN \
-                         T8_ENABL_DEBUG \
+                         T8_ENABLE_DEBUG \
                          T8_WITH_VTK \
                          T8_WITH_OCC \
                          T8_WITH_NETCDF \


### PR DESCRIPTION
**_Describe your changes here:_**
Adds our link flags to the preprocessor macros of Doxygen. This way, Doxygen also generates the documentation behind a `T8_ENABLE_DEBUG`, `T8_WITH_VTK`, ... macro.
Fixes #426 


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
