### PR TITLE
Fix serial build

### DIFF
--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -330,7 +330,7 @@ t8_forest_no_overlap (t8_forest_t forest)
   int                 has_overlap_local_global;
   int                 mpiret =
     sc_MPI_Allreduce (&has_overlap_local, &has_overlap_local_global,
-                      1, MPI_INT, sc_MPI_MAX, forest->mpicomm);
+                      1, sc_MPI_INT, sc_MPI_MAX, forest->mpicomm);
   SC_CHECK_MPI (mpiret);
 
   T8_ASSERT (has_overlap_local_global == 0 || has_overlap_local_global == 1);


### PR DESCRIPTION
**_Describe your changes here:_**

Adapt MPI_INT to sc_MPI_INT to enable serial build

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] New Datatypes are added to t8indent_custom_datatypes.txt
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
