### PR TITLE
Fix t8_element_child for quads and hexs when input=output

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -156,7 +156,7 @@ t8_default_scheme_hex_c::t8_element_child (const t8_element_t *elem,
   r->y = childid & 0x02 ? (q->y | shift) : q->y;
   r->z = childid & 0x04 ? (q->z | shift) : q->z;
   r->level = q->level + 1;
-  if(q!=r){
+  if (q != r) {
     T8_ASSERT (p8est_quadrant_is_parent (q, r));
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -156,7 +156,9 @@ t8_default_scheme_hex_c::t8_element_child (const t8_element_t *elem,
   r->y = childid & 0x02 ? (q->y | shift) : q->y;
   r->z = childid & 0x04 ? (q->z | shift) : q->z;
   r->level = q->level + 1;
-  T8_ASSERT (p8est_quadrant_is_parent (q, r));
+  if(q!=r){
+    T8_ASSERT (p8est_quadrant_is_parent (q, r));
+  }
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -204,7 +204,7 @@ t8_default_scheme_quad_c::t8_element_child (const t8_element_t *elem,
   r->y = childid & 0x02 ? (q->y | shift) : q->y;
   r->level = q->level + 1;
 
-  if(q!=r){
+  if (q != r) {
     T8_ASSERT (p4est_quadrant_is_parent (q, r));
   }
   t8_element_copy_surround (q, r);

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -203,8 +203,10 @@ t8_default_scheme_quad_c::t8_element_child (const t8_element_t *elem,
   r->x = childid & 0x01 ? (q->x | shift) : q->x;
   r->y = childid & 0x02 ? (q->y | shift) : q->y;
   r->level = q->level + 1;
-  T8_ASSERT (p4est_quadrant_is_parent (q, r));
 
+  if(q!=r){
+    T8_ASSERT (p4est_quadrant_is_parent (q, r));
+  }
   t8_element_copy_surround (q, r);
 }
 


### PR DESCRIPTION
**_Describe your changes here:_**
Currently, due to an assertion, the t8_element_child function cannot be called with the same element for input and output for quads and hexs in debug mode. According to the documentation, it should be.

This PR introduces the change that the assertion to check that the input is the parent of the output is only called, when input and output element differ.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] New Datatypes are added to t8indent_custom_datatypes.txt
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
