### PR TITLE
Vtk parallel checks

### DIFF
--- a/src/t8_vtk/t8_vtk_reader.cxx
+++ b/src/t8_vtk/t8_vtk_reader.cxx
@@ -144,6 +144,7 @@ t8_file_to_vtkGrid (const char *filename,
       /* Communicate the success/failure of the reading process. */
       sc_MPI_Bcast (&main_proc_read_successful, 1, sc_MPI_INT, main_proc,
                     comm);
+      return main_proc_read_successful;
     }
   }
   if (partition) {
@@ -309,8 +310,8 @@ t8_vtkGrid_to_cmesh (vtkSmartPointer < vtkDataSet > vtkGrid,
   T8_ASSERT (0 <= main_proc && main_proc < mpisize);
 
   /* Already declared here, because we might use them during communication */
-  t8_gloidx_t         num_trees;
-  int                 dim;
+  t8_gloidx_t         num_trees = 0;
+  int                 dim = 0;
 
   t8_cmesh_init (&cmesh);
   if (!partition || mpirank == main_proc) {
@@ -329,11 +330,12 @@ t8_vtkGrid_to_cmesh (vtkSmartPointer < vtkDataSet > vtkGrid,
     }
     /* Communicate the dimension to all processes */
     sc_MPI_Bcast (&dim, 1, sc_MPI_INT, main_proc, comm);
+    t8_cmesh_set_dimension (cmesh, dim);
     /* Communicate the number of trees to all processes. 
      * TODO: This probably crashes when a vtkGrid is distributed in many 
      * files. */
     sc_MPI_Bcast (&num_trees, 1, T8_MPI_GLOIDX, main_proc, comm);
-    t8_cmesh_set_dimension (cmesh, dim);
+
     /* Build the partition. */
     if (mpirank < main_proc) {
       first_tree = 0;
@@ -407,7 +409,7 @@ t8_vtk_reader (const char *filename, const int partition,
   T8_ASSERT (filename != NULL);
   vtk_read_success_t  main_proc_read_successful = read_failure;
 
-  vtkSmartPointer < vtkDataSet > vtkGrid;
+  vtkSmartPointer < vtkDataSet > vtkGrid = NULL;
   switch (vtk_file_type) {
   case VTK_UNSTRUCTURED_FILE:
     vtkGrid = vtkSmartPointer < vtkUnstructuredGrid >::New ();
@@ -471,7 +473,7 @@ t8_vtk_reader_cmesh (const char *filename, const int partition,
     return cmesh;
   }
   else {
-    t8_global_errorf ("Error translating file %s\n", filename);
+    t8_global_errorf ("Error translating file \n");
     return NULL;
   }
 #else

--- a/test/t8_IO/t8_gtest_vtk_reader.cxx
+++ b/test/t8_IO/t8_gtest_vtk_reader.cxx
@@ -39,7 +39,7 @@ class vtk_reader : public testing::TestWithParam<std::tuple<vtk_file_type_t, int
       int mpisize;
       int mpiret = sc_MPI_Comm_size (sc_MPI_COMM_WORLD, &mpisize);
       SC_CHECK_MPI (mpiret);
-      if (MPI_size > T8_VTK_TEST_NUM_PROCS) {
+      if (mpisize > T8_VTK_TEST_NUM_PROCS) {
         GTEST_SKIP ();
       } 
       file_type = std::get<0>(GetParam());


### PR DESCRIPTION
First I enhanced the tests by checking also the partitioned read (only one proc reads) and checking different main_procs. 
An error occured that I fixed, too. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
