### PR TITLE
Added a newline in cmesh examples warnings output.

### DIFF
--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -60,7 +60,7 @@ t8_cmesh_new_from_p4est_ext (void *conn, int dim,
    * and raise a warning. */
   if (!sc_package_is_registered (p4est_package_id)) {
     t8_global_errorf
-      ("WARNING: p4est is not yet initialized. Doing it now for you.");
+      ("WARNING: p4est is not yet initialized. Doing it now for you.\n");
     p4est_init (NULL, SC_LP_ESSENTIAL);
   }
 


### PR DESCRIPTION
**_Describe your changes here:_**

Nothing to explain further.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
