### PR TITLE
Implemented wrapper for sc_shmem_prefix

### DIFF
--- a/src/t8_data/t8_shmem.c
+++ b/src/t8_data/t8_shmem.c
@@ -218,6 +218,18 @@ t8_shmem_array_allgather (const void *sendbuf, int sendcount,
                       recvcount, recvtype, recvarray->comm);
 }
 
+void
+t8_shmem_array_prefix (const void *sendbuf,
+                       t8_shmem_array_t recvarray,
+                       const int count,
+                       sc_MPI_Datatype type, sc_MPI_Op op, sc_MPI_Comm comm)
+{
+  T8_ASSERT (t8_shmem_array_is_initialized (recvarray));
+  T8_ASSERT (!t8_shmem_array_is_writing_possible (recvarray));
+
+  sc_shmem_prefix ((void *) sendbuf, recvarray->array, count, type, op, comm);
+}
+
 /**
  * Computes the recvcounter- and displacement array for 
  * an MPI_Gatherv

--- a/src/t8_data/t8_shmem.h
+++ b/src/t8_data/t8_shmem.h
@@ -172,6 +172,29 @@ void                t8_shmem_array_allgatherv (void *sendbuf,
                                                sc_MPI_Datatype
                                                recvtype, sc_MPI_Comm comm);
 
+/**
+ * Fill a t8_shmem array with an Allgather of the prefix operation over all 
+ * processes. 
+ * 
+ * The recieve array will be
+ * (0, send0, send0 op send1, send0 op send1 op send2, ...)
+ * 
+ * \note the first entry of \a recvarray will be set to 0 using memset. 
+ * The entry can be changed after calling t8_shmem_array_prefix 
+ * 
+ * @param sendbuf 
+ * @param recvarray 
+ * @param count 
+ * @param type 
+ * @param op 
+ * @param comm 
+ */
+void                t8_shmem_array_prefix (const void *sendbuf,
+                                           t8_shmem_array_t recvarray,
+                                           const int count,
+                                           sc_MPI_Datatype type,
+                                           sc_MPI_Op op, sc_MPI_Comm comm);
+
 /** Return the MPI communicator associated with a shmem array.
  * \param [in]          array The shmem_array to be queried.
  * \return              The MPI communicator stored at \a array.


### PR DESCRIPTION
Wrapper for sc_shmem_prefix + a simple test. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
