### PR TITLE
reduced num testscases for LESS-TESTS

### DIFF
--- a/src/t8_cmesh/t8_cmesh_testcases.c
+++ b/src/t8_cmesh/t8_cmesh_testcases.c
@@ -29,19 +29,15 @@
 #include <t8_cmesh/t8_cmesh_examples.h>
 #include <t8_cmesh/t8_cmesh_testcases.h>
 
-#ifdef T8_ENABLE_LESS_TESTS
-#define T8_CMESH_TEST_NUM_COMMS 1
-#define T8_CMESH_BINARY 2
-#define T8_CMESH_DIM_RANGE 4
-#define T8_CMESH_MAX_TEST_DIMS 3
-#define T8_CMESH_MAX_NUM_OF_TREES 20
-#define T8_CMESH_MAX_NUM_OF_PRISMS 20
-#define T8_CMESH_MAX_NUM_XYZ_TREES 5
-#else
 #define T8_CMESH_TEST_NUM_COMMS 1
 #define T8_CMESH_BINARY 2
 #define T8_CMESH_DIM_RANGE 4    /* this is the dim range for hypercube hybrid and empty cmesh */
 #define T8_CMESH_MAX_TEST_DIMS 3
+#ifdef T8_ENABLE_LESS_TESTS
+#define T8_CMESH_MAX_NUM_OF_TREES 5
+#define T8_CMESH_MAX_NUM_OF_PRISMS 5
+#define T8_CMESH_MAX_NUM_XYZ_TREES 3
+#else
 #define T8_CMESH_MAX_NUM_OF_TREES 10
 #define T8_CMESH_MAX_NUM_OF_PRISMS 10
 #define T8_CMESH_MAX_NUM_XYZ_TREES 5


### PR DESCRIPTION
**_Describe your changes here:_**
See issue #574

Closes #574


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] New Datatypes are added to t8indent_custom_datatypes.txt
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
