### PR TITLE
Parametrize gtest eclass

### DIFF
--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -39,22 +39,23 @@ TEST (t8_gtest_eclass, eclassCountIs8)
   EXPECT_EQ (T8_ECLASS_COUNT, 8);
 }
 
+TEST (t8_gtest_eclass, invalid_class)
+{
+  EXPECT_FALSE (t8_eclass_is_valid ((t8_eclass_t) T8_ECLASS_INVALID));
+}
+
 TEST_P (t8_gtest_eclass, dimension)
 {
   int                 eclass_dims[8] = { 0, 1, 2, 2, 3, 3, 3, 3 };
   EXPECT_EQ (t8_eclass_to_dimension[ieclass], eclass_dims[ieclass]);
 }
 
-TEST (t8_gtest_eclass, valid_class)
+TEST_P (t8_gtest_eclass, valid_class)
 {
   int                 eclass;
   for (eclass = T8_ECLASS_ZERO; eclass < T8_ECLASS_COUNT; ++eclass) {
     EXPECT_TRUE (t8_eclass_is_valid ((t8_eclass_t) eclass));
   }
-  for (eclass = T8_ECLASS_COUNT; eclass <= T8_ECLASS_INVALID; ++eclass) {
-    EXPECT_FALSE (t8_eclass_is_valid ((t8_eclass_t) eclass));
-  }
-
 }
 
 TEST (t8_gtest_eclass, compare)

--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -24,18 +24,25 @@
 #include <gtest/gtest.h>
 #include <t8_eclass.h>
 
+/* *INDENT-OFF* */
+class t8_gtest_eclass : public testing::TestWithParam<int>{
+protected:
+  void SetUP() override {
+    ieclass = GetParam();
+  }
+  int ieclass;
+};
+/* *INDENT-ON* */
+
 TEST (t8_gtest_eclass, eclassCountIs8)
 {
   EXPECT_EQ (T8_ECLASS_COUNT, 8);
 }
 
-TEST (t8_gtest_eclass, dimension)
+TEST_P (t8_gtest_eclass, dimension)
 {
   int                 eclass_dims[8] = { 0, 1, 2, 2, 3, 3, 3, 3 };
-
-  for (int eci = T8_ECLASS_ZERO; eci < T8_ECLASS_COUNT; ++eci) {
-    EXPECT_EQ (t8_eclass_to_dimension[eci], eclass_dims[eci]);
-  }
+  EXPECT_EQ (t8_eclass_to_dimension[ieclass], eclass_dims[ieclass]);
 }
 
 TEST (t8_gtest_eclass, valid_class)
@@ -80,3 +87,6 @@ TEST (t8_gtest_eclass, t8_to_vtk_corner_numbers)
     }
   }
 }
+
+INSTANTIATE_TEST_SUITE_P (t8_gtest_eclass,
+                          testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));

--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -55,19 +55,17 @@ TEST_P (t8_gtest_eclass, valid_class)
   EXPECT_TRUE (t8_eclass_is_valid ((t8_eclass_t) ieclass));
 }
 
-TEST (t8_gtest_eclass, compare)
+TEST_P (t8_gtest_eclass, compare)
 {
-  int                 eci, ecj;
-  for (eci = T8_ECLASS_ZERO; eci < T8_ECLASS_COUNT; ++eci) {
-    for (ecj = T8_ECLASS_ZERO; ecj < T8_ECLASS_COUNT; ++ecj) {
-      if (eci == ecj) {
-        EXPECT_FALSE (t8_eclass_compare
-                      ((t8_eclass_t) eci, (t8_eclass_t) ecj));
-      }
-      else if (t8_eclass_to_dimension[eci] == t8_eclass_to_dimension[ecj]) {
-        EXPECT_TRUE (t8_eclass_compare
-                     ((t8_eclass_t) eci, (t8_eclass_t) ecj));
-      }
+  for (int jeclass = T8_ECLASS_ZERO; jeclass < T8_ECLASS_COUNT; ++jeclass) {
+    if (ieclass == jeclass) {
+      EXPECT_FALSE (t8_eclass_compare
+                    ((t8_eclass_t) ieclass, (t8_eclass_t) jeclass));
+    }
+    else if (t8_eclass_to_dimension[ieclass] ==
+             t8_eclass_to_dimension[jeclass]) {
+      EXPECT_TRUE (t8_eclass_compare
+                   ((t8_eclass_t) ieclass, (t8_eclass_t) jeclass));
     }
   }
 }

--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -46,7 +46,7 @@ TEST (gtest_eclass, invalid_class)
 
 TEST_P (gtest_eclass, dimension)
 {
-  int                 eclass_dims[8] = { 0, 1, 2, 2, 3, 3, 3, 3 };
+  const int           eclass_dims[8] = { 0, 1, 2, 2, 3, 3, 3, 3 };
   EXPECT_EQ (t8_eclass_to_dimension[ieclass], eclass_dims[ieclass]);
 }
 

--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -70,17 +70,15 @@ TEST_P (t8_gtest_eclass, compare)
   }
 }
 
