### PR TITLE
Added constancy to flags in t8_forest_replace_t

### DIFF
--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -88,10 +88,11 @@ typedef void        (*t8_forest_replace_t) (t8_forest_t forest_old,
                                             t8_forest_t forest_new,
                                             t8_locidx_t which_tree,
                                             t8_eclass_scheme_c *ts,
-                                            int refine, int num_outgoing,
-                                            t8_locidx_t first_outgoing,
-                                            int num_incoming,
-                                            t8_locidx_t first_incoming);
+                                            const int refine,
+                                            const int num_outgoing,
+                                            const t8_locidx_t first_outgoing,
+                                            const int num_incoming,
+                                            const t8_locidx_t first_incoming);
 
 /** Callback function prototype to decide for refining and coarsening.
  * If \a is_family equals 1, the first \a num_elements in \a elements


### PR DESCRIPTION
**Added constancy to flags in t8_forest_replace_t**



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
