### PR TITLE
Enable ghost cell output in tutorial step 4

### DIFF
--- a/doc/author_geihe.txt
+++ b/doc/author_geihe.txt
@@ -1,0 +1,1 @@
+I place my contributions to t8code under the FreeBSD license. Benedict Geihe (bgeihe@uni-koeln.de)

--- a/tutorials/general/t8_step4_partition_balance_ghost.cxx
+++ b/tutorials/general/t8_step4_partition_balance_ghost.cxx
@@ -281,7 +281,7 @@ t8_step4_main (int argc, char **argv)
     (" [step4] Repartitioned forest and built ghost layer.\n");
   t8_step3_print_forest_information (forest);
   /* Write forest to vtu files. */
-  t8_forest_write_vtk (forest, prefix_partition_ghost);
+  t8_forest_write_vtk_ext (forest, prefix_partition_ghost, 1, 1, 1, 1, 1, 0, 0, 0, NULL);
 
   /*
    * Balance

--- a/tutorials/general/t8_step4_partition_balance_ghost.cxx
+++ b/tutorials/general/t8_step4_partition_balance_ghost.cxx
@@ -281,7 +281,8 @@ t8_step4_main (int argc, char **argv)
     (" [step4] Repartitioned forest and built ghost layer.\n");
   t8_step3_print_forest_information (forest);
   /* Write forest to vtu files. */
-  t8_forest_write_vtk_ext (forest, prefix_partition_ghost, 1, 1, 1, 1, 1, 0, 0, 0, NULL);
+  t8_forest_write_vtk_ext (forest, prefix_partition_ghost, 1, 1, 1, 1, 1, 0,
+                           0, 0, NULL);
 
   /*
    * Balance


### PR DESCRIPTION
Switched to `t8_forest_write_vtk_ext` to be able to pass flag for writing ghost cells.



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] New Datatypes are added to t8indent_custom_datatypes.txt
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
