### PR TITLE
Parametrize vtk tests

### DIFF
--- a/src/t8_vtk/t8_vtk_types.h
+++ b/src/t8_vtk/t8_vtk_types.h
@@ -62,7 +62,8 @@ typedef enum vtk_file_type
 {
   VTK_FILE_ERROR = -1,          /*For Testing purpose. */
   VTK_UNSTRUCTURED_FILE = 0,
-  VTK_POLYDATA_FILE = 1
+  VTK_POLYDATA_FILE = 1,
+  VTK_NUM_TYPES
 } vtk_file_type_t;
 
 typedef enum vtk_read_success

--- a/test/t8_IO/t8_gtest_vtk_reader.cxx
+++ b/test/t8_IO/t8_gtest_vtk_reader.cxx
@@ -29,7 +29,7 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
  * test yet. 
  * 
  */
-TEST (t8__vtk_reader, vtk_to_cmesh)
+TEST (t8_vtk_reader, vtk_to_cmesh)
 {
 #if T8_WITH_VTK
   t8_cmesh_t          cmesh =
@@ -58,6 +58,24 @@ TEST (t8__vtk_reader, vtk_to_cmesh)
   EXPECT_FALSE (cmesh == NULL);
   t8_cmesh_destroy (&cmesh);
 
+#else
+#endif
+}
+
+TEST (t8_vtk_reader, vtk_to_pointSet)
+{
+#if T8_WITH_VTK
+  vtkSmartPointer < vtkPointSet > points =
+    t8_vtk_reader_pointSet ("test/testfiles/test_vtk_tri.vtu", 0, 0,
+                            sc_MPI_COMM_WORLD, VTK_UNSTRUCTURED_FILE);
+  int                 num_points = points->GetNumberOfPoints ();
+  EXPECT_EQ (num_points, 121);
+
+  points =
+    t8_vtk_reader_pointSet ("test/testfiles/test_vtk_cube.vtp", 0, 0,
+                            sc_MPI_COMM_WORLD, VTK_POLYDATA_FILE);
+  num_points = points->GetNumberOfPoints ();
+  EXPECT_EQ (num_points, 24);
 #else
 #endif
 }

--- a/test/t8_IO/t8_gtest_vtk_reader.cxx
+++ b/test/t8_IO/t8_gtest_vtk_reader.cxx
@@ -29,7 +29,7 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
  * test yet. 
  * 
  */
-TEST (t8_cmesh_vtk_reader, dummy_test)
+TEST (t8__vtk_reader, vtk_to_cmesh)
 {
 #if T8_WITH_VTK
   t8_cmesh_t          cmesh =


### PR DESCRIPTION
Parametrized the existing test and added a test for pointSets. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
