### PR TITLE
Remove a t8_dtri_is_valid assertion, that gets called with a pyramid-descendant

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
@@ -403,7 +403,6 @@ t8_dtri_compute_reference_coords (const t8_dtri_t *elem,
    *   z--> x
    */
   T8_ASSERT (ref_coords != NULL);
-  T8_ASSERT (t8_dtri_is_valid (elem));
 
   t8_dtri_type_t      type;
   t8_dtri_coord_t     h;


### PR DESCRIPTION
Closes #545 

Removed a ```T8_ASSERT(t8_dtri_is_valid(elem)```.
This assertion was called with a pyramid as an argument, too, because the function gets called when t8_dpyramid_compute_reference_coords is called with a tetrahedral descendant. The Assertion fails, because elem->eclass_int8 is not set correctly (line 1727 in t8_dtri_bits.c)

In a pure tetrahedral or triangular scheme the check is called in t8_default_tet/tri_cxx.cxx



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
