### PR TITLE
Fix pyramid element ref coords

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -1761,8 +1761,8 @@ t8_dpyramid_compute_reference_coords (const t8_dpyramid_t *elem,
       out_coords[2] += ref_coords[2] * length;
     }
     else {
-      out_coords[0] += ref_coords[0] * length * (1 - ref_coords[2]);
-      out_coords[1] += ref_coords[1] * length * (1 - ref_coords[2]);
+      out_coords[0] += (ref_coords[0] - ref_coords[2]) * length;
+      out_coords[1] += (ref_coords[1] - ref_coords[2]) * length;
       out_coords[2] += (1 - ref_coords[2]) * length;
     }
 


### PR DESCRIPTION
**_Describe your changes here:_**
The implementation of pyramid element reference coordinates was faulty:
![image (1)](https://github.com/DLR-AMR/t8code/assets/49643115/de169e4b-49bd-4a1e-bbf2-01f8276017f2)
This can only be observed, if the pyramids are written out as curved and if the nonlinear subdivision level in ParaView is >0.
After the fix, it looks like this:
![grafik](https://github.com/DLR-AMR/t8code/assets/49643115/f60221d8-1136-4892-9872-0e0b8bd58613)

Here is a quick code for generating pyramids and write them as curved elements:
```
#include <t8.h>
#include <t8_cmesh/t8_cmesh_examples.h>
#include <t8_forest/t8_forest_general.h>
#include <t8_forest/t8_forest_geometrical.h>
#include <t8_forest/t8_forest_profiling.h>
#include <t8_forest/t8_forest_io.h>
#include <t8_forest/t8_forest_vtk.h>
#include <t8_schemes/t8_default/t8_default_cxx.hxx>

int main(int argc, char **argv)
{ 
  int mpiret = sc_MPI_Init (&argc, &argv);
  SC_CHECK_MPI (mpiret);

  sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_ESSENTIAL);
  t8_init (SC_LP_DEFAULT);
  t8_cmesh_t cmesh = t8_cmesh_new_hypercube(T8_ECLASS_PYRAMID, sc_MPI_COMM_WORLD, 0, 0, 0);
  t8_forest_t forest =  t8_forest_new_uniform (cmesh, t8_scheme_new_default_cxx(), 1, 0, sc_MPI_COMM_WORLD);
  t8_forest_write_vtk_ext(forest, "testfile", 1, 1, 1, 1, 0, 1, 0, 0, NULL);
  t8_forest_unref(&forest);
  sc_finalize ();

  mpiret = sc_MPI_Finalize ();
  SC_CHECK_MPI (mpiret);
}
```



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