-TEST (t8_gtest_eclass, t8_to_vtk_corner_numbers)
+TEST_P (t8_gtest_eclass, t8_to_vtk_corner_numbers)
 {
-  for (int ieclass = T8_ECLASS_ZERO; ieclass < T8_ECLASS_COUNT; ieclass++) {
-    const int           num_vertices = t8_eclass_num_vertices[ieclass];
-    for (int ivertex = 0; ivertex < num_vertices; ivertex++) {
-      const int           vtk_corner_number =
-        t8_eclass_t8_to_vtk_corner_number[ieclass][ivertex];
-      const int           t8_corner_number =
-        t8_eclass_vtk_to_t8_corner_number[ieclass][vtk_corner_number];
-      EXPECT_EQ (ivertex, t8_corner_number);
-    }
+  const int           num_vertices = t8_eclass_num_vertices[ieclass];
+  for (int ivertex = 0; ivertex < num_vertices; ivertex++) {
+    const int           vtk_corner_number =
+      t8_eclass_t8_to_vtk_corner_number[ieclass][ivertex];
+    const int           t8_corner_number =
+      t8_eclass_vtk_to_t8_corner_number[ieclass][vtk_corner_number];
+    EXPECT_EQ (ivertex, t8_corner_number);
   }
 }
 

--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -52,10 +52,7 @@ TEST_P (t8_gtest_eclass, dimension)
 
 TEST_P (t8_gtest_eclass, valid_class)
 {
-  int                 eclass;
-  for (eclass = T8_ECLASS_ZERO; eclass < T8_ECLASS_COUNT; ++eclass) {
-    EXPECT_TRUE (t8_eclass_is_valid ((t8_eclass_t) eclass));
-  }
+  EXPECT_TRUE (t8_eclass_is_valid ((t8_eclass_t) ieclass));
 }
 
 TEST (t8_gtest_eclass, compare)

--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -25,37 +25,37 @@
 #include <t8_eclass.h>
 
 /* *INDENT-OFF* */
-class t8_gtest_eclass : public testing::TestWithParam<int>{
+class gtest_eclass : public testing::TestWithParam<int>{
 protected:
-  void SetUP() override {
+  void SetUp() override {
     ieclass = GetParam();
   }
   int ieclass;
 };
 /* *INDENT-ON* */
 
-TEST (t8_gtest_eclass, eclassCountIs8)
+TEST (gtest_eclass, eclassCountIs8)
 {
   EXPECT_EQ (T8_ECLASS_COUNT, 8);
 }
 
-TEST (t8_gtest_eclass, invalid_class)
+TEST (gtest_eclass, invalid_class)
 {
   EXPECT_FALSE (t8_eclass_is_valid ((t8_eclass_t) T8_ECLASS_INVALID));
 }
 
-TEST_P (t8_gtest_eclass, dimension)
+TEST_P (gtest_eclass, dimension)
 {
   int                 eclass_dims[8] = { 0, 1, 2, 2, 3, 3, 3, 3 };
   EXPECT_EQ (t8_eclass_to_dimension[ieclass], eclass_dims[ieclass]);
 }
 
-TEST_P (t8_gtest_eclass, valid_class)
+TEST_P (gtest_eclass, valid_class)
 {
   EXPECT_TRUE (t8_eclass_is_valid ((t8_eclass_t) ieclass));
 }
 
-TEST_P (t8_gtest_eclass, compare)
+TEST_P (gtest_eclass, compare)
 {
   for (int jeclass = T8_ECLASS_ZERO; jeclass < T8_ECLASS_COUNT; ++jeclass) {
     if (ieclass == jeclass) {
@@ -70,7 +70,7 @@ TEST_P (t8_gtest_eclass, compare)
   }
 }
 
-TEST_P (t8_gtest_eclass, t8_to_vtk_corner_numbers)
+TEST_P (gtest_eclass, t8_to_vtk_corner_numbers)
 {
   const int           num_vertices = t8_eclass_num_vertices[ieclass];
   for (int ivertex = 0; ivertex < num_vertices; ivertex++) {
@@ -82,5 +82,6 @@ TEST_P (t8_gtest_eclass, t8_to_vtk_corner_numbers)
   }
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_eclass,
-                          testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_eclass, gtest_eclass,
+                          testing::Range ((int) T8_ECLASS_ZERO,
+                                          (int) T8_ECLASS_COUNT));


### PR DESCRIPTION
Closes #600 

Parametrize the eclass test. Seperate the valid-class check into two seperate functions. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
