### PR TITLE
Fix minor typo in pyramid scheme.

### DIFF
--- a/example/cmesh/t8_cmesh_set_join_by_vertices.cxx
+++ b/example/cmesh/t8_cmesh_set_join_by_vertices.cxx
@@ -31,7 +31,7 @@
 
 /* This program tests the `t8_set_join_by_vertices` routine by reading in
  * a given mesh file, retrieving the vertices and building the face
- * connectivity. The results are then compared to the connectivty information from
+ * connectivity. The results are then compared to the connectivity information from
  * `cmesh` object. If there a differences they are printed to stdout.
  */
 

--- a/src/t8_cmesh/t8_cmesh_helpers.h
+++ b/src/t8_cmesh/t8_cmesh_helpers.h
@@ -34,7 +34,7 @@
 
 T8_EXTERN_C_BEGIN ();
 
-/** Sets the face connectivity information of an un-commited \cmesh based on a list of tree vertices.
+/** Sets the face connectivity information of an un-committed \cmesh based on a list of tree vertices.
  * \param[in,out]   cmesh         Pointer to a t8code cmesh object. If set to NULL this argument is ignored.
  * \param[in]       ntrees        Number of coarse mesh elements resp. trees.
  * \param[in]       vertices      List of per element vertices with dimensions [ntrees,T8_ECLASS_MAX_CORNERS,T8_ECLASS_MAX_DIM].
@@ -45,7 +45,7 @@ T8_EXTERN_C_BEGIN ();
                                   testing purposes. The dimension of \a connectivity are [ntrees,T8_ECLASS_MAX_FACES,3].
                                   For each element and each face the following is stored:
                                       neighbor_tree_id, neighbor_dual_face_id, orientation
- * \param[in]       do_both_directions Compute the connectivty from both neighboring sides. Takes much longer to compute.
+ * \param[in]       do_both_directions Compute the connectivity from both neighboring sides. Takes much longer to compute.
 
   \warning This routine might be too expensive for very large meshes. In this case, consider to use a fully featured mesh generator.
 

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid.h
@@ -34,7 +34,7 @@
 #define T8_DPYRAMID_NUM_TYPES 8
 
 /** The type of the root pyramid*/
