### PR TITLE
Use t8_vec-functions that do the same to reduce code duplication

### DIFF
--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -469,35 +469,6 @@ t8_cmesh_set_tree_class (t8_cmesh_t cmesh, t8_gloidx_t gtree_id,
 #endif
 }
 
-/* Compute erg = v_1 . v_2
- * the 3D scalar product.
- */
-static double
-t8_cmesh_tree_vertices_dot (double *v_1, double *v_2)
-{
-  double              erg = 0;
-  int                 i;
-
-  for (i = 0; i < 3; i++) {
-    erg += v_1[i] * v_2[i];
-  }
-  return erg;
-}
-
-/* Compute erg = v_1 x v_2
- * the 3D cross product.
- */
-static void
-t8_cmesh_tree_vertices_cross (double *v_1, double *v_2, double *erg)
-{
-  int                 i;
-
-  for (i = 0; i < 3; i++) {
-    erg[i] = v_1[(i + 1) % 3] * v_2[(i + 2) % 3]
-      - v_1[(i + 2) % 3] * v_2[(i + 1) % 3];
-  }
-}
-
 /* Given a set of vertex coordinates for a tree of a given eclass.
  * Query whether the geometric volume of the tree with this coordinates
  * would be negative.
@@ -557,9 +528,9 @@ t8_cmesh_tree_vertices_negative_volume (t8_eclass_t eclass,
     v_j[i] = vertices[3 * j + i] - vertices[i];
   }
   /* compute cross = v_1 x v_2 */
-  t8_cmesh_tree_vertices_cross (v_1, v_2, cross);
+  t8_vec_cross (v_1, v_2, cross);
   /* Compute sc_prod = <v_j, cross> */
-  sc_prod = t8_cmesh_tree_vertices_dot (v_j, cross);
+  sc_prod = t8_vec_dot (v_j, cross);
 
   T8_ASSERT (sc_prod != 0);
   return eclass == T8_ECLASS_TET ? sc_prod > 0 : sc_prod < 0;


### PR DESCRIPTION
Title says it all. 


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
