### PR TITLE
Fix eclass vtk corner number

### DIFF
--- a/src/t8_cmesh/t8_cmesh_netcdf.c
+++ b/src/t8_cmesh/t8_cmesh_netcdf.c
@@ -727,11 +727,11 @@ t8_cmesh_write_netcdf_coordinate_data (t8_cmesh_t cmesh,
     for (; i < t8_eclass_num_vertices[tree_class]; i++) {
       /* Stores the x-, y- and z- coordinate of the nodes */
       Mesh_node_x[num_it] =
-        vertices[3 * (t8_eclass_vtk_corner_number[tree_class][i])];
+        vertices[3 * (t8_eclass_t8_to_vtk_corner_number[tree_class][i])];
       Mesh_node_y[num_it] =
-        vertices[3 * (t8_eclass_vtk_corner_number[tree_class][i]) + 1];
+        vertices[3 * (t8_eclass_t8_to_vtk_corner_number[tree_class][i]) + 1];
       Mesh_node_z[num_it] =
-        vertices[3 * (t8_eclass_vtk_corner_number[tree_class][i]) + 2];
+        vertices[3 * (t8_eclass_t8_to_vtk_corner_number[tree_class][i]) + 2];
       /* Stores the the nodes which correspond to this element. */
       Mesh_elem_nodes[(ltree_id) * context->nMaxMesh_elem_nodes + i] =
         local_tree_offset + num_it;

--- a/src/t8_cmesh/t8_cmesh_vtk_writer.c
+++ b/src/t8_cmesh/t8_cmesh_vtk_writer.c
@@ -135,7 +135,7 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix,
       for (ivertex = 0; ivertex < t8_eclass_num_vertices[tree->eclass];
            ivertex++) {
         vertex = vertices +
-          3 * t8_eclass_vtk_to_t8corner_number[tree->eclass][ivertex];
+          3 * t8_eclass_vtk_to_t8_corner_number[tree->eclass][ivertex];
         x = vertex[0];
         y = vertex[1];
         z = vertex[2];
@@ -162,7 +162,7 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix,
         /* TODO: This code is duplicated above */
         for (ivertex = 0; ivertex < t8_eclass_num_vertices[eclass]; ivertex++) {
           vertex = vertices +
-            3 * t8_eclass_vtk_to_t8corner_number[eclass][ivertex];
+            3 * t8_eclass_vtk_to_t8_corner_number[eclass][ivertex];
           x = vertex[0];
           y = vertex[1];
           z = vertex[2];

--- a/src/t8_cmesh/t8_cmesh_vtk_writer.c
+++ b/src/t8_cmesh/t8_cmesh_vtk_writer.c
@@ -135,7 +135,7 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix,
       for (ivertex = 0; ivertex < t8_eclass_num_vertices[tree->eclass];
            ivertex++) {
         vertex = vertices +
-          3 * t8_eclass_vtk_to_t8_corner_number[tree->eclass][ivertex];
+          3 * t8_eclass_t8_to_vtk_corner_number[tree->eclass][ivertex];
         x = vertex[0];
         y = vertex[1];
         z = vertex[2];

--- a/src/t8_cmesh/t8_cmesh_vtk_writer.c
+++ b/src/t8_cmesh/t8_cmesh_vtk_writer.c
@@ -135,7 +135,7 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix,
       for (ivertex = 0; ivertex < t8_eclass_num_vertices[tree->eclass];
            ivertex++) {
         vertex = vertices +
-          3 * t8_eclass_vtk_corner_number[tree->eclass][ivertex];
+          3 * t8_eclass_vtk_to_t8corner_number[tree->eclass][ivertex];
         x = vertex[0];
         y = vertex[1];
         z = vertex[2];
@@ -162,7 +162,7 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix,
         /* TODO: This code is duplicated above */
         for (ivertex = 0; ivertex < t8_eclass_num_vertices[eclass]; ivertex++) {
           vertex = vertices +
-            3 * t8_eclass_vtk_corner_number[eclass][ivertex];
+            3 * t8_eclass_vtk_to_t8corner_number[eclass][ivertex];
           x = vertex[0];
           y = vertex[1];
           z = vertex[2];

--- a/src/t8_eclass.c
+++ b/src/t8_eclass.c
@@ -114,7 +114,7 @@ const int t8_eclass_num_edges[T8_ECLASS_COUNT] =
 const int t8_eclass_vtk_type[T8_ECLASS_COUNT] =
   { 1, 3, 9, 5, 12, 10, 13, 14 };
 
-const int t8_eclass_vtk_to_t8corner_number[T8_ECLASS_COUNT][T8_ECLASS_MAX_CORNERS] = {
+const int t8_eclass_vtk_to_t8_corner_number[T8_ECLASS_COUNT][T8_ECLASS_MAX_CORNERS] = {
   { 0, -1, -1, -1, -1, -1, -1, -1 },    /* vertex */
   { 0,  1, -1, -1, -1, -1, -1, -1 },    /* line */
   { 0,  1,  3,  2, -1, -1, -1, -1 },    /* quad */

--- a/src/t8_eclass.c
+++ b/src/t8_eclass.c
@@ -125,6 +125,17 @@ const int t8_eclass_vtk_to_t8_corner_number[T8_ECLASS_COUNT][T8_ECLASS_MAX_CORNE
   { 0,  1,  3,  2,  4, -1, -1, -1 }     /* pyramid */
 };
 
+const int t8_eclass_t8_to_vtk_corner_number[T8_ECLASS_COUNT][T8_ECLASS_MAX_CORNERS] = {
+  { 0, -1, -1, -1, -1, -1, -1, -1 },    /* vertex */
+  { 0,  1, -1, -1, -1, -1, -1, -1 },    /* line */
+  { 0,  1,  3,  2, -1, -1, -1, -1 },    /* quad */
+  { 0,  1,  2, -1, -1, -1, -1, -1 },    /* triangle */
+  { 0,  1,  3,  2,  4,  5,  7,  6 },    /* hex */
+  { 0,  2,  1,  3, -1, -1, -1, -1 },    /* tet */
+  { 0,  2,  1,  3,  5,  4, -1, -1 },    /* prism */
+  { 0,  1,  3,  2,  4, -1, -1, -1 }     /* pyramid */
+};
+
 const int t8_eclass_face_types[T8_ECLASS_COUNT][T8_ECLASS_MAX_FACES] = {
   {-1, -1, -1, -1, -1, -1 },    /* vertex */
   { 0,  0, -1, -1, -1, -1 },    /* line */

--- a/src/t8_eclass.c
+++ b/src/t8_eclass.c
@@ -114,7 +114,7 @@ const int t8_eclass_num_edges[T8_ECLASS_COUNT] =
 const int t8_eclass_vtk_type[T8_ECLASS_COUNT] =
   { 1, 3, 9, 5, 12, 10, 13, 14 };
 
-const int t8_eclass_vtk_corner_number[T8_ECLASS_COUNT][T8_ECLASS_MAX_CORNERS] = {
+const int t8_eclass_vtk_to_t8corner_number[T8_ECLASS_COUNT][T8_ECLASS_MAX_CORNERS] = {
   { 0, -1, -1, -1, -1, -1, -1, -1 },    /* vertex */
   { 0,  1, -1, -1, -1, -1, -1, -1 },    /* line */
   { 0,  1,  3,  2, -1, -1, -1, -1 },    /* quad */

--- a/src/t8_eclass.h
+++ b/src/t8_eclass.h
@@ -135,10 +135,15 @@ extern const int    t8_eclass_num_edges[T8_ECLASS_COUNT];
 /** The vtk cell type for the eclass */
 extern const int    t8_eclass_vtk_type[T8_ECLASS_COUNT];
 
+/* *INDENT-OFF* */
+/** Map the vtk corner number to the t8 corner number */
+extern const int   
+  t8_eclass_vtk_to_t8_corner_number[T8_ECLASS_COUNT][T8_ECLASS_MAX_CORNERS];
+
 /** Map the t8code corner number to the vtk corner number */
-extern const int
-   
-   t8_eclass_vtk_to_t8_corner_number[T8_ECLASS_COUNT][T8_ECLASS_MAX_CORNERS];
+extern const int   
+  t8_eclass_t8_to_vtk_corner_number[T8_ECLASS_COUNT][T8_ECLASS_MAX_CORNERS];
+/* *INDENT-ON* */
 
 /** For each of the element classes, list the type of the faces. */
 extern const int

--- a/src/t8_eclass.h
+++ b/src/t8_eclass.h
@@ -137,7 +137,7 @@ extern const int    t8_eclass_vtk_type[T8_ECLASS_COUNT];
 
 /** Map the t8code corner number to the vtk corner number */
 extern const int
-     t8_eclass_vtk_corner_number[T8_ECLASS_COUNT][T8_ECLASS_MAX_CORNERS];
+     t8_eclass_vtk_to_t8corner_number[T8_ECLASS_COUNT][T8_ECLASS_MAX_CORNERS];
 
 /** For each of the element classes, list the type of the faces. */
 extern const int

--- a/src/t8_eclass.h
+++ b/src/t8_eclass.h
@@ -137,7 +137,8 @@ extern const int    t8_eclass_vtk_type[T8_ECLASS_COUNT];
 
 /** Map the t8code corner number to the vtk corner number */
 extern const int
-     t8_eclass_vtk_to_t8corner_number[T8_ECLASS_COUNT][T8_ECLASS_MAX_CORNERS];
+   
+   t8_eclass_vtk_to_t8_corner_number[T8_ECLASS_COUNT][T8_ECLASS_MAX_CORNERS];
 
 /** For each of the element classes, list the type of the faces. */
 extern const int

--- a/src/t8_element_shape.c
+++ b/src/t8_element_shape.c
@@ -57,7 +57,7 @@ t8_element_shape_vtk_type (int element_shape)
 int
 t8_element_shape_vtk_corner_number (int element_shape, int index)
 {
-  return t8_eclass_vtk_corner_number[element_shape][index];
+  return t8_eclass_vtk_to_t8corner_number[element_shape][index];
 }
 
 /** For each element_shape, the name of this class as a string */

--- a/src/t8_element_shape.c
+++ b/src/t8_element_shape.c
@@ -57,7 +57,7 @@ t8_element_shape_vtk_type (int element_shape)
 int
 t8_element_shape_vtk_corner_number (int element_shape, int index)
 {
-  return t8_eclass_vtk_to_t8corner_number[element_shape][index];
+  return t8_eclass_vtk_to_t8_corner_number[element_shape][index];
 }
 
 /** For each element_shape, the name of this class as a string */

--- a/src/t8_element_shape.c
+++ b/src/t8_element_shape.c
@@ -57,7 +57,7 @@ t8_element_shape_vtk_type (int element_shape)
 int
 t8_element_shape_vtk_corner_number (int element_shape, int index)
 {
-  return t8_eclass_vtk_to_t8_corner_number[element_shape][index];
+  return t8_eclass_t8_to_vtk_corner_number[element_shape][index];
 }
 
 /** For each element_shape, the name of this class as a string */

--- a/src/t8_forest/t8_forest_vtk.cxx
+++ b/src/t8_forest/t8_forest_vtk.cxx
@@ -710,7 +710,7 @@ t8_forest_vtk_cells_vertices_kernel (t8_forest_t forest,
   num_el_vertices = t8_eclass_num_vertices[element_shape];
   for (ivertex = 0; ivertex < num_el_vertices; ivertex++) {
     t8_forest_element_coordinate (forest, ltree_id, element,
-                                  t8_eclass_vtk_to_t8_corner_number
+                                  t8_eclass_t8_to_vtk_corner_number
                                   [element_shape]
                                   [ivertex], element_coordinates);
     freturn = fprintf (vtufile, "         ");

--- a/src/t8_forest/t8_forest_vtk.cxx
+++ b/src/t8_forest/t8_forest_vtk.cxx
@@ -710,7 +710,8 @@ t8_forest_vtk_cells_vertices_kernel (t8_forest_t forest,
   num_el_vertices = t8_eclass_num_vertices[element_shape];
   for (ivertex = 0; ivertex < num_el_vertices; ivertex++) {
     t8_forest_element_coordinate (forest, ltree_id, element,
-                                  t8_eclass_vtk_corner_number[element_shape]
+                                  t8_eclass_vtk_to_t8corner_number
+                                  [element_shape]
                                   [ivertex], element_coordinates);
     freturn = fprintf (vtufile, "         ");
     if (freturn <= 0) {

--- a/src/t8_forest/t8_forest_vtk.cxx
+++ b/src/t8_forest/t8_forest_vtk.cxx
@@ -710,7 +710,7 @@ t8_forest_vtk_cells_vertices_kernel (t8_forest_t forest,
   num_el_vertices = t8_eclass_num_vertices[element_shape];
   for (ivertex = 0; ivertex < num_el_vertices; ivertex++) {
     t8_forest_element_coordinate (forest, ltree_id, element,
-                                  t8_eclass_vtk_to_t8corner_number
+                                  t8_eclass_vtk_to_t8_corner_number
                                   [element_shape]
                                   [ivertex], element_coordinates);
     freturn = fprintf (vtufile, "         ");

--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -66,3 +66,17 @@ TEST (t8_gtest_eclass, compare)
     }
   }
 }
+
+TEST (t8_gtest_eclass, t8_to_vtk_corner_numbers)
+{
+  for (int ieclass = T8_ECLASS_ZERO; ieclass < T8_ECLASS_COUNT; ieclass++) {
+    const int           num_vertices = t8_eclass_num_vertices[ieclass];
+    for (int ivertex = 0; ivertex < num_vertices; ivertex++) {
+      const int           vtk_corner_number =
+        t8_eclass_t8_to_vtk_corner_number[ieclass][ivertex];
+      const int           t8_corner_number =
+        t8_eclass_vtk_to_t8_corner_number[ieclass][vtk_corner_number];
+      EXPECT_EQ (ivertex, t8_corner_number);
+    }
+  }
+}


### PR DESCRIPTION
Closes #104 
Adds new look-up table, updates the look-up tables used in the function and adds a test for the look-up table. 


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
