### PR TITLE
update github runners to 22.04 due to new doxygen version requirements

### DIFF
--- a/.github/workflows/add_release_documentation.yml
+++ b/.github/workflows/add_release_documentation.yml
@@ -38,8 +38,8 @@ on:
 jobs:
   add_release_doc:
 
-    runs-on: ubuntu-20.04
-    
+    runs-on: ubuntu-22.04
+
     timeout-minutes: 10
     steps:
 # check if release is at least a minor release

--- a/.github/workflows/update_documentation.yml
+++ b/.github/workflows/update_documentation.yml
@@ -37,8 +37,8 @@ on:
 jobs:
   update_dev_doc:
 
-    runs-on: ubuntu-20.04
-    
+    runs-on: ubuntu-22.04
+
     timeout-minutes: 10
     steps:
 #


### PR DESCRIPTION
**_Describe your changes here:_**
Our new doxyfiles require doxygen > 1.9 but the standard version for ubuntu 20.04 is 1.8.x. Therefore we upgrade to Ubuntu 22.04


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