-#define T8_DPYRAMID_ROOT_TPYE 6
+#define T8_DPYRAMID_ROOT_TYPE 6
 
 /** The first type of pyramids in the shape of a pyramid*/
 #define T8_DPYRAMID_FIRST_TYPE 6

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -80,7 +80,7 @@ compute_type_same_shape_ext (const t8_dpyramid_t *p, const int level,
   }
   if (level == 0) {
     /*Type of the root pyra */
-    return T8_DPYRAMID_ROOT_TPYE;
+    return T8_DPYRAMID_ROOT_TYPE;
   }
   for (int i = known_level; i > level; i--) {
     const t8_dpyramid_cube_id_t cube_id = compute_cubeid (p, i);
@@ -542,7 +542,7 @@ t8_dpyramid_init_linear_id (t8_dpyramid_t *p, const int level,
   p->pyramid.x = 0;
   p->pyramid.y = 0;
   p->pyramid.z = 0;
-  t8_dpyramid_type_t  type = T8_DPYRAMID_ROOT_TPYE;     /*This is the type of the root pyramid */
+  t8_dpyramid_type_t  type = T8_DPYRAMID_ROOT_TYPE;     /*This is the type of the root pyramid */
   for (int i = 1; i <= level; i++) {
     const int           offset_expo = T8_DPYRAMID_MAXLEVEL - i;
     p_sum1 >>= 3;
@@ -992,7 +992,7 @@ t8_dpyramid_is_inside_root (const t8_dpyramid_t *p)
              && p->pyramid.level <= T8_DPYRAMID_MAXLEVEL);
   /*Check, if p is root pyramid */
   if (p->pyramid.level == 0) {
-    return p->pyramid.type == T8_DPYRAMID_ROOT_TPYE && p->pyramid.x == 0
+    return p->pyramid.type == T8_DPYRAMID_ROOT_TYPE && p->pyramid.x == 0
       && p->pyramid.y == 0 && p->pyramid.z == 0;
   }
   /*Check, if all coordinates are in the limit set by the length of root */
@@ -1351,7 +1351,7 @@ t8_dpyramid_extrude_face (const t8_element_t *face, t8_dpyramid_t *p,
     p->pyramid.x = ((int64_t) q->x * T8_DPYRAMID_ROOT_LEN) / P4EST_ROOT_LEN;
     p->pyramid.y = ((int64_t) q->y * T8_DPYRAMID_ROOT_LEN) / P4EST_ROOT_LEN;
     p->pyramid.z = 0;
-    p->pyramid.type = T8_DPYRAMID_ROOT_TPYE;
+    p->pyramid.type = T8_DPYRAMID_ROOT_TYPE;
     p->pyramid.level = q->level;
     p->switch_shape_at_level = -1;
     return root_face;
@@ -1993,7 +1993,7 @@ t8_dpyramid_is_valid (const t8_dpyramid_t *p)
     && p->pyramid.type < T8_DPYRAMID_NUM_TYPES;
 
   if (p->pyramid.level == 0) {
-    is_valid = is_valid && (p->pyramid.type == T8_DPYRAMID_ROOT_TPYE);
+    is_valid = is_valid && (p->pyramid.type == T8_DPYRAMID_ROOT_TYPE);
   }
   if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
     is_valid = is_valid && (p->switch_shape_at_level > 0);

--- a/test/t8_schemes/t8_gtest_pyra_connectivity.cxx
+++ b/test/t8_schemes/t8_gtest_pyra_connectivity.cxx
@@ -40,11 +40,11 @@ TEST (pyramid_connectivity, cid_type_to_parenttype_check)
   t8_dpyramid_type_t  pyra_parent_type;
   t8_dpyramid_type_t  type;
   /* iterate over all pyramid-types */
-  for (type = T8_DPYRAMID_ROOT_TPYE; type <= T8_DPYRAMID_SECOND_TYPE; type++) {
+  for (type = T8_DPYRAMID_ROOT_TYPE; type <= T8_DPYRAMID_SECOND_TYPE; type++) {
     /* iterate over all cube-ids */
     for (cid = 0; cid < 8; cid++) {
       pyra_parent_type =
-        t8_dpyramid_type_cid_to_parenttype[type - T8_DPYRAMID_ROOT_TPYE][cid];
+        t8_dpyramid_type_cid_to_parenttype[type - T8_DPYRAMID_ROOT_TYPE][cid];
       parent_type = t8_dpyramid_cid_type_to_parenttype[cid][type];
       EXPECT_EQ (parent_type, pyra_parent_type);
     }
@@ -69,16 +69,16 @@ TEST (pyramid_connectivity, cid_type_parenttype)
     /* Number of children depends on the parent-type */
     max_Iloc =
       p_type <
-      T8_DPYRAMID_ROOT_TPYE ? T8_DTET_CHILDREN : T8_DPYRAMID_CHILDREN;
+      T8_DPYRAMID_ROOT_TYPE ? T8_DTET_CHILDREN : T8_DPYRAMID_CHILDREN;
     for (t8_locidx_t Iloc = 0; Iloc < max_Iloc; Iloc++) {
       type = t8_dpyramid_parenttype_Iloc_to_type[p_type][Iloc];
       cid = t8_dpyramid_parenttype_Iloc_to_cid[p_type][Iloc];
       /*Look-up of parent-type depends on the parent-type and the type of the element itself */
-      if (p_type < T8_DPYRAMID_ROOT_TPYE) {
+      if (p_type < T8_DPYRAMID_ROOT_TYPE) {
         check_type = t8_dpyramid_cid_type_to_parenttype[cid][type];
       }
       else {
-        if (type < T8_DPYRAMID_ROOT_TPYE) {
+        if (type < T8_DPYRAMID_ROOT_TYPE) {
           check_type = t8_dtet_type_cid_to_pyramid_parenttype[type][cid];
         }
         else {


### PR DESCRIPTION
**_Describe your changes here:_**

Title says it all.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
