### PR TITLE
Pretify Data-writing

### DIFF
--- a/src/t8_forest/t8_forest_vtk.cxx
+++ b/src/t8_forest/t8_forest_vtk.cxx
@@ -655,17 +655,19 @@ t8_forest_to_vtkUnstructuredGrid (t8_forest_t forest,
    */
   for (int idata = 0; idata < num_data; idata++) {
     dataArrays[idata] = vtkDoubleArray::New ();
-    if (data[idata].type == T8_VTK_SCALAR) {
-      dataArrays[idata]->SetName (data[idata].description);     /* Set the name of the array */
-      dataArrays[idata]->SetVoidArray (data[idata].data, num_elements, 1);      /* We write the data in the array from the input array */
-      unstructuredGrid->GetCellData ()->AddArray (dataArrays[idata]);   /* We add the array to the cell data object */
+    const int           num_components =
+      data[idata].type == T8_VTK_SCALAR ? 1 : 3;
+    dataArrays[idata]->SetName (data[idata].description);       /* Set the name of the array */
+    dataArrays[idata]->SetNumberOfTuples (num_elements);        /* We want number of tuples=number of elements */
+    dataArrays[idata]->SetNumberOfComponents (num_components);  /* Each tuples has 3 values */
+    dataArrays[idata]->SetVoidArray (data[idata].data,
+                                     num_elements * num_components, 1);
+    if (num_components == 1) {
+      unstructuredGrid->GetCellData ()->SetScalars (dataArrays[idata]);
     }
     else {
-      dataArrays[idata]->SetName (data[idata].description);     /* Set the name of the array */
-      dataArrays[idata]->SetNumberOfTuples (num_elements);      /* We want number of tuples=number of elements */
-      dataArrays[idata]->SetNumberOfComponents (3);     /* Each tuples has 3 values */
-      dataArrays[idata]->SetVoidArray (data[idata].data, num_elements * 3, 1);  /*  */
-      unstructuredGrid->GetCellData ()->SetVectors (dataArrays[idata]); /*  */
+      unstructuredGrid->GetCellData ()->SetVectors (dataArrays[idata]);
+
     }
   }
 


### PR DESCRIPTION
Simplified data-writing and used the proper functions to set scalars. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
