### PR TITLE
Fix issue546

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
@@ -31,7 +31,7 @@ t8_dhex_compute_reference_coords (const t8_dhex_t * elem,
   const p8est_quadrant_t *q1 = (const p8est_quadrant_t *) elem;
 
   /* Get the length of the quadrant */
-  const int           len = P8EST_QUADRANT_LEN (q1->level);
+  const p4est_qcoord_t len = P8EST_QUADRANT_LEN (q1->level);
 
   /* Compute the x, y and z coordinates of the point depending on the
    * reference coordinates */

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
@@ -41,7 +41,7 @@ t8_dhex_compute_reference_coords (const t8_dhex_t * elem,
 
   /* We divide the integer coordinates by the root length of the hex
    * to obtain the reference coordinates. */
-  out_coords[0] /= (double) T8_DHEX_ROOT_LEN;
-  out_coords[1] /= (double) T8_DHEX_ROOT_LEN;
-  out_coords[2] /= (double) T8_DHEX_ROOT_LEN;
+  out_coords[0] /= (double) P8EST_ROOT_LEN;
+  out_coords[1] /= (double) P8EST_ROOT_LEN;
+  out_coords[2] /= (double) P8EST_ROOT_LEN;
 }

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c
@@ -29,14 +29,12 @@ t8_dquad_compute_reference_coords (const t8_dquad_t * elem,
                                    double *out_coords)
 {
   const p4est_quadrant_t *q1 = (const p4est_quadrant_t *) elem;
-  out_coords[0] = q1->x / (double) T8_DQUAD_ROOT_LEN;
-  out_coords[1] = q1->y / (double) T8_DQUAD_ROOT_LEN;
-  const double        len =
-    P4EST_QUADRANT_LEN (q1->level) / (double) T8_DQUAD_ROOT_LEN;
 
-  out_coords[0] += ref_coords[0] * len;
-  out_coords[1] += ref_coords[1] * len;
+  const p4est_qcoord_t h = P4EST_QUADRANT_LEN (q1->level);
 
-  out_coords[0] /= (double) T8_DQUAD_ROOT_LEN;
-  out_coords[1] /= (double) T8_DQUAD_ROOT_LEN;
+  out_coords[0] = q1->x + ref_coords[0] * h;
+  out_coords[1] = q1->y + ref_coords[1] * h;
+
+  out_coords[0] /= (double) P4EST_ROOT_LEN;
+  out_coords[1] /= (double) P4EST_ROOT_LEN;
 }


### PR DESCRIPTION
fixes Issue #546 

The computation of the reference-coordinates when the vtk-API is used was incorrect, because p4est and t8code Makros were mixed together. This fixes it. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
