### PR TITLE
Add check to only commit and push if there are changes

### DIFF
--- a/.github/workflows/update_documentation.yml
+++ b/.github/workflows/update_documentation.yml
@@ -101,3 +101,4 @@ jobs:
         git add content/doc/dev/
         git commit -m "Add newest documentation"
         git push --force-with-lease
+        

--- a/.github/workflows/update_documentation.yml
+++ b/.github/workflows/update_documentation.yml
@@ -88,7 +88,12 @@ jobs:
         rm -rf doc/dev/*
         mkdir -p doc/dev
         cp -r ../../build_debug/doc/html/* doc/dev/
+    - name: check_diff
+      run: |
+        cd t8code-website
+        git diff --quiet || echo "::set-output name=commit_new_doc::true"
     - name: Commit and push files
+      if: steps.check_diff.outputs.commit_new_doc == 'true'
       run: |
         cd t8code-website
         git config --local user.email "t8ddy.bot@gmail.com"


### PR DESCRIPTION
The workflow update_documentation failed if no changes where to commit. 
This PR should fix it by looking at git diff befor commiting. 

Test-run: https://github.com/DLR-AMR/t8code/actions/runs/5645602999/job/15291708751
**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
