### PR TITLE
Feature puma patches [8/x] Batch processing of tree ref_coords [3/x] Curved geometries

### DIFF
--- a/.github/workflows/add_release_documentation.yml
+++ b/.github/workflows/add_release_documentation.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Install dependencies
       if: ${{ env.MINOR_RELEASE == 'true' }}
-      run: sudo apt-get install libz-dev doxygen
+      run: sudo apt-get install libz-dev doxygen-latex
     - name: init submodules
       if: ${{ env.MINOR_RELEASE == 'true' }}
       run: |

--- a/.github/workflows/update_documentation.yml
+++ b/.github/workflows/update_documentation.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install zlib
       run: sudo apt-get install libz-dev
     - name: Install doxygen
-      run: sudo apt-get install doxygen
+      run: sudo apt-get install doxygen-latex
     - name: init submodules
       run: git submodule init
     - name: update submodules

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1604,7 +1604,7 @@ FORMULA_MACROFILE      =
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-USE_MATHJAX            = NO
+USE_MATHJAX            = YES
 
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. See the MathJax site (see:

--- a/example/geometry/t8_example_geometries.cxx
+++ b/example/geometry/t8_example_geometries.cxx
@@ -93,7 +93,7 @@ public:
    * models the rectangle [0,2] x [0,1].
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^2 \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^2 \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -130,7 +130,7 @@ public:
   }
 };
 
-/** This geometry maps the unit square \f( [0,1]^2 \f) to the moebius strip.
+/** This geometry maps the unit square \f$ [0,1]^2 \f$ to the moebius strip.
  * The unit square can be modelled with any cmesh (consisting of any number of trees).
  * 
  * It inherits from the w_vertices geometry since we use the tree's vertex coordinates.
@@ -145,10 +145,10 @@ public:
   }
 
   /**
-   * Map a point in a point in \f( [0,1]^2 \f) to the moebius band.
+   * Map a point in a point in \f$ [0,1]^2 \f$ to the moebius band.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^2 \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^2 \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -207,7 +207,7 @@ public:
    * Map a reference point in the unit square to a cylinder.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -239,7 +239,7 @@ public:
 };
 
 /**
- * This geometry map a unit square \f( [0,1]^2 \f) cmesh to a circle with midpoint 0
+ * This geometry map a unit square \f$ [0,1]^2 \f$ cmesh to a circle with midpoint 0
  * and radius 1.
  * This geometry massively distorts elements near the boundary and should not be
  * used for actual numerical experiments.
@@ -258,7 +258,7 @@ public:
    * Map a reference point in the unit square to a circle.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^2 \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^2 \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -300,7 +300,7 @@ public:
   /* Load tree data is inherited from vertices geometry. */
 };
 
-/* This geometry rotates \f( [0,1]^2 \f) with time around the origin.
+/* This geometry rotates \f$ [0,1]^2 \f$ with time around the origin.
  * The rotation direction is reversed after 2 seconds.
  * Additionally, the z coordinate is modifyied according to the
  * sincos function and multiplied with the current time.
@@ -324,7 +324,7 @@ public:
    * Map a reference point in the unit square to a square distorted with time.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^2 \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^2 \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -376,7 +376,7 @@ protected:
   const double       *ptime;    /* Time pointer to outside time variable */
 };
 
-/** Map the unit cube \f( [0,1]^3 \f) onto a cube that is distorted
+/** Map the unit cube \f$ [0,1]^3 \f$ onto a cube that is distorted
  * in z direction.
  * Can be used with 1 tree unit cube cmesh only.
  */
@@ -392,7 +392,7 @@ public:
    * Map a reference point in the unit cube to a cube distorted in the z axis.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^3 \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^3 \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,

--- a/example/geometry/t8_example_geometries.cxx
+++ b/example/geometry/t8_example_geometries.cxx
@@ -93,7 +93,7 @@ public:
    * models the rectangle [0,2] x [0,1].
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^2.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^2 \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -130,7 +130,7 @@ public:
   }
 };
 
-/** This geometry maps the unit square [0,1]^2 to the moebius strip.
+/** This geometry maps the unit square \f( [0,1]^2 \f) to the moebius strip.
  * The unit square can be modelled with any cmesh (consisting of any number of trees).
  * 
  * It inherits from the w_vertices geometry since we use the tree's vertex coordinates.
@@ -145,10 +145,10 @@ public:
   }
 
   /**
-   * Map a point in a point in [0,1]^2 to the moebius band.
+   * Map a point in a point in \f( [0,1]^2 \f) to the moebius band.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^2.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^2 \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -207,7 +207,7 @@ public:
    * Map a reference point in the unit square to a cylinder.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -239,7 +239,7 @@ public:
 };
 
 /**
- * This geometry map a unit square [0,1]^2 cmesh to a circle with midpoint 0
+ * This geometry map a unit square \f( [0,1]^2 \f) cmesh to a circle with midpoint 0
  * and radius 1.
  * This geometry massively distorts elements near the boundary and should not be
  * used for actual numerical experiments.
@@ -258,7 +258,7 @@ public:
    * Map a reference point in the unit square to a circle.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^2.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^2 \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -300,7 +300,7 @@ public:
   /* Load tree data is inherited from vertices geometry. */
 };
 
-/* This geometry rotates [0,1]^2 with time around the origin.
+/* This geometry rotates \f( [0,1]^2 \f) with time around the origin.
  * The rotation direction is reversed after 2 seconds.
  * Additionally, the z coordinate is modifyied according to the
  * sincos function and multiplied with the current time.
@@ -324,7 +324,7 @@ public:
    * Map a reference point in the unit square to a square distorted with time.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^2.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^2 \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -376,7 +376,7 @@ protected:
   const double       *ptime;    /* Time pointer to outside time variable */
 };
 
-/** Map the unit cube [0,1]^3 onto a cube that is distorted
+/** Map the unit cube \f( [0,1]^3 \f) onto a cube that is distorted
  * in z direction.
  * Can be used with 1 tree unit cube cmesh only.
  */
@@ -392,7 +392,7 @@ public:
    * Map a reference point in the unit cube to a cube distorted in the z axis.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^3.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^3 \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -807,7 +807,7 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
       };
       t8_cmesh_set_tree_vertices (cmesh, 0, vertices0, 8);
 
-      /* The valid parameter range for bspline surfaces is [0, 1]^2. We defined the bspline surface in such a way, 
+      /* The valid parameter range for bspline surfaces is [0,1]^2. We defined the bspline surface in such a way, 
        * that parameters 0, 0.5 and 1 resemble the vertices of the connected surface. */
       double              parameters0[8] = { 0, 0,
         0.5, 0,
@@ -842,7 +842,7 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
       };
       t8_cmesh_set_tree_vertices (cmesh, 1, vertices1, 8);
 
-      /* The valid parameter range for bspline surfaces is [0, 1]^2. We defined the bspline surface in such a way, 
+      /* The valid parameter range for bspline surfaces is [0,1]^2. We defined the bspline surface in such a way, 
        *  that parameters 0, 0.5 and 1 resemble the vertices of the connected surface. */
       double              parameters1[8] = { 0.5, 0,
         1, 0,

--- a/example/geometry/t8_example_geometries.cxx
+++ b/example/geometry/t8_example_geometries.cxx
@@ -94,13 +94,17 @@ public:
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
    * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^2 \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
                                         t8_gloidx_t gtreeid,
                                         const double *ref_coords,
+                                        const int num_coords,
                                         double out_coords[3]) const
   {
+    if (num_coords != 1)
+      SC_ABORT ("Error: Batch computation of geometry not yet supported.");
     double              x = ref_coords[0];
     if                  (gtreeid == 1) {
       /* Translate ref coordinates by +1 in x direction for the second tree. */
@@ -116,6 +120,7 @@ public:
   void                t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                                                  t8_gloidx_t gtreeid,
                                                  const double *ref_coords,
+                                                 const int num_coords,
                                                  double *jacobian) const
   {
     SC_ABORT_NOT_REACHED ();
@@ -149,13 +154,17 @@ public:
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
    * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^2 \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
                                         t8_gloidx_t gtreeid,
                                         const double *ref_coords,
+                                        const int num_coords,
                                         double out_coords[3]) const
   {
+    if (num_coords != 1)
+      SC_ABORT ("Error: Batch computation of geometry not yet supported.");
     double              t;
     double              phi;
 
@@ -182,6 +191,7 @@ public:
   void                t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                                                  t8_gloidx_t gtreeid,
                                                  const double *ref_coords,
+                                                 const int num_coords,
                                                  double *jacobian) const
   {
     SC_ABORT_NOT_REACHED ();
@@ -208,13 +218,17 @@ public:
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
    * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
                                         t8_gloidx_t gtreeid,
                                         const double *ref_coords,
+                                        const int num_coords,
                                         double out_coords[3]) const
   {
+    if (num_coords != 1)
+      SC_ABORT ("Error: Batch computation of geometry not yet supported.");
     out_coords[0] = cos (ref_coords[0] * 2 * M_PI);
     out_coords[1] = ref_coords[1];
     out_coords[2] = sin (ref_coords[0] * 2 * M_PI);
@@ -224,6 +238,7 @@ public:
   void                t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                                                  t8_gloidx_t gtreeid,
                                                  const double *ref_coords,
+                                                 const int num_coords,
                                                  double *jacobian) const
   {
     SC_ABORT_NOT_REACHED ();
@@ -259,13 +274,17 @@ public:
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
    * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^2 \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
                                         t8_gloidx_t gtreeid,
                                         const double *ref_coords,
+                                        const int num_coords,
                                         double out_coords[3]) const
   {
+    if (num_coords != 1)
+      SC_ABORT ("Error: Batch computation of geometry not yet supported.");
     double              x;
     double              y;
 
@@ -292,6 +311,7 @@ public:
   void                t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                                                  t8_gloidx_t gtreeid,
                                                  const double *ref_coords,
+                                                 const int num_coords,
                                                  double *jacobian) const
   {
     SC_ABORT_NOT_REACHED ();
@@ -325,13 +345,17 @@ public:
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
    * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^2 \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
                                         t8_gloidx_t gtreeid,
                                         const double *ref_coords,
+                                        const int num_coords,
                                         double out_coords[3]) const
   {
+    if (num_coords != 1)
+      SC_ABORT ("Error: Batch computation of geometry not yet supported.");
     double              x = ref_coords[0] - .5;
     double              y = ref_coords[1] - .5;
     const double        time = *ptime;
@@ -359,6 +383,7 @@ public:
   void                t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                                                  t8_gloidx_t gtreeid,
                                                  const double *ref_coords,
+                                                 const int num_coords,
                                                  double *jacobian) const
   {
     SC_ABORT_NOT_REACHED ();
@@ -393,13 +418,17 @@ public:
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
    * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^3 \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void                t8_geom_evaluate (t8_cmesh_t cmesh,
                                         t8_gloidx_t gtreeid,
                                         const double *ref_coords,
+                                        const int num_coords,
                                         double out_coords[3]) const
   {
+    if (num_coords != 1)
+      SC_ABORT ("Error: Batch computation of geometry not yet supported.");
     out_coords[0] = ref_coords[0];
     out_coords[1] = ref_coords[1];
     out_coords[2] = ref_coords[2] * (0.8 +
@@ -411,6 +440,7 @@ public:
   void                t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                                                  t8_gloidx_t gtreeid,
                                                  const double *ref_coords,
+                                                 const int num_coords,
                                                  double *jacobian) const
   {
     SC_ABORT_NOT_REACHED ();

--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -605,17 +605,19 @@ public:
                                                           double coords[])
     const = 0;
 
-  /** Convert a point in the reference space of an element to a point in the
+  /** Convert points in the reference space of an element to points in the
    *  reference space of the tree.
    * 
    * \param [in] elem         The element.
-   * \param [in] coords_input The coordinates of the point in the reference space of the element.
-   * \param [in] user_data    User data.
-   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
+   *                          in the reference space of the element.
+   * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [out] out_coords  The coordinates of the points in the
+   *                          reference space of the tree.
    */
   virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
-                                                   const void *user_data,
+                                                   const int num_coords,
                                                    double *out_coords)
     const = 0;
 

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -440,7 +440,7 @@ t8_forest_element_from_ref_coords (t8_forest_t forest, t8_locidx_t ltreeid,
   const t8_eclass_t   tree_class = t8_forest_get_tree_class (forest, ltreeid);
   const t8_eclass_scheme_c *scheme =
     t8_forest_get_eclass_scheme (forest, tree_class);
-  scheme->t8_element_reference_coords (element, ref_coords, NULL,
+  scheme->t8_element_reference_coords (element, ref_coords, 1,
                                        tree_ref_coords);
   const t8_cmesh_t    cmesh = t8_forest_get_cmesh (forest);
   const t8_gloidx_t   gtreeid = t8_forest_global_tree_id (forest, ltreeid);

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -426,13 +426,14 @@ t8_forest_element_coordinate (t8_forest_t forest, t8_locidx_t ltree_id,
   /* Get the cmesh */
   cmesh = t8_forest_get_cmesh (forest);
   /* Evaluate the geometry */
-  t8_geometry_evaluate (cmesh, gtreeid, vertex_coords, coordinates);
+  t8_geometry_evaluate (cmesh, gtreeid, vertex_coords, 1, coordinates);
 }
 
 void
 t8_forest_element_from_ref_coords (t8_forest_t forest, t8_locidx_t ltreeid,
                                    const t8_element_t *element,
                                    const double *ref_coords,
+                                   const int num_coords,
                                    double *coords_out,
                                    sc_array_t *stretch_factors)
 {
@@ -440,11 +441,12 @@ t8_forest_element_from_ref_coords (t8_forest_t forest, t8_locidx_t ltreeid,
   const t8_eclass_t   tree_class = t8_forest_get_tree_class (forest, ltreeid);
   const t8_eclass_scheme_c *scheme =
     t8_forest_get_eclass_scheme (forest, tree_class);
-  scheme->t8_element_reference_coords (element, ref_coords, 1,
+  scheme->t8_element_reference_coords (element, ref_coords, num_coords,
                                        tree_ref_coords);
   const t8_cmesh_t    cmesh = t8_forest_get_cmesh (forest);
   const t8_gloidx_t   gtreeid = t8_forest_global_tree_id (forest, ltreeid);
-  t8_geometry_evaluate (cmesh, gtreeid, tree_ref_coords, coords_out);
+  t8_geometry_evaluate (cmesh, gtreeid, tree_ref_coords, num_coords,
+                        coords_out);
 }
 
 /* Compute the diameter of an element. */

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -508,7 +508,7 @@ t8_forest_element_centroid (t8_forest_t forest, t8_locidx_t ltreeid,
   element_shape = t8_element_shape (ts, element);
   t8_forest_element_from_ref_coords (forest, ltreeid, element,
                                      t8_element_centroid_ref_coords
-                                     [element_shape], coordinates, NULL);
+                                     [element_shape], 1, coordinates, NULL);
 }
 
 /* Compute the length of the line from one corner to a second corner in an element */

--- a/src/t8_forest/t8_forest_geometrical.h
+++ b/src/t8_forest/t8_forest_geometrical.h
@@ -59,6 +59,7 @@ void                t8_forest_element_coordinate (t8_forest_t forest,
  * \param [in]      ltreeid           The forest local id of the tree in which the element is.
  * \param [in]      element           The element.
  * \param [in]      ref_coord         The reference coordinates of the point inside the element.
+ * \param [in]      num_coords        The number of coordinate sets in ref_coord (dimension x double).
  * \param [out]     coords_out        On input an allocated array to store 3 doubles, on output
  *                                    the x, y and z coordinates of the point inside the domain.
  * \param [in]      stretch_factors   An element-wise array with d (dimension) doubles per element, 
@@ -72,6 +73,7 @@ void                t8_forest_element_from_ref_coords (t8_forest_t forest,
                                                        *element,
                                                        const double
                                                        *ref_coord,
+                                                       const int num_coords,
                                                        double *coords_out,
                                                        sc_array_t
                                                        *stretch_factors);

--- a/src/t8_forest/t8_forest_vtk.cxx
+++ b/src/t8_forest/t8_forest_vtk.cxx
@@ -228,7 +228,7 @@ t8_forest_vtk_get_element_nodes (t8_forest_t forest, t8_locidx_t ltreeid,
   const double       *ref_coords =
     t8_forest_vtk_point_to_element_ref_coords[element_shape]
     [vertex];
-  t8_forest_element_from_ref_coords (forest, ltreeid, element, ref_coords,
+  t8_forest_element_from_ref_coords (forest, ltreeid, element, ref_coords, 1,
                                      out_coords, stretch_factors);
 }
 

--- a/src/t8_geometry/t8_geometry.cxx
+++ b/src/t8_geometry/t8_geometry.cxx
@@ -317,7 +317,8 @@ t8_geom_handler_update_tree (t8_geometry_handler_t *geom_handler,
 
 void
 t8_geometry_evaluate (t8_cmesh_t cmesh, t8_gloidx_t gtreeid,
-                      const double *ref_coords, double *out_coords)
+                      const double *ref_coords, const int num_coords,
+                      double *out_coords)
 {
   double              start_wtime = 0;  /* Used for profiling. */
   /* The cmesh must be committed */
@@ -341,7 +342,8 @@ t8_geometry_evaluate (t8_cmesh_t cmesh, t8_gloidx_t gtreeid,
   /* Evaluate the geometry. */
   geom_handler->active_geometry->t8_geom_evaluate (cmesh,
                                                    geom_handler->active_tree,
-                                                   ref_coords, out_coords);
+                                                   ref_coords, num_coords,
+                                                   out_coords);
 
   if (cmesh->profile != NULL) {
     /* If profiling is enabled, add the runtime to the profiling
@@ -354,7 +356,8 @@ t8_geometry_evaluate (t8_cmesh_t cmesh, t8_gloidx_t gtreeid,
 
 void
 t8_geometry_jacobian (t8_cmesh_t cmesh, t8_gloidx_t gtreeid,
-                      const double *ref_coords, double *jacobian)
+                      const double *ref_coords, const int num_coords,
+                      double *jacobian)
 {
   /* The cmesh must be committed */
   T8_ASSERT (t8_cmesh_is_committed (cmesh));
@@ -370,7 +373,7 @@ t8_geometry_jacobian (t8_cmesh_t cmesh, t8_gloidx_t gtreeid,
   /* Evaluate the jacobian. */
   /* *INDENT-OFF* */
   geom_handler->active_geometry->
-    t8_geom_evaluate_jacobian (cmesh, geom_handler->active_tree, ref_coords,
+    t8_geom_evaluate_jacobian (cmesh, geom_handler->active_tree, ref_coords, num_coords,
                               jacobian);
   /* *INDENT-ON* */
 }

--- a/src/t8_geometry/t8_geometry.h
+++ b/src/t8_geometry/t8_geometry.h
@@ -146,6 +146,7 @@ t8_geometry_c      *t8_geom_handler_find_geometry (const
 void                t8_geometry_evaluate (t8_cmesh_t cmesh,
                                           t8_gloidx_t gtreeid,
                                           const double *ref_coords,
+                                          const int num_coords,
                                           double *out_coords);
 
 void                t8_geometry_jacobian (t8_cmesh_t cmesh,

--- a/src/t8_geometry/t8_geometry.h
+++ b/src/t8_geometry/t8_geometry.h
@@ -152,6 +152,7 @@ void                t8_geometry_evaluate (t8_cmesh_t cmesh,
 void                t8_geometry_jacobian (t8_cmesh_t cmesh,
                                           t8_gloidx_t gtreeid,
                                           const double *ref_coords,
+                                          const int num_coords,
                                           double *jacobian);
 
 T8_EXTERN_C_END ();

--- a/src/t8_geometry/t8_geometry_base.hxx
+++ b/src/t8_geometry/t8_geometry_base.hxx
@@ -59,10 +59,10 @@ public:
   }
 
   /**
-   * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
+   * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   virtual void        t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -71,10 +71,10 @@ public:
                                         double out_coords[3]) const = 0;
 
   /**
-   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
+   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  glreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^\mathrm{dim} \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    */

--- a/src/t8_geometry/t8_geometry_base.hxx
+++ b/src/t8_geometry/t8_geometry_base.hxx
@@ -60,27 +60,31 @@ public:
 
   /**
    * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
-   * \param [in]  cmesh      The cmesh in which the point lies.
-   * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  cmesh       The cmesh in which the point lies.
+   * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
+   * \param [in]  ref_coords  Array of \a dimension x \a num_coords many entries, specifying points in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   virtual void        t8_geom_evaluate (t8_cmesh_t cmesh,
                                         t8_gloidx_t gtreeid,
                                         const double *ref_coords,
+                                        const int num_coords,
                                         double out_coords[3]) const = 0;
 
   /**
    * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
-   * \param [in]  glreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
-   * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
+   * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
+   * \param [in]  ref_coords  Array of \a dimension x \a num_coords many entries, specifying points in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
+   * \param [out] jacobian    The jacobian at \a ref_coords. Array of size \a num_coords x dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    */
   virtual void        t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                                                  t8_gloidx_t gtreeid,
                                                  const double *ref_coords,
+                                                 const int num_coords,
                                                  double *jacobian) const = 0;
 
   /** Update a possible internal data buffer for per tree data.

--- a/src/t8_geometry/t8_geometry_base.hxx
+++ b/src/t8_geometry/t8_geometry_base.hxx
@@ -59,10 +59,10 @@ public:
   }
 
   /**
-   * Map a point in the reference space $$[0,1]^dimension$$ to $$\mathbb R^3$$
+   * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   virtual void        t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -71,10 +71,10 @@ public:
                                         double out_coords[3]) const = 0;
 
   /**
-   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space $$[0,1]^dimension$$.
+   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  glreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^\mathrm{dim} \f).
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    */

--- a/src/t8_geometry/t8_geometry_helpers.c
+++ b/src/t8_geometry/t8_geometry_helpers.c
@@ -33,24 +33,24 @@ t8_geom_linear_interpolation (const double *coefficients,
                               double *evaluated_function)
 {
   double              temp[3] = { 0 };
-  for (int i = 0; i < corner_value_dim; i++) {
-    temp[i] = corner_values[0 * corner_value_dim + i] * (1 - coefficients[0])   /* x=0 y=0 z=0 */
-      +corner_values[1 * corner_value_dim + i] * coefficients[0];       /* x=1 y=0 z=0 */
+  for (int dim = 0; dim < corner_value_dim; dim++) {
+    temp[dim] = corner_values[0 * corner_value_dim + dim] * (1 - coefficients[0])       /* x=0 y=0 z=0 */
+      +corner_values[1 * corner_value_dim + dim] * coefficients[0];     /* x=1 y=0 z=0 */
     if (interpolation_dim > 1) {
-      temp[i] *= (1 - coefficients[1]);
-      temp[i] += (corner_values[2 * corner_value_dim + i] * (1 - coefficients[0])       /* x=0 y=1 z=0 */
-                  +corner_values[3 * corner_value_dim + i] * coefficients[0])   /* x=1 y=1 z=0 */
+      temp[dim] *= (1 - coefficients[1]);
+      temp[dim] += (corner_values[2 * corner_value_dim + dim] * (1 - coefficients[0])   /* x=0 y=1 z=0 */
+                    +corner_values[3 * corner_value_dim + dim] * coefficients[0])       /* x=1 y=1 z=0 */
         *coefficients[1];
       if (interpolation_dim == 3) {
-        temp[i] *= (1 - coefficients[2]);
-        temp[i] += (corner_values[4 * corner_value_dim + i] * (1 - coefficients[0]) * (1 - coefficients[1])     /* x=0 y=0 z=1 */
-                    +corner_values[5 * corner_value_dim + i] * coefficients[0] * (1 - coefficients[1])  /* x=1 y=0 z=1 */
-                    +corner_values[6 * corner_value_dim + i] * (1 - coefficients[0]) * coefficients[1]  /* x=0 y=1 z=1 */
-                    +corner_values[7 * corner_value_dim + i] * coefficients[0] * coefficients[1])       /* x=1 y=1 z=1 */
+        temp[dim] *= (1 - coefficients[2]);
+        temp[dim] += (corner_values[4 * corner_value_dim + dim] * (1 - coefficients[0]) * (1 - coefficients[1]) /* x=0 y=0 z=1 */
+                      +corner_values[5 * corner_value_dim + dim] * coefficients[0] * (1 - coefficients[1])      /* x=1 y=0 z=1 */
+                      +corner_values[6 * corner_value_dim + dim] * (1 - coefficients[0]) * coefficients[1]      /* x=0 y=1 z=1 */
+                      +corner_values[7 * corner_value_dim + dim] * coefficients[0] * coefficients[1])   /* x=1 y=1 z=1 */
           *coefficients[2];
       }
     }
-    evaluated_function[i] = temp[i];
+    evaluated_function[dim] = temp[dim];
   }
 }
 
@@ -67,22 +67,23 @@ t8_geom_triangular_interpolation (const double *coefficients,
    */
   double              temp[3] = { 0 };
 
-  for (int i = 0; i < corner_value_dim; i++) {
-    temp[i] = (corner_values[corner_value_dim + i] -    /* (p2 - p1) * ref_coords */
-               corner_values[i]) * coefficients[0] + (interpolation_dim ==
-                                                      3
-                                                      ? (corner_values
-                                                         [3 *
-                                                          corner_value_dim +
-                                                          i] -
-                                                         corner_values[2 *
-                                                                       corner_value_dim
-                                                                       + i])
-                                                      * coefficients[1]
-                                                      : 0.)     /* (p4 - p3) * ref_coords */
-      +(corner_values[2 * corner_value_dim + i] - corner_values[corner_value_dim + i]) * coefficients[interpolation_dim - 1]    /* (p3 - p2) * ref_coords */
-      +corner_values[i];        /* p1 */
-    evaluated_function[i] = temp[i];
+  for (int dim = 0; dim < corner_value_dim; dim++) {
+    temp[dim] = (corner_values[corner_value_dim + dim] -        /* (p2 - p1) * ref_coords */
+                 corner_values[dim]) * coefficients[0] + (interpolation_dim ==
+                                                          3
+                                                          ? (corner_values
+                                                             [3 *
+                                                              corner_value_dim
+                                                              + dim] -
+                                                             corner_values[2 *
+                                                                           corner_value_dim
+                                                                           +
+                                                                           dim])
+                                                          * coefficients[1]
+                                                          : 0.) /* (p4 - p3) * ref_coords */
+      +(corner_values[2 * corner_value_dim + dim] - corner_values[corner_value_dim + dim]) * coefficients[interpolation_dim - 1]        /* (p3 - p2) * ref_coords */
+      +corner_values[dim];      /* p1 */
+    evaluated_function[dim] = temp[dim];
   }
 }
 
@@ -92,22 +93,22 @@ t8_geom_compute_linear_geometry (t8_eclass_t tree_class,
                                  const double *ref_coords,
                                  double out_coords[3])
 {
-  int                 i;
+  int                 dim;
   int                 dimension = t8_eclass_to_dimension[tree_class];
   /* Compute the coordinates, depending on the shape of the element */
   switch (tree_class) {
   case T8_ECLASS_VERTEX:
     /* A vertex has exactly one corner, and we already know its coordinates, since they are
      * the same as the trees coordinates. */
-    for (i = 0; i < 3; i++) {
-      out_coords[i] = tree_vertices[i];
+    for (dim = 0; dim < 3; dim++) {
+      out_coords[dim] = tree_vertices[dim];
     }
     break;
   case T8_ECLASS_LINE:
-    for (i = 0; i < 3; i++) {
-      out_coords[i] =
-        (tree_vertices[3 + i] -
-         tree_vertices[i]) * ref_coords[0] + tree_vertices[i];
+    for (dim = 0; dim < 3; dim++) {
+      out_coords[dim] =
+        (tree_vertices[3 + dim] -
+         tree_vertices[dim]) * ref_coords[0] + tree_vertices[dim];
     }
     break;
   case T8_ECLASS_TRIANGLE:
@@ -121,16 +122,16 @@ t8_geom_compute_linear_geometry (t8_eclass_t tree_class,
       /* Prisminterpolation, via height, and triangle */
       /* Get a triangle at the specific height */
       double              tri_vertices[9];
-      for (i = 0; i < 9; i++) {
-        tri_vertices[i] =
-          (tree_vertices[9 + i] -
-           tree_vertices[i]) * ref_coords[2] + tree_vertices[i];
+      for (int coord = 0; coord < 9; coord++) {
+        tri_vertices[coord] =
+          (tree_vertices[9 + coord] -
+           tree_vertices[coord]) * ref_coords[2] + tree_vertices[coord];
       }
-      for (i = 0; i < 3; i++) {
-        out_coords[i] =
-          (tri_vertices[3 + i] - tri_vertices[i]) * ref_coords[0] +
-          (tri_vertices[6 + i] - tri_vertices[3 + i]) * ref_coords[1]
-          + tri_vertices[i];
+      for (dim = 0; dim < 3; dim++) {
+        out_coords[dim] =
+          (tri_vertices[3 + dim] - tri_vertices[dim]) * ref_coords[0] +
+          (tri_vertices[6 + dim] - tri_vertices[3 + dim]) * ref_coords[1]
+          + tri_vertices[dim];
       }
     }
     break;
@@ -152,26 +153,27 @@ t8_geom_compute_linear_geometry (t8_eclass_t tree_class,
       /*In this case, the vertex is the tip of the parent pyramid and we don't have to compute
        * anything.*/
       if (ref_coords[0] == 1. && ref_coords[1] == 1. && ref_coords[2] == 1.) {
-        for (i = 0; i < 3; i++) {
-          out_coords[i] = tree_vertices[12 + i];
+        for (dim = 0; dim < 3; dim++) {
+          out_coords[dim] = tree_vertices[12 + dim];
         }
         break;
       }
       /* Project vertex_coord onto x-y-plane */
-      for (i = 0; i < 3; i++) {
-        ray[i] = 1 - ref_coords[i];
+      for (dim = 0; dim < 3; dim++) {
+        ray[dim] = 1 - ref_coords[dim];
       }
       lambda = ref_coords[2] / ray[2];
-      for (i = 0; i < 2; i++) {
+      for (dim = 0; dim < 2; dim++) {
         /*Compute coords of vertex in the plane */
-        quad_coords[i] = ref_coords[i] - lambda * ray[i];
-        length += (1 - quad_coords[i]) * (1 - quad_coords[i]);
+        quad_coords[dim] = ref_coords[dim] - lambda * ray[dim];
+        length += (1 - quad_coords[dim]) * (1 - quad_coords[dim]);
       }
       length += 1;
       /*compute the ratio */
-      for (i = 0; i < 3; i++) {
+      for (dim = 0; dim < 3; dim++) {
         length2 +=
-          (ref_coords[i] - quad_coords[i]) * (ref_coords[i] - quad_coords[i]);
+          (ref_coords[dim] - quad_coords[dim]) * (ref_coords[dim] -
+                                                  quad_coords[dim]);
       }
       lambda = sqrt (length2) / sqrt (length);
 
@@ -179,8 +181,9 @@ t8_geom_compute_linear_geometry (t8_eclass_t tree_class,
       t8_geom_linear_interpolation ((const double *) quad_coords,
                                     tree_vertices, 3, 2, out_coords);
       /*Project it back */
-      for (i = 0; i < 3; i++) {
-        out_coords[i] += (tree_vertices[12 + i] - out_coords[i]) * lambda;
+      for (dim = 0; dim < 3; dim++) {
+        out_coords[dim] +=
+          (tree_vertices[12 + dim] - out_coords[dim]) * lambda;
       }
       break;
     }

--- a/src/t8_geometry/t8_geometry_helpers.c
+++ b/src/t8_geometry/t8_geometry_helpers.c
@@ -209,8 +209,9 @@ t8_geom_compute_linear_axis_aligned_geometry (t8_eclass_t tree_class,
     /* The two vertices of a line must have two matching coordinates to be
      * axis-aligned. A quad needs one matching coordinate. */
     int                 n_equal_coords = 0;
-    for (int dim = 0; dim < 3; ++dim) {
-      if (abs (tree_vertices[dim] - tree_vertices[3 + dim]) <= SC_EPS) {
+    for (int dim = 0; dim < T8_ECLASS_MAX_DIM; ++dim) {
+      if (abs (tree_vertices[dim] - tree_vertices[T8_ECLASS_MAX_DIM + dim]) <=
+          SC_EPS) {
         ++n_equal_coords;
       }
     }
@@ -222,15 +223,20 @@ t8_geom_compute_linear_axis_aligned_geometry (t8_eclass_t tree_class,
     }
   }
 #endif /* T8_ENABLE_DEBUG */
-
+  const int           dimension = t8_eclass_get_dimension (tree_class);
   /* Compute vector between both points */
   double              vector[3];
-  t8_vec_diff (tree_vertices + 3, tree_vertices, vector);
+  t8_vec_diff (tree_vertices + T8_ECLASS_MAX_DIM, tree_vertices, vector);
 
   /* Compute the coordinates of the reference point. */
-  for (int dim = 0; dim < 3; ++dim) {
-    out_coords[dim] = tree_vertices[dim];
-    out_coords[dim] += ref_coords[dim] * vector[dim];
+  for (int coord = 0; coord < num_coords; ++coord) {
+    const int           offset_tree_dim = coord * dimension;
+    const int           offset_domain_dim = coord * T8_ECLASS_MAX_DIM;
+    for (int dim = 0; dim < T8_ECLASS_MAX_DIM; ++dim) {
+      out_coords[offset_tree_dim + dim] = tree_vertices[dim];
+      out_coords[offset_tree_dim + dim] +=
+        ref_coords[offset_tree_dim] * vector[dim];
+    }
   }
 }
 

--- a/src/t8_geometry/t8_geometry_helpers.h
+++ b/src/t8_geometry/t8_geometry_helpers.h
@@ -52,6 +52,7 @@ void                t8_geom_compute_linear_geometry (t8_eclass_t tree_class,
  * \param [in]    tree_class     The eclass of the tree.
  * \param [in]    tree_vertices  Array with the tree vertex coordinates.
  * \param [in]    ref_coords     The reference coordinates of the point.
+ * \param [in]    num_coords     Number of points to evaluate.
  * \param [out]   out_coords     The output coordinates.
  */
 void                t8_geom_compute_linear_axis_aligned_geometry (t8_eclass_t
@@ -60,9 +61,10 @@ void                t8_geom_compute_linear_axis_aligned_geometry (t8_eclass_t
                                                                   *tree_vertices,
                                                                   const double
                                                                   *ref_coords,
+                                                                  const int
+                                                                  num_coords,
                                                                   double
-                                                                  out_coords
-                                                                  [3]);
+                                                                  *out_coords);
 
 /** Interpolates linearly between 2, bilinearly between 4 or trilineraly between 8 points.
  * \param [in]    coefficients        An array of size at least dim giving the coefficients used for the interpolation

--- a/src/t8_geometry/t8_geometry_helpers.h
+++ b/src/t8_geometry/t8_geometry_helpers.h
@@ -36,12 +36,14 @@ T8_EXTERN_C_BEGIN ();
  * \param [in]    tree_class     The eclass of the tree.
  * \param [in]    tree_vertices  Array with the tree vertex coordinates.
  * \param [in]    ref_coords     The reference coordinates of the point.
+ * \param [in]    num_coords     Number of points to evaluate.
  * \param [out]   out_coords     The output coordinates.
  */
 void                t8_geom_compute_linear_geometry (t8_eclass_t tree_class,
                                                      const double
                                                      *tree_vertices,
                                                      const double *ref_coords,
+                                                     const int num_coords,
                                                      double out_coords[3]);
 
 /** Compute the linear, axis-aligned geometry of a tree at a given reference coordinate.

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.cxx
@@ -42,9 +42,9 @@ t8_geometry_analytic::t8_geometry_analytic (int dim, const char *name_in,
 }
 
 /**
- * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
+ * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
  * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
  * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
  */
 /* *INDENT-OFF* */
@@ -62,9 +62,9 @@ t8_geometry_analytic::t8_geom_evaluate (t8_cmesh_t cmesh,
 }
 
 /**
- * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
+ * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
  * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
  * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
  *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
  */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.cxx
@@ -42,9 +42,9 @@ t8_geometry_analytic::t8_geometry_analytic (int dim, const char *name_in,
 }
 
 /**
- * Map a point in the reference space $$[0,1]^dimension$$ to $$\mathbb R^3$$
+ * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
  * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
  * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
  */
 /* *INDENT-OFF* */
@@ -62,9 +62,9 @@ t8_geometry_analytic::t8_geom_evaluate (t8_cmesh_t cmesh,
 }
 
 /**
- * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space $$[0,1]^dimension$$.
+ * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
  * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
  * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
  *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
  */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.cxx
@@ -41,33 +41,22 @@ t8_geometry_analytic::t8_geometry_analytic (int dim, const char *name_in,
   user_data = user_data_in;
 }
 
-/**
- * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
- * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
- * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
- */
 /* *INDENT-OFF* */
 /* Indent has trouble with the const keyword at the end */
 void
 t8_geometry_analytic::t8_geom_evaluate (t8_cmesh_t cmesh,
                                         t8_gloidx_t gtreeid,
                                         const double *ref_coords,
+                                        const int num_coords,
                                         double out_coords[3]) const
 /* *INDENT-ON* */
+
 {
   T8_ASSERT (analytical_function != NULL);
-  analytical_function (cmesh, gtreeid, ref_coords, out_coords,
+  analytical_function (cmesh, gtreeid, ref_coords, num_coords, out_coords,
                        tree_data, user_data);
 }
 
-/**
- * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
- * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
- * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
- *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
- */
 /* *INDENT-OFF* */
 /* Indent has trouble with the const keyword at the end */
 void
@@ -75,11 +64,14 @@ t8_geometry_analytic::t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                                                 t8_gloidx_t gtreeid,
                                                 const double
                                                 *ref_coords,
+                                                const int num_coords,
                                                 double *jacobian_out) const
 /* *INDENT-ON* */
+
 {
   T8_ASSERT (jacobian != NULL);
-  jacobian (cmesh, gtreeid, ref_coords, jacobian_out, tree_data, user_data);
+  jacobian (cmesh, gtreeid, ref_coords, num_coords, jacobian_out, tree_data,
+            user_data);
 }
 
 void

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.hxx
@@ -37,7 +37,8 @@
  * coordinates.
  * \param [in]  cmesh       The cmesh.
  * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
+ * \param [in]  ref_coords  Array of dimension x \a num_coords many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
+ * \param [in]  num_coords  
  * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
  * \param [in]  tree_data   The data of the current tree as loaded by a \ref t8_geom_load_tree_data_fn.
  * \param [in]  user_data   The user data pointer stored in the geometry.
@@ -45,6 +46,7 @@
 typedef void        (*t8_geom_analytic_fn) (t8_cmesh_t cmesh,
                                             t8_gloidx_t gtreeid,
                                             const double *ref_coords,
+                                            const int num_coords,
                                             double out_coords[3],
                                             const void *tree_data,
                                             const void *user_data);
@@ -53,8 +55,8 @@ typedef void        (*t8_geom_analytic_fn) (t8_cmesh_t cmesh,
  * Definition for the jacobian of an analytic geometry function.
  * \param [in]  cmesh       The cmesh.
  * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
- * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
+ * \param [in]  ref_coords  Array of dimension x \a num_coords many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
+ * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3 x \a num_coords. Indices 3*i, 3*i+1, 3*i+2
  *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
  * \param [in]  tree_data   The data of the current tree as loaded by a \ref t8_geom_load_tree_data_fn.
  * \param [in]  user_data   The user data pointer stored in the geometry.
@@ -62,6 +64,7 @@ typedef void        (*t8_geom_analytic_fn) (t8_cmesh_t cmesh,
 typedef void        (*t8_geom_analytic_jacobian_fn) (t8_cmesh_t cmesh,
                                                      t8_gloidx_t gtreeid,
                                                      const double *ref_coords,
+                                                     const int num_coords,
                                                      double *jacobian,
                                                      const void *tree_data,
                                                      const void *user_data);
@@ -99,23 +102,25 @@ public:
 
   /**
    * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
-   * \param [in]  cmesh      The cmesh in which the point lies.
-   * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  cmesh       The cmesh in which the point lies.
+   * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
+   * \param [in]  ref_coords  Array of \a dimension x \a num_coords many entries, specifying points in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
-   * \note Since this is the identity geometry, \a out_coords will be equal to \a ref_coords.
    */
   virtual void        t8_geom_evaluate (t8_cmesh_t cmesh,
                                         t8_gloidx_t gtreeid,
                                         const double *ref_coords,
+                                        const int num_coords,
                                         double out_coords[3]) const;
 
   /**
    * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
-   * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
+   * \param [in]  ref_coords  Array of \a dimension x \a num_coords many entries, specifying points in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
+   * \param [out] jacobian    The jacobian at \a ref_coords. Array of size \a num_coords x dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    * \note The jacobian will be
    *            (1)              (1 0)             (1 0 0)
@@ -125,6 +130,7 @@ public:
   virtual void        t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                                                  t8_gloidx_t gtreeid,
                                                  const double *ref_coords,
+                                                 const int num_coords,
                                                  double *jacobian) const;
 
   /** Update a possible internal data buffer for per tree data.

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.hxx
@@ -37,7 +37,7 @@
  * coordinates.
  * \param [in]  cmesh       The cmesh.
  * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
  * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
  * \param [in]  tree_data   The data of the current tree as loaded by a \ref t8_geom_load_tree_data_fn.
  * \param [in]  user_data   The user data pointer stored in the geometry.
@@ -53,7 +53,7 @@ typedef void        (*t8_geom_analytic_fn) (t8_cmesh_t cmesh,
  * Definition for the jacobian of an analytic geometry function.
  * \param [in]  cmesh       The cmesh.
  * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
  * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
  *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
  * \param [in]  tree_data   The data of the current tree as loaded by a \ref t8_geom_load_tree_data_fn.
@@ -98,10 +98,10 @@ public:
   }
 
   /**
-   * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
+   * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    * \note Since this is the identity geometry, \a out_coords will be equal to \a ref_coords.
    */
@@ -111,10 +111,10 @@ public:
                                         double out_coords[3]) const;
 
   /**
-   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
+   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    * \note The jacobian will be

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.hxx
@@ -37,7 +37,7 @@
  * coordinates.
  * \param [in]  cmesh       The cmesh.
  * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
  * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
  * \param [in]  tree_data   The data of the current tree as loaded by a \ref t8_geom_load_tree_data_fn.
  * \param [in]  user_data   The user data pointer stored in the geometry.
@@ -53,7 +53,7 @@ typedef void        (*t8_geom_analytic_fn) (t8_cmesh_t cmesh,
  * Definition for the jacobian of an analytic geometry function.
  * \param [in]  cmesh       The cmesh.
  * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
  * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
  *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
  * \param [in]  tree_data   The data of the current tree as loaded by a \ref t8_geom_load_tree_data_fn.
@@ -98,10 +98,10 @@ public:
   }
 
   /**
-   * Map a point in the reference space $$[0,1]^dimension$$ to $$\mathbb R^3$$
+   * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    * \note Since this is the identity geometry, \a out_coords will be equal to \a ref_coords.
    */
@@ -111,10 +111,10 @@ public:
                                         double out_coords[3]) const;
 
   /**
-   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space $$[0,1]^dimension$$.
+   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    * \note The jacobian will be

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
@@ -48,6 +48,8 @@ t8_geometry_linear::t8_geom_evaluate (t8_cmesh_t cmesh,
                                       const int num_coords,
                                       double *out_coords) const
 {
+  if (num_coords != 1)
+    SC_ABORT ("Error: Batch computation of geometry not yet supported.");
   t8_geom_compute_linear_geometry (active_tree_class,
                                    active_tree_vertices, ref_coords,
                                    out_coords);

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
@@ -41,44 +41,25 @@ t8_geometry_linear::~t8_geometry_linear ()
   T8_FREE ((char *) name);
 }
 
-/**
- * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
- * \param [in]  cmesh      The cmesh in which the point lies.
- * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
- * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
- */
-/* *INDENT-OFF* */
-/* indent adds second const */
 void
 t8_geometry_linear::t8_geom_evaluate (t8_cmesh_t cmesh,
                                       t8_gloidx_t gtreeid,
                                       const double *ref_coords,
-                                      double out_coords[3]) const
-/* *INDENT-ON* */
+                                      const int num_coords,
+                                      double *out_coords) const
 {
   t8_geom_compute_linear_geometry (active_tree_class,
                                    active_tree_vertices, ref_coords,
                                    out_coords);
 }
 
-/**
- * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
- * \param [in]  cmesh      The cmesh in which the point lies.
- * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
- * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
- *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
- */
-/* *INDENT-OFF* */
-/* indent adds second const */
 void
 t8_geometry_linear::t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
-                                              t8_gloidx_t gtreeid,
-                                              const double
-                                              *ref_coords,
-                                              double *jacobian) const
-/* *INDENT-ON* */
+                                               t8_gloidx_t gtreeid,
+                                               const double
+                                               *ref_coords,
+                                               const int num_coords,
+                                               double *jacobian) const
 {
   SC_ABORT ("Not implemented.");
 }

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
@@ -42,10 +42,10 @@ t8_geometry_linear::~t8_geometry_linear ()
 }
 
 /**
- * Map a point in the reference space $$[0,1]^dimension$$ to $$\mathbb R^3$$
+ * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
  * \param [in]  cmesh      The cmesh in which the point lies.
  * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
  * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
  */
 /* *INDENT-OFF* */
@@ -63,10 +63,10 @@ t8_geometry_linear::t8_geom_evaluate (t8_cmesh_t cmesh,
 }
 
 /**
- * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space $$[0,1]^dimension$$.
+ * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
  * \param [in]  cmesh      The cmesh in which the point lies.
  * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
  * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
  *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
  */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
@@ -48,11 +48,9 @@ t8_geometry_linear::t8_geom_evaluate (t8_cmesh_t cmesh,
                                       const int num_coords,
                                       double *out_coords) const
 {
-  if (num_coords != 1)
-    SC_ABORT ("Error: Batch computation of geometry not yet supported.");
   t8_geom_compute_linear_geometry (active_tree_class,
                                    active_tree_vertices, ref_coords,
-                                   out_coords);
+                                   num_coords, out_coords);
 }
 
 void

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
@@ -42,10 +42,10 @@ t8_geometry_linear::~t8_geometry_linear ()
 }
 
 /**
- * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
+ * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
  * \param [in]  cmesh      The cmesh in which the point lies.
  * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
  * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
  */
 /* *INDENT-OFF* */
@@ -63,10 +63,10 @@ t8_geometry_linear::t8_geom_evaluate (t8_cmesh_t cmesh,
 }
 
 /**
- * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
+ * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
  * \param [in]  cmesh      The cmesh in which the point lies.
  * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
  * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
  *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
  */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.hxx
@@ -52,10 +52,10 @@ public:
   virtual ~           t8_geometry_linear ();
 
   /**
-   * Map a point in the reference space $$[0,1]^dimension$$ to $$\mathbb R^3$$
+   * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   virtual void        t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -64,10 +64,10 @@ public:
                                         double out_coords[3]) const;
 
   /**
-   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space $$[0,1]^dimension$$.
+   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.hxx
@@ -53,27 +53,31 @@ public:
 
   /**
    * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
-   * \param [in]  cmesh      The cmesh in which the point lies.
-   * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  cmesh       The cmesh in which the point lies.
+   * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
+   * \param [in]  ref_coords  Array of \a dimension x \a num_coords many entries, specifying points in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   virtual void        t8_geom_evaluate (t8_cmesh_t cmesh,
                                         t8_gloidx_t gtreeid,
                                         const double *ref_coords,
+                                        const int num_coords,
                                         double out_coords[3]) const;
 
   /**
    * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
-   * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
+   * \param [in]  ref_coords  Array of \a dimension x \a num_coords many entries, specifying points in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
+   * \param [out] jacobian    The jacobian at \a ref_coords. Array of size \a num_coords x dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    */
   virtual void        t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                                                  t8_gloidx_t gtreeid,
                                                  const double *ref_coords,
+                                                 const int num_coords,
                                                  double *jacobian) const;
 
   /* Load tree data is inherited from t8_geometry_with_vertices. */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.hxx
@@ -52,10 +52,10 @@ public:
   virtual ~           t8_geometry_linear ();
 
   /**
-   * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
+   * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   virtual void        t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -64,10 +64,10 @@ public:
                                         double out_coords[3]) const;
 
   /**
-   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
+   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.cxx
@@ -41,44 +41,28 @@ t8_geometry_linear_axis_aligned::~t8_geometry_linear_axis_aligned ()
   T8_FREE ((char *) name);
 }
 
-/**
- * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
- * \param [in]  cmesh      The cmesh in which the point lies.
- * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
- * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
- */
-/* *INDENT-OFF* */
-/* indent adds second const */
 void
 t8_geometry_linear_axis_aligned::t8_geom_evaluate (t8_cmesh_t cmesh,
-                                      t8_gloidx_t gtreeid,
-                                      const double *ref_coords,
-                                      double out_coords[3]) const
-/* *INDENT-ON* */
+                                                   t8_gloidx_t gtreeid,
+                                                   const double *ref_coords,
+                                                   const int num_coords,
+                                                   double out_coords[3]) const
 {
   t8_geom_compute_linear_axis_aligned_geometry (active_tree_class,
                                                 active_tree_vertices,
                                                 ref_coords, out_coords);
 }
 
-/**
- * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
- * \param [in]  cmesh      The cmesh in which the point lies.
- * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
- * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
- *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
- */
-/* *INDENT-OFF* */
-/* indent adds second const */
 void
 t8_geometry_linear_axis_aligned::t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
-                                              t8_gloidx_t gtreeid,
-                                              const double
-                                              *ref_coords,
-                                              double *jacobian) const
-/* *INDENT-ON* */
+                                                            t8_gloidx_t
+                                                            gtreeid,
+                                                            const double
+                                                            *ref_coords,
+                                                            const int
+                                                            num_coords,
+                                                            double *jacobian)
+  const
 {
   SC_ABORT ("Not implemented.");
 }

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.cxx
@@ -48,6 +48,8 @@ t8_geometry_linear_axis_aligned::t8_geom_evaluate (t8_cmesh_t cmesh,
                                                    const int num_coords,
                                                    double out_coords[3]) const
 {
+  if (num_coords != 1)
+    SC_ABORT ("Error: Batch computation of geometry not yet supported.");
   t8_geom_compute_linear_axis_aligned_geometry (active_tree_class,
                                                 active_tree_vertices,
                                                 ref_coords, out_coords);

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.cxx
@@ -42,10 +42,10 @@ t8_geometry_linear_axis_aligned::~t8_geometry_linear_axis_aligned ()
 }
 
 /**
- * Map a point in the reference space $$[0,1]^dimension$$ to $$\mathbb R^3$$
+ * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
  * \param [in]  cmesh      The cmesh in which the point lies.
  * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
  * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
  */
 /* *INDENT-OFF* */
@@ -63,10 +63,10 @@ t8_geometry_linear_axis_aligned::t8_geom_evaluate (t8_cmesh_t cmesh,
 }
 
 /**
- * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space $$[0,1]^dimension$$.
+ * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
  * \param [in]  cmesh      The cmesh in which the point lies.
  * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
  * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
  *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
  */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.cxx
@@ -48,11 +48,10 @@ t8_geometry_linear_axis_aligned::t8_geom_evaluate (t8_cmesh_t cmesh,
                                                    const int num_coords,
                                                    double out_coords[3]) const
 {
-  if (num_coords != 1)
-    SC_ABORT ("Error: Batch computation of geometry not yet supported.");
   t8_geom_compute_linear_axis_aligned_geometry (active_tree_class,
                                                 active_tree_vertices,
-                                                ref_coords, out_coords);
+                                                ref_coords, num_coords,
+                                                out_coords);
 }
 
 void

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.cxx
@@ -42,10 +42,10 @@ t8_geometry_linear_axis_aligned::~t8_geometry_linear_axis_aligned ()
 }
 
 /**
- * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
+ * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
  * \param [in]  cmesh      The cmesh in which the point lies.
  * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
  * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
  */
 /* *INDENT-OFF* */
@@ -63,10 +63,10 @@ t8_geometry_linear_axis_aligned::t8_geom_evaluate (t8_cmesh_t cmesh,
 }
 
 /**
- * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
+ * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
  * \param [in]  cmesh      The cmesh in which the point lies.
  * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
  * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
  *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
  */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.hxx
@@ -57,27 +57,31 @@ public:
 
   /**
    * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
-   * \param [in]  cmesh      The cmesh in which the point lies.
-   * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  cmesh       The cmesh in which the point lies.
+   * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
+   * \param [in]  ref_coords  Array of \a dimension x \a num_coords many entries, specifying points in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   virtual void        t8_geom_evaluate (t8_cmesh_t cmesh,
                                         t8_gloidx_t gtreeid,
                                         const double *ref_coords,
+                                        const int num_coords,
                                         double out_coords[3]) const;
 
   /**
    * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
-   * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
+   * \param [in]  ref_coords  Array of \a dimension x \a num_coords many entries, specifying points in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
+   * \param [out] jacobian    The jacobian at \a ref_coords. Array of size \a num_coords x dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    */
   virtual void        t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                                                  t8_gloidx_t gtreeid,
                                                  const double *ref_coords,
+                                                 const int num_coords,
                                                  double *jacobian) const;
 };
 

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.hxx
@@ -22,7 +22,7 @@
 
 /** \file t8_geometry_linear_axis_aligned.hxx
  * Definition of an axis-aligned geometry. It maps from
- * $$[0,1]^dimension$$ to $$\mathbb R^3$$, using two vertices. 
+ * \f( [0,1]^\mathrm{dim} \f) to \f$ \mathbb{R}^3 \f), using two vertices. 
  */
 
 #ifndef T8_GEOMETRY_LINEAR_AXIS_ALIGNED_HXX
@@ -56,10 +56,10 @@ public:
   /* *INDENT-ON* */
 
   /**
-   * Map a point in the reference space $$[0,1]^dimension$$ to $$\mathbb R^3$$
+   * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in $$[0,1]^dimension$$.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^\mathrm{dim} \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   virtual void        t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -68,10 +68,10 @@ public:
                                         double out_coords[3]) const;
 
   /**
-   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space $$[0,1]^dimension$$.
+   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in $$[0,1]^dimension$$.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^\mathrm{dim} \f).
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.hxx
@@ -22,7 +22,7 @@
 
 /** \file t8_geometry_linear_axis_aligned.hxx
  * Definition of an axis-aligned geometry. It maps from
- * \f( [0,1]^\mathrm{dim} \f) to \f$ \mathbb{R}^3 \f), using two vertices. 
+ * \f$ [0,1]^\mathrm{dim} \f$ to \f$ \mathbb{R}^3 \f$, using two vertices. 
  */
 
 #ifndef T8_GEOMETRY_LINEAR_AXIS_ALIGNED_HXX
@@ -56,10 +56,10 @@ public:
   /* *INDENT-ON* */
 
   /**
-   * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
+   * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^\mathrm{dim} \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   virtual void        t8_geom_evaluate (t8_cmesh_t cmesh,
@@ -68,10 +68,10 @@ public:
                                         double out_coords[3]) const;
 
   /**
-   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
+   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^\mathrm{dim} \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
@@ -434,10 +434,10 @@ t8_geometry_occ::t8_geom_evaluate_occ_triangle (t8_cmesh_t cmesh,
         /* Calculate displacement between points on curve and point on linear curve.
          * Then scale it and add the scaled displacement to the result. */
         for (int dim = 0; dim < 3; ++dim) {
-          double              displacement =
+          const double        displacement =
             pnt.Coord (dim + 1) - glob_intersection[dim];
-          double              scaled_displacement =
-            displacement * pow (scaling_factor, 2);
+          const double        scaled_displacement =
+            displacement * scaling_factor * scaling_factor;
           out_coords[dim] += scaled_displacement;
         }
       }

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
@@ -491,7 +491,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_quad (t8_cmesh_t cmesh,
     /* Iterate over each edge to search for parameter displacements */
     for (int i_edge = 0; i_edge < num_edges; ++i_edge) {
       if (edges[i_edge] > 0) {
-        /* The edges of a quad point in direction of ref_coord (1 - i_edge / 2).
+        /* The edges of a quad point in direction of ref_coord (1 - i_edge >> 1).
          *
          *     2 -------E3------- 3
          *     |                  |
@@ -503,7 +503,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_quad (t8_cmesh_t cmesh,
          *     0 -------E2------- 1    x-- x
          *        
          */
-        const int           edge_orthogonal_direction = (i_edge / 2);
+        const int           edge_orthogonal_direction = (i_edge >> 1);
         const int           edge_direction = 1 - edge_orthogonal_direction;
         /* Retrieve edge parameters and interpolate */
         const double       *edge_parameters =
@@ -558,7 +558,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_quad (t8_cmesh_t cmesh,
             converted_edge_surface_parameters[dim]
             - interpolated_edge_surface_parameters[dim];
           double              scaled_displacement;
-          if (i_edge % 2 == 0) {
+          if (i_edge & 1) {
             scaled_displacement =
               displacement * (1 - ref_coords[edge_orthogonal_direction]);
           }
@@ -598,7 +598,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_quad (t8_cmesh_t cmesh,
         T8_ASSERT (!(edges[i_edge] > 0)
                    || !(edges[i_edge + num_edges] > 0));
 
-        /* The edges of a quad point in direction of ref_coord (1 - i_edge / 2).
+        /* The edges of a quad point in direction of ref_coord (1 - i_edge >> 1).
          *
          *     2 -------E3------- 3
          *     |                  |
@@ -610,7 +610,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_quad (t8_cmesh_t cmesh,
          *     0 -------E2------- 1    x-- x
          *        
          */
-        const int           edge_orthogonal_direction = (i_edge / 2);
+        const int           edge_orthogonal_direction = (i_edge >> 1);
         const int           edge_direction = 1 - edge_orthogonal_direction;
         double              temp_edge_vertices[2 * 3];
 
@@ -677,7 +677,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_quad (t8_cmesh_t cmesh,
           const double        displacement = pnt.Coord (dim + 1)
             - interpolated_coords[dim];
           double              scaled_displacement;
-          if (i_edge % 2 == 0) {
+          if (i_edge & 1) {
             scaled_displacement =
               displacement * (1 - ref_coords[edge_orthogonal_direction]);
           }
@@ -729,7 +729,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_hex (t8_cmesh_t cmesh,
       T8_ASSERT (!(edges[i_edge] > 0) != !(edges[i_edge + num_edges] > 0));
 
       /* Interpolate coordinates between edge vertices. Due to the indices i_edge of the edges, the edges point in
-       * direction of ref_coord i_edge / 4. Therefore, we can use ref_coords[i_edge / 4] for the interpolation.              
+       * direction of ref_coord i_edge >> 2. Therefore, we can use ref_coords[i_edge >> 2] for the interpolation.
        *          6 -------E3------- 7
        *         /|                 /|
        *       E5 |               E7 |
@@ -745,7 +745,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_hex (t8_cmesh_t cmesh,
        *     0 -------E0------- 1
        *        
        */
-      const int           edge_direction = i_edge / 4;
+      const int           edge_direction = i_edge >> 2;
       /* Save the edge vertices temporarily. */
 
       t8_geom_get_edge_vertices (active_tree_class,
@@ -817,7 +817,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_hex (t8_cmesh_t cmesh,
 
       /* *INDENT-OFF* */
       double scaling_factor = 0;
-      switch (i_edge % 4) {
+      switch (i_edge & (4 - 1)) {
       case 0:
         scaling_factor = (1 - ref_coords[(edge_direction + 1) % 3]) 
                        * (1 - ref_coords[(edge_direction + 2) % 3]);
@@ -850,7 +850,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_hex (t8_cmesh_t cmesh,
     if (faces[i_faces] > 0) {
       /* Allocate some variables and save the normal direction of the face and the face vertices 
        * in a separate array for later usage. */
-      const int           face_normal_direction = i_faces / 2;
+      const int           face_normal_direction = i_faces >> 1;
       t8_geom_get_face_vertices (T8_ECLASS_HEX,
                                  active_tree_vertices,
                                  i_faces, 3, temp_face_vertices);
@@ -871,7 +871,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_hex (t8_cmesh_t cmesh,
         if (edges[t8_face_edge_to_tree_edge[i_faces][i_face_edge]] > 0) {
           /* Calculating some indices */
           const int           edge_direction =
-            t8_face_edge_to_tree_edge[i_faces][i_face_edge] / 4;
+            t8_face_edge_to_tree_edge[i_faces][i_face_edge] >> 2;
           int                 orthogonal_direction_of_edge_on_face = 0;
           switch (edge_direction + face_normal_direction) {
           case 1:
@@ -935,7 +935,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_hex (t8_cmesh_t cmesh,
           curve->D0 (interpolated_curve_param, pnt);
 
           /* Calculate the displacement generated by the presence of the curve */
-          if (i_face_edge % 2 == 0) {
+          if (i_face_edge & 1) {
             for (int dim = 0; dim <= 2; ++dim) {
               face_displacement_from_edges[dim]
                 += (1 - ref_coords[orthogonal_direction_of_edge_on_face])
@@ -960,7 +960,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_hex (t8_cmesh_t cmesh,
           /* Calculate the displacement between the interpolated parameters on the surface 
            * and the parameters on the surface converted from the parameter of the curve
            * and scale them with the corresponding ref coord */
-          if (i_face_edge % 2 == 0) {
+          if (i_face_edge & 1) {
             for (int dim = 0; dim < 2; ++dim) {
               surface_parameter_displacement_from_edges[dim]
                 += (1 - ref_coords[orthogonal_direction_of_edge_on_face])
@@ -1041,7 +1041,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_hex (t8_cmesh_t cmesh,
 
       /* Compute the displacement between surface and interpolated coords, scale them with the appropriate ref_coord 
        * and add them to the out_coords. */
-      if (i_faces % 2 == 0) {
+      if (i_faces & 1) {
         out_coords[0]
           += (pnt.X () - interpolated_coords[0])
           * (1 - ref_coords[face_normal_direction]);

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
@@ -168,8 +168,8 @@ t8_geometry_occ::t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
       in1[dim] -= 0.5 * h;
       in2[dim] += 0.5 * h;
     }
-    t8_geometry_occ::t8_geom_evaluate (cmesh, gtreeid, in1, out1);
-    t8_geometry_occ::t8_geom_evaluate (cmesh, gtreeid, in2, out2);
+    t8_geometry_occ::t8_geom_evaluate (cmesh, gtreeid, in1, 1, out1);
+    t8_geometry_occ::t8_geom_evaluate (cmesh, gtreeid, in2, 1, out2);
     for (int dim2 = 0; dim2 < 3; ++dim2) {
       jacobian_out[dim * 3 + dim2] = (out2[dim2] - out1[dim2]) / h;
     }

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
@@ -116,6 +116,7 @@ void
 t8_geometry_occ::t8_geom_evaluate (t8_cmesh_t cmesh,
                                    t8_gloidx_t gtreeid,
                                    const double *ref_coords,
+                                   const int num_coords,
                                    double out_coords[3]) const
 {
   switch (active_tree_class) {

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
@@ -119,6 +119,8 @@ t8_geometry_occ::t8_geom_evaluate (t8_cmesh_t cmesh,
                                    const int num_coords,
                                    double out_coords[3]) const
 {
+  if (num_coords != 1)
+    SC_ABORT ("Error: Batch computation of geometry not yet supported.");
   switch (active_tree_class) {
   case T8_ECLASS_TRIANGLE:
     t8_geometry_occ::t8_geom_evaluate_occ_triangle (cmesh, gtreeid,
@@ -144,8 +146,11 @@ t8_geometry_occ::t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                                             t8_gloidx_t gtreeid,
                                             const double
                                             *ref_coords,
+                                            const int num_coords,
                                             double *jacobian_out) const
 {
+  if (num_coords != 1)
+    SC_ABORT ("Error: Batch computation of geometry not yet supported.");
   double              h = 1e-9;
   double              in1[3], in2[3];
   double              out1[3], out2[3];

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.hxx
@@ -108,12 +108,14 @@ public:
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
    * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   virtual void
   t8_geom_evaluate (t8_cmesh_t cmesh,
                     t8_gloidx_t gtreeid,
                     const double *ref_coords,
+                    const int num_coords,
                     double out_coords[3]) const;
 
   /**
@@ -121,6 +123,7 @@ public:
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
    * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    */
@@ -128,6 +131,7 @@ public:
   t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                             t8_gloidx_t gtreeid,
                             const double *ref_coords,
+                            const int num_coords,
                             double *jacobian) const;
 
 

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.hxx
@@ -63,7 +63,7 @@ extern const int
  * coordinates regarding the occ geometries linked to the cells edges and faces.
  * \param [in]  cmesh       The cmesh.
  * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
  * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
  * \param [in]  tree_data   The data of the current tree as loaded by a \ref t8_geom_load_tree_data_fn.
  */
@@ -104,10 +104,10 @@ public:
   }
 
   /**
-   * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
+   * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   virtual void
@@ -117,10 +117,10 @@ public:
                     double out_coords[3]) const;
 
   /**
-   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
+   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    */
@@ -319,10 +319,10 @@ public:
 
 private:
   /**
-   * Map a point in the reference space \f( [0,1]^2 \f) to \f$ \mathbb{R}^3 \f). Only for triangle trees.
+   * Map a point in the reference space \f$ [0,1]^2 \f$ to \f$ \mathbb{R}^3 \f$. Only for triangle trees.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of 2 entries, specifying a point in \f( [0,1]^2 \f).
+   * \param [in]  ref_coords  Array of 2 entries, specifying a point in \f$ [0,1]^2 \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void
@@ -332,10 +332,10 @@ private:
                                  double out_coords[3]) const;
 
   /**
-   * Map a point in the reference space \f( [0,1]^2 \f) to \f$ \mathbb{R}^3 \f). Only for quad trees.
+   * Map a point in the reference space \f$ [0,1]^2 \f$ to \f$ \mathbb{R}^3 \f$. Only for quad trees.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of 2 entries, specifying a point in \f( [0,1]^2 \f).
+   * \param [in]  ref_coords  Array of 2 entries, specifying a point in \f$ [0,1]^2 \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void
@@ -345,10 +345,10 @@ private:
                              double out_coords[3]) const;
 
   /**
-   * Map a point in the reference space \f( \f( [0,1]^3 \f) \f) to \f$ \mathbb{R}^3 \f). Only for hex trees.
+   * Map a point in the reference space \f$ \f$ [0,1]^3 \f$ \f$ to \f$ \mathbb{R}^3 \f$. Only for hex trees.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of 3 entries, specifying a point in \f( [0,1]^3 \f).
+   * \param [in]  ref_coords  Array of 3 entries, specifying a point in \f$ [0,1]^3 \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.hxx
@@ -63,7 +63,7 @@ extern const int
  * coordinates regarding the occ geometries linked to the cells edges and faces.
  * \param [in]  cmesh       The cmesh.
  * \param [in]  gtreeid     The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
  * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
  * \param [in]  tree_data   The data of the current tree as loaded by a \ref t8_geom_load_tree_data_fn.
  */
@@ -104,10 +104,10 @@ public:
   }
 
   /**
-   * Map a point in the reference space $$[0,1]^dimension$$ to $$\mathbb R^3$$
+   * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   virtual void
@@ -117,10 +117,10 @@ public:
                     double out_coords[3]) const;
 
   /**
-   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space $$[0,1]^dimension$$.
+   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    */
@@ -319,10 +319,10 @@ public:
 
 private:
   /**
-   * Map a point in the reference space $$[0,1]^2$$ to $$\mathbb R^3$$. Only for triangle trees.
+   * Map a point in the reference space \f( [0,1]^2 \f) to \f$ \mathbb{R}^3 \f). Only for triangle trees.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of 2 entries, specifying a point in [0,1]^2.
+   * \param [in]  ref_coords  Array of 2 entries, specifying a point in \f( [0,1]^2 \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void
@@ -332,10 +332,10 @@ private:
                                  double out_coords[3]) const;
 
   /**
-   * Map a point in the reference space $$[0,1]^2$$ to $$\mathbb R^3$$. Only for quad trees.
+   * Map a point in the reference space \f( [0,1]^2 \f) to \f$ \mathbb{R}^3 \f). Only for quad trees.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of 2 entries, specifying a point in [0,1]^2.
+   * \param [in]  ref_coords  Array of 2 entries, specifying a point in \f( [0,1]^2 \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void
@@ -345,10 +345,10 @@ private:
                              double out_coords[3]) const;
 
   /**
-   * Map a point in the reference space $$[0,1]^3$$ to $$\mathbb R^3$$. Only for hex trees.
+   * Map a point in the reference space \f( \f( [0,1]^3 \f) \f) to \f$ \mathbb{R}^3 \f). Only for hex trees.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of 3 entries, specifying a point in [0,1]^3.
+   * \param [in]  ref_coords  Array of 3 entries, specifying a point in \f( [0,1]^3 \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    */
   void

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.cxx
@@ -38,47 +38,31 @@ t8_geometry_zero::~t8_geometry_zero ()
   T8_FREE ((char *) name);
 }
 
-/**
- * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
- * \param [in]  cmesh      The cmesh in which the point lies.
- * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
- * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
- */
-/* *INDENT-OFF* */
-/* Indent has trouble with the const keyword at the end */
 void
 t8_geometry_zero::t8_geom_evaluate (t8_cmesh_t cmesh,
                                     t8_gloidx_t gtreeid,
                                     const double *ref_coords,
-                                    double out_coords[3]) const
-/* *INDENT-ON* */
+                                    const int num_coords,
+                                    double *out_coords) const
 {
   /* Set the out_coords to 0 */
-  out_coords[0] = 0;
-  out_coords[1] = 0;
-  out_coords[2] = 0;
+  for (int coord = 0; coord < num_coords; coord++) {
+    out_coords[0 + num_coords * T8_ECLASS_MAX_DIM] = 0;
+    out_coords[1 + num_coords * T8_ECLASS_MAX_DIM] = 0;
+    out_coords[2 + num_coords * T8_ECLASS_MAX_DIM] = 0;
+  }
 }
 
-/**
- * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
- * \param [in]  cmesh      The cmesh in which the point lies.
- * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
- * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
- *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
- */
-/* *INDENT-OFF* */
-/* Indent has trouble with the const keyword at the end */
 void
 t8_geometry_zero::t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
-                                            t8_gloidx_t gtreeid,
-                                            const double
-                                            *ref_coords, double *jacobian) const
-/* *INDENT-ON* */
+                                             t8_gloidx_t gtreeid,
+                                             const double
+                                             *ref_coords,
+                                             const int num_coords,
+                                             double *jacobian) const
 {
   /* Set the jacobian to 0 */
-  memset (jacobian, 0, sizeof (double) * 3 * dimension);
+  memset (jacobian, 0, sizeof (double) * 3 * dimension * num_coords);
 }
 
 inline void

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.cxx
@@ -39,10 +39,10 @@ t8_geometry_zero::~t8_geometry_zero ()
 }
 
 /**
- * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
+ * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
  * \param [in]  cmesh      The cmesh in which the point lies.
  * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
  * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
  */
 /* *INDENT-OFF* */
@@ -61,10 +61,10 @@ t8_geometry_zero::t8_geom_evaluate (t8_cmesh_t cmesh,
 }
 
 /**
- * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
+ * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
  * \param [in]  cmesh      The cmesh in which the point lies.
  * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
  * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
  *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
  */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.cxx
@@ -39,10 +39,10 @@ t8_geometry_zero::~t8_geometry_zero ()
 }
 
 /**
- * Map a point in the reference space $$[0,1]^dimension$$ to $$\mathbb R^3$$
+ * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
  * \param [in]  cmesh      The cmesh in which the point lies.
  * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
  * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
  */
 /* *INDENT-OFF* */
@@ -61,10 +61,10 @@ t8_geometry_zero::t8_geom_evaluate (t8_cmesh_t cmesh,
 }
 
 /**
- * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space $$[0,1]^dimension$$.
+ * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
  * \param [in]  cmesh      The cmesh in which the point lies.
  * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
- * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
  * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
  *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
  */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.hxx
@@ -46,10 +46,10 @@ public:
                       virtual ~ t8_geometry_zero ();
 
   /**
-   * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
+   * Map a point in the reference space \f$ [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    * \note All entries in out_coords will be set to 0.
    */
@@ -59,10 +59,10 @@ public:
                                         double out_coords[3]) const;
 
   /**
-   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
+   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f$ [0,1]^\mathrm{dim} \f$.
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    * \note All entries in \a jacobian will be set to zero.

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.hxx
@@ -46,10 +46,10 @@ public:
                       virtual ~ t8_geometry_zero ();
 
   /**
-   * Map a point in the reference space $$[0,1]^dimension$$ to $$\mathbb R^3$$
+   * Map a point in the reference space \f( [0,1]^\mathrm{dim} \to \mathbb{R}^3 \f).
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    * \note All entries in out_coords will be set to 0.
    */
@@ -59,10 +59,10 @@ public:
                                         double out_coords[3]) const;
 
   /**
-   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space $$[0,1]^dimension$$.
+   * Compute the jacobian of the \a t8_geom_evaluate map at a point in the reference space \f( [0,1]^\mathrm{dim} \f).
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
-   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+   * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f( [0,1]^dimension \f).
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    * \note All entries in \a jacobian will be set to zero.

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.hxx
@@ -50,12 +50,14 @@ public:
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
    * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
    * \note All entries in out_coords will be set to 0.
    */
   virtual void        t8_geom_evaluate (t8_cmesh_t cmesh,
                                         t8_gloidx_t gtreeid,
                                         const double *ref_coords,
+                                        const int num_coords,
                                         double out_coords[3]) const;
 
   /**
@@ -63,6 +65,7 @@ public:
    * \param [in]  cmesh      The cmesh in which the point lies.
    * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
    * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in \f$ [0,1]^\mathrm{dim} \f$.
+   * \param [in]  num_coords  Amount of points of /f$ \mathrm{dim} /f$ to map.
    * \param [out] jacobian    The jacobian at \a ref_coords. Array of size dimension x 3. Indices 3*i, 3*i+1, 3*i+2
    *                          correspond to the i-th column of the jacobian (Entry 3*i + j is del f_j/del x_i).
    * \note All entries in \a jacobian will be set to zero.
@@ -70,6 +73,7 @@ public:
   virtual void        t8_geom_evaluate_jacobian (t8_cmesh_t cmesh,
                                                  t8_gloidx_t gtreeid,
                                                  const double *ref_coords,
+                                                 const int num_coords,
                                                  double *jacobian) const;
 
   /** Update a possible internal data buffer for per tree data.

--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
@@ -109,17 +109,19 @@ public:
                                                 int vertex,
                                                 int coords[]) const = 0;
 
-  /** Convert a point in the reference space of an element to a point in the
+  /** Convert points in the reference space of an element to points in the
    *  reference space of the tree.
    * 
    * \param [in] elem         The element.
-   * \param [in] coords_input The coordinates of the point in the reference space of the element.
-   * \param [in] user_data    User data.
-   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
+   *                          in the reference space of the element.
+   * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [out] out_coords  The coordinates of the points in the
+   *                          reference space of the tree.
    */
   virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
-                                                   const void *user_data,
+                                                   const int num_coords,
                                                    double *out_coords)
     const = 0;
 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -664,13 +664,13 @@ t8_default_scheme_hex_c::t8_element_reference_coords (const t8_element_t
                                                       *elem,
                                                       const double
                                                       *ref_coords,
-                                                      const void *user_data,
+                                                      const int num_coords,
                                                       double *out_coords)
   const
 {
   T8_ASSERT (t8_element_is_valid (elem));
   t8_dhex_compute_reference_coords ((const t8_dhex_t *) elem, ref_coords,
-                                    out_coords);
+                                    num_coords, out_coords);
 }
 
 int

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -569,17 +569,19 @@ public:
                                                           double coords[])
     const;
 
-  /** Convert a point in the reference space of an element to a point in the
+  /** Convert points in the reference space of an element to points in the
    *  reference space of the tree.
    * 
    * \param [in] elem         The element.
-   * \param [in] coords_input The coordinates of the point in the reference space of the element.
-   * \param [in] user_data    User data.
-   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
+   *                          in the reference space of the element.
+   * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [out] out_coords  The coordinates of the points in the
+   *                          reference space of the tree.
    */
   virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
-                                                   const void *user_data,
+                                                   const int num_coords,
                                                    double *out_coords)
     const;
 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
@@ -26,22 +26,25 @@
 void
 t8_dhex_compute_reference_coords (const t8_dhex_t * elem,
                                   const double *ref_coords,
-                                  double *out_coords)
+                                  const int num_coords, double *out_coords)
 {
   const p8est_quadrant_t *q1 = (const p8est_quadrant_t *) elem;
 
   /* Get the length of the quadrant */
   const p4est_qcoord_t len = P8EST_QUADRANT_LEN (q1->level);
 
-  /* Compute the x, y and z coordinates of the point depending on the
-   * reference coordinates */
-  out_coords[0] = q1->x + ref_coords[0] * len;
-  out_coords[1] = q1->y + ref_coords[1] * len;
-  out_coords[2] = q1->z + ref_coords[2] * len;
+  for (int coord = 0; coord < num_coords; ++coord) {
+    const int           offset = 3 * coord;
+    /* Compute the x, y and z coordinates of the point depending on the
+     * reference coordinates */
+    out_coords[offset + 0] = q1->x + ref_coords[offset + 0] * len;
+    out_coords[offset + 1] = q1->y + ref_coords[offset + 1] * len;
+    out_coords[offset + 2] = q1->z + ref_coords[offset + 2] * len;
 
-  /* We divide the integer coordinates by the root length of the hex
-   * to obtain the reference coordinates. */
-  out_coords[0] /= (double) P8EST_ROOT_LEN;
-  out_coords[1] /= (double) P8EST_ROOT_LEN;
-  out_coords[2] /= (double) P8EST_ROOT_LEN;
+    /* We divide the integer coordinates by the root length of the hex
+     * to obtain the reference coordinates. */
+    out_coords[offset + 0] /= (double) P8EST_ROOT_LEN;
+    out_coords[offset + 1] /= (double) P8EST_ROOT_LEN;
+    out_coords[offset + 2] /= (double) P8EST_ROOT_LEN;
+  }
 }

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
@@ -33,9 +33,9 @@
 T8_EXTERN_C_BEGIN ();
 
 /** Convert a point in the reference space of a hex element to a point in the
- *  reference space of the tree (level 0) embedded in \f( [0,1]^3 \f).
+ *  reference space of the tree (level 0) embedded in \f$ [0,1]^3 \f$.
  * \param [in]  elem       Input hex.
- * \param [in]  ref_coords The reference coordinate on the hex \f( [0,1]^3 \f)
+ * \param [in]  ref_coords The reference coordinate on the hex \f$ [0,1]^3 \f$
  * \param [out] out_coords An array of 1 double that
  * 		                     will be filled with the reference coordinates
  *                         of the point on the hex.

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
@@ -33,9 +33,9 @@
 T8_EXTERN_C_BEGIN ();
 
 /** Convert a point in the reference space of a hex element to a point in the
- *  reference space of the tree (level 0) embedded in [0,1]^3.
+ *  reference space of the tree (level 0) embedded in \f( [0,1]^3 \f).
  * \param [in]  elem       Input hex.
- * \param [in]  ref_coords The reference coordinate on the hex [0, 1]^3
+ * \param [in]  ref_coords The reference coordinate on the hex \f( [0,1]^3 \f)
  * \param [out] out_coords An array of 1 double that
  * 		                     will be filled with the reference coordinates
  *                         of the point on the hex.

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
@@ -32,17 +32,20 @@
 
 T8_EXTERN_C_BEGIN ();
 
-/** Convert a point in the reference space of a hex element to a point in the
+/** Convert points in the reference space of a hex element to points in the
  *  reference space of the tree (level 0) embedded in \f$ [0,1]^3 \f$.
  * \param [in]  elem       Input hex.
- * \param [in]  ref_coords The reference coordinate on the hex \f$ [0,1]^3 \f$
- * \param [out] out_coords An array of 1 double that
+ * \param [in]  ref_coords The reference coordinates in the hex
+ *                         (\a num_coords times \f$ [0,1]^3 \f$)
+ * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [out] out_coords An array of \a num_coords x 3 x double that
  * 		                     will be filled with the reference coordinates
- *                         of the point on the hex.
+ *                         of the points on the hex.
  */
 void                t8_dhex_compute_reference_coords (const t8_dhex_t * elem,
                                                       const double
                                                       *ref_coords,
+                                                      const int num_coords,
                                                       double *out_coords);
 
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
@@ -372,14 +372,14 @@ t8_default_scheme_line_c::t8_element_reference_coords (const t8_element_t
                                                        *elem,
                                                        const double
                                                        *ref_coords,
-                                                       const void *user_data,
+                                                       const int num_coords,
                                                        double *out_coords)
   const
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (ref_coords != NULL);
   t8_dline_compute_reference_coords ((const t8_dline_t *) elem, ref_coords,
-                                     out_coords);
+                                     num_coords, 0, out_coords);
 }
 
 int

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
@@ -587,17 +587,19 @@ public:
                                                           double coords[])
     const;
 
-  /** Convert a point in the reference space of an element to a point in the
+  /** Convert points in the reference space of an element to points in the
    *  reference space of the tree.
    * 
    * \param [in] elem         The element.
-   * \param [in] coords_input The coordinates of the point in the reference space of the element.
-   * \param [in] user_data    User data.
-   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
+   *                          in the reference space of the element.
+   * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [out] out_coords  The coordinates of the points in the
+   *                          reference space of the tree.
    */
   virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
-                                                   const void *user_data,
+                                                   const int num_coords,
                                                    double *out_coords)
     const;
 

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
@@ -352,12 +352,16 @@ t8_dline_vertex_ref_coords (const t8_dline_t *elem, const int vertex,
 void
 t8_dline_compute_reference_coords (const t8_dline_t *elem,
                                    const double *ref_coords,
-                                   double *out_coords)
+                                   const int num_coords,
+                                   const int skip_coords, double *out_coords)
 {
   T8_ASSERT (t8_dline_is_valid (elem));
-  out_coords[0] = elem->x;
-  out_coords[0] += T8_DLINE_LEN (elem->level) * ref_coords[0];
-  out_coords[0] /= (double) T8_DLINE_ROOT_LEN;
+  for (int coord = 0; coord < num_coords; ++coord) {
+    const int           offset = coord * skip_coords;
+    out_coords[offset] = elem->x;
+    out_coords[offset] += T8_DLINE_LEN (elem->level) * ref_coords[coord];
+    out_coords[offset] /= (double) T8_DLINE_ROOT_LEN;
+  }
 }
 
 t8_linearidx_t

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
@@ -242,17 +242,25 @@ void                t8_dline_vertex_ref_coords (const t8_dline_t *elem,
                                                 const int vertex,
                                                 double coordinates[1]);
 
-/** Convert a point in the reference space of a line element to a point in the
+/** Convert points in the reference space of a line element to points in the
  *  reference space of the tree (level 0) embedded in [0,1]^1.
  * \param [in]  elem       Input line.
- * \param [in]  ref_coords The reference coordinate on the line \f$ [0,1]^1 \f$
- * \param [out] out_coords An array of 1 double that
+ * \param [in]  ref_coords The reference coordinates in the line
+ *                         (\a num_coords times \f$ [0,1]^1 \f$)
+ * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [in]  skip_coords Only used for batch computation of prisms.
+ *                          In all other cases 0.
+ *                          Skip coordinates in the \a ref_coords and
+ *                          \a out_coords array.
+ * \param [out] out_coords An array of \a num_coords x 1 x double that
  * 		                     will be filled with the reference coordinates
- *                         of the point on the line.
+ *                         of the points on the line.
  */
 void                t8_dline_compute_reference_coords (const t8_dline_t *elem,
                                                        const double
                                                        *ref_coords,
+                                                       const int num_coords,
+                                                       const int skip_coords,
                                                        double *out_coords);
 
 /** Computes the linear position of a line in an uniform grid.

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
@@ -245,7 +245,7 @@ void                t8_dline_vertex_ref_coords (const t8_dline_t *elem,
 /** Convert a point in the reference space of a line element to a point in the
  *  reference space of the tree (level 0) embedded in [0,1]^1.
  * \param [in]  elem       Input line.
- * \param [in]  ref_coords The reference coordinate on the line [0, 1]^1
+ * \param [in]  ref_coords The reference coordinate on the line \f( [0,1]^1 \f)
  * \param [out] out_coords An array of 1 double that
  * 		                     will be filled with the reference coordinates
  *                         of the point on the line.

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
@@ -245,7 +245,7 @@ void                t8_dline_vertex_ref_coords (const t8_dline_t *elem,
 /** Convert a point in the reference space of a line element to a point in the
  *  reference space of the tree (level 0) embedded in [0,1]^1.
  * \param [in]  elem       Input line.
- * \param [in]  ref_coords The reference coordinate on the line \f( [0,1]^1 \f)
+ * \param [in]  ref_coords The reference coordinate on the line \f$ [0,1]^1 \f$
  * \param [out] out_coords An array of 1 double that
  * 		                     will be filled with the reference coordinates
  *                         of the point on the line.

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -484,13 +484,13 @@ t8_default_scheme_prism_c::t8_element_reference_coords (const t8_element_t
                                                         *elem,
                                                         const double
                                                         *ref_coords,
-                                                        const void *user_data,
+                                                        const int num_coords,
                                                         double *out_coords)
   const
 {
   T8_ASSERT (t8_element_is_valid (elem));
   t8_dprism_compute_reference_coords ((const t8_dprism_t *) elem, ref_coords,
-                                      out_coords);
+                                      num_coords, out_coords);
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
@@ -596,17 +596,19 @@ public:
                                                           double coords[])
     const;
 
-  /** Convert a point in the reference space of an element to a point in the
+  /** Convert points in the reference space of an element to points in the
    *  reference space of the tree.
    * 
    * \param [in] elem         The element.
-   * \param [in] coords_input The coordinates of the point in the reference space of the element.
-   * \param [in] user_data    User data.
-   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
+   *                          in the reference space of the element.
+   * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [out] out_coords  The coordinates of the points in the
+   *                          reference space of the tree.
    */
   virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
-                                                   const void *user_data,
+                                                   const int num_coords,
                                                    double *out_coords)
     const;
 

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -597,15 +597,16 @@ t8_dprism_vertex_ref_coords (const t8_dprism_t *elem, const int vertex,
 void
 t8_dprism_compute_reference_coords (const t8_dprism_t *elem,
                                     const double *ref_coords,
-                                    double *out_coords)
+                                    const int num_coords, double *out_coords)
 {
   T8_ASSERT (t8_dprism_is_valid (elem));
   T8_ASSERT (elem->line.level == elem->tri.level);
   /*Compute x and y coordinate */
-  t8_dtri_compute_reference_coords (&elem->tri, ref_coords, out_coords);
+  t8_dtri_compute_reference_coords (&elem->tri, ref_coords, num_coords, 1,
+                                    out_coords);
   /*Compute z coordinate */
-  t8_dline_compute_reference_coords (&elem->line, ref_coords + 2,
-                                     out_coords + 2);
+  t8_dline_compute_reference_coords (&elem->line, ref_coords + 2, num_coords,
+                                     2, out_coords + 2);
 }
 
 t8_linearidx_t

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
@@ -316,18 +316,20 @@ void                t8_dprism_vertex_ref_coords (const t8_dprism_t *elem,
                                                  int vertex,
                                                  double coords[3]);
 
-/** Convert a point in the reference space of a prism element to a point in the
+/** Convert points in the reference space of a prism element to points in the
  *  reference space of the tree (level 0) embedded in \f$ [0,1]^3 \f$.
- * \param [in]  elem       Input prism.
- * \param [in]  ref_coords The reference coordinates inside the
- *                         prism element \f$ [0,1]^3 \f$
- * \param [out] out_coords An array of 3 doubles that will be filled with the
- *                         reference coordinates in the tree of the prism.
+ * \param [in]  ref_coords The reference coordinates in the prism
+ *                         (\a num_coords times \f$ [0,1]^3 \f$)
+ * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [out] out_coords An array of \a num_coords x 3 x double that
+ * 		                     will be filled with the reference coordinates
+ *                         of the points on the prism.
  */
 void                t8_dprism_compute_reference_coords (const t8_dprism_t
                                                         *elem,
                                                         const double
                                                         *ref_coords,
+                                                        const int num_coords,
                                                         double *out_coords);
 
 /** Computes the linear position of a prism in an uniform grid.

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
@@ -306,7 +306,7 @@ void                t8_dprism_vertex_coords (const t8_dprism_t *elem,
                                              int vertex, int coords[3]);
 
 /** Compute the reference coordinates of a vertex of a prism when the 
- * tree (level 0) is embedded in \f( [0,1]^3 \f).
+ * tree (level 0) is embedded in \f$ [0,1]^3 \f$.
  * \param [in] elem         Input prism.
  * \param [in] vertex       The number of the vertex.
  * \param [out] coordinates An array of 3 double that
@@ -317,10 +317,10 @@ void                t8_dprism_vertex_ref_coords (const t8_dprism_t *elem,
                                                  double coords[3]);
 
 /** Convert a point in the reference space of a prism element to a point in the
- *  reference space of the tree (level 0) embedded in \f( [0,1]^3 \f).
+ *  reference space of the tree (level 0) embedded in \f$ [0,1]^3 \f$.
  * \param [in]  elem       Input prism.
  * \param [in]  ref_coords The reference coordinates inside the
- *                         prism element \f( [0,1]^3 \f)
+ *                         prism element \f$ [0,1]^3 \f$
  * \param [out] out_coords An array of 3 doubles that will be filled with the
  *                         reference coordinates in the tree of the prism.
  */

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
@@ -306,7 +306,7 @@ void                t8_dprism_vertex_coords (const t8_dprism_t *elem,
                                              int vertex, int coords[3]);
 
 /** Compute the reference coordinates of a vertex of a prism when the 
- * tree (level 0) is embedded in [0,1]^3.
+ * tree (level 0) is embedded in \f( [0,1]^3 \f).
  * \param [in] elem         Input prism.
  * \param [in] vertex       The number of the vertex.
  * \param [out] coordinates An array of 3 double that
@@ -317,10 +317,10 @@ void                t8_dprism_vertex_ref_coords (const t8_dprism_t *elem,
                                                  double coords[3]);
 
 /** Convert a point in the reference space of a prism element to a point in the
- *  reference space of the tree (level 0) embedded in [0,1]^3.
+ *  reference space of the tree (level 0) embedded in \f( [0,1]^3 \f).
  * \param [in]  elem       Input prism.
  * \param [in]  ref_coords The reference coordinates inside the
- *                         prism element [0,1]^3
+ *                         prism element \f( [0,1]^3 \f)
  * \param [out] out_coords An array of 3 doubles that will be filled with the
  *                         reference coordinates in the tree of the prism.
  */

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -480,14 +480,14 @@ t8_default_scheme_pyramid_c::t8_element_reference_coords (const t8_element_t
                                                           *elem,
                                                           const double
                                                           *ref_coords,
-                                                          const void
-                                                          *user_data,
+                                                          const int
+                                                          num_coords,
                                                           double *out_coords)
   const
 {
   T8_ASSERT (t8_element_is_valid (elem));
   t8_dpyramid_compute_reference_coords ((const t8_dpyramid_t *) elem,
-                                        ref_coords, out_coords);
+                                        ref_coords, num_coords, out_coords);
 }
 
 int

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
@@ -615,17 +615,19 @@ public:
                                                           double coords[])
     const;
 
-  /** Convert a point in the reference space of an element to a point in the
+  /** Convert points in the reference space of an element to points in the
    *  reference space of the tree.
    * 
    * \param [in] elem         The element.
-   * \param [in] coords_input The coordinates of the point in the reference space of the element.
-   * \param [in] user_data    User data.
-   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
+   *                          in the reference space of the element.
+   * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [out] out_coords  The coordinates of the points in the
+   *                          reference space of the tree.
    */
   virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
-                                                   const void *user_data,
+                                                   const int num_coords,
                                                    double *out_coords)
     const;
 

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -1745,35 +1745,42 @@ t8_dpyramid_vertex_reference_coords (const t8_dpyramid_t *elem,
 void
 t8_dpyramid_compute_reference_coords (const t8_dpyramid_t *elem,
                                       const double *ref_coords,
+                                      const int num_coords,
                                       double *out_coords)
 {
   T8_ASSERT (ref_coords != NULL);
   T8_ASSERT (t8_dpyramid_is_valid (elem));
   if (t8_dpyramid_shape (elem) == T8_ECLASS_PYRAMID) {
     const t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (elem->pyramid.level);
-    out_coords[0] = elem->pyramid.x;
-    out_coords[1] = elem->pyramid.y;
-    out_coords[2] = elem->pyramid.z;
 
-    if (elem->pyramid.type == T8_DPYRAMID_FIRST_TYPE) {
-      out_coords[0] += ref_coords[0] * length;
-      out_coords[1] += ref_coords[1] * length;
-      out_coords[2] += ref_coords[2] * length;
-    }
-    else {
-      out_coords[0] += (ref_coords[0] - ref_coords[2]) * length;
-      out_coords[1] += (ref_coords[1] - ref_coords[2]) * length;
-      out_coords[2] += (1 - ref_coords[2]) * length;
-    }
+    for (int coord = 0; coord < num_coords; ++coord) {
+      const int           offset = coord * 3;
+      out_coords[offset + 0] = elem->pyramid.x;
+      out_coords[offset + 1] = elem->pyramid.y;
+      out_coords[offset + 2] = elem->pyramid.z;
 
-    /*scale the coordinates onto the reference cube */
-    out_coords[0] /= (double) T8_DPYRAMID_ROOT_LEN;
-    out_coords[1] /= (double) T8_DPYRAMID_ROOT_LEN;
-    out_coords[2] /= (double) T8_DPYRAMID_ROOT_LEN;
+      if (elem->pyramid.type == T8_DPYRAMID_FIRST_TYPE) {
+        out_coords[offset + 0] += ref_coords[offset + 0] * length;
+        out_coords[offset + 1] += ref_coords[offset + 1] * length;
+        out_coords[offset + 2] += ref_coords[offset + 2] * length;
+      }
+      else {
+        out_coords[offset + 0] +=
+          (ref_coords[offset + 0] - ref_coords[offset + 2]) * length;
+        out_coords[offset + 1] +=
+          (ref_coords[offset + 1] - ref_coords[offset + 2]) * length;
+        out_coords[offset + 2] += (1 - ref_coords[offset + 2]) * length;
+      }
+
+      /*scale the coordinates onto the reference cube */
+      out_coords[offset + 0] /= (double) T8_DPYRAMID_ROOT_LEN;
+      out_coords[offset + 1] /= (double) T8_DPYRAMID_ROOT_LEN;
+      out_coords[offset + 2] /= (double) T8_DPYRAMID_ROOT_LEN;
+    }
   }
   else {
     t8_dtet_compute_reference_coords (&(elem->pyramid), ref_coords,
-                                      out_coords);
+                                      num_coords, out_coords);
   }
 }
 

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
@@ -361,7 +361,7 @@ void                t8_dpyramid_successor (const t8_dpyramid_t *elem,
                                            t8_dpyramid_t *s, const int level);
 
 /** Compute the reference coordinates of a vertex of a pyramid when the
- * tree (level 0 triangle) is embedded in [0,1]^3.
+ * tree (level 0 triangle) is embedded in \f( [0,1]^3 \f).
  * \param [in] elem    Input pyramid.
  * \param [in] vertex The number of the vertex.
  * \param [out] coordinates An array of 3 double that
@@ -373,10 +373,10 @@ void                t8_dpyramid_vertex_reference_coords (const t8_dpyramid_t
                                                          double coords[]);
 
 /** Convert a point in the reference space of a pyramid element to a point in
- *  the reference space of the tree (level 0) embedded in [0,1]^3.
+ *  the reference space of the tree (level 0) embedded in \f( [0,1]^3 \f).
  * \param [in]  elem       Input pyramid.
  * \param [in]  ref_coords The reference coordinates inside the
- *                         pyramid element [0,1]^3
+ *                         pyramid element \f( [0,1]^3 \f)
  * \param [out] out_coords An array of 3 doubles that will be filled with the
  *                         reference coordinates in the tree of the pyramid.
  */

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
@@ -372,18 +372,22 @@ void                t8_dpyramid_vertex_reference_coords (const t8_dpyramid_t
                                                          const int vertex,
                                                          double coords[]);
 
-/** Convert a point in the reference space of a pyramid element to a point in
- *  the reference space of the tree (level 0) embedded in \f$ [0,1]^3 \f$.
+/** Convert points in the reference space of a pyramid element to points in the
+ *  reference space of the tree (level 0) embedded in \f$ [0,1]^3 \f$.
  * \param [in]  elem       Input pyramid.
- * \param [in]  ref_coords The reference coordinates inside the
- *                         pyramid element \f$ [0,1]^3 \f$
- * \param [out] out_coords An array of 3 doubles that will be filled with the
- *                         reference coordinates in the tree of the pyramid.
+ * \param [in]  ref_coords The reference coordinates in the pyramid
+ *                         (\a num_coords times \f$ [0,1]^3 \f$)
+ * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [out] out_coords An array of \a num_coords x 3 x double that
+ * 		                     will be filled with the reference coordinates
+ *                         of the points on the pyramid.
  */
 void                t8_dpyramid_compute_reference_coords (const t8_dpyramid_t
                                                           *elem,
                                                           const double
                                                           *ref_coords,
+                                                          const int
+                                                          num_coords,
                                                           double *out_coords);
 
 /**

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
@@ -361,7 +361,7 @@ void                t8_dpyramid_successor (const t8_dpyramid_t *elem,
                                            t8_dpyramid_t *s, const int level);
 
 /** Compute the reference coordinates of a vertex of a pyramid when the
- * tree (level 0 triangle) is embedded in \f( [0,1]^3 \f).
+ * tree (level 0 triangle) is embedded in \f$ [0,1]^3 \f$.
  * \param [in] elem    Input pyramid.
  * \param [in] vertex The number of the vertex.
  * \param [out] coordinates An array of 3 double that
@@ -373,10 +373,10 @@ void                t8_dpyramid_vertex_reference_coords (const t8_dpyramid_t
                                                          double coords[]);
 
 /** Convert a point in the reference space of a pyramid element to a point in
- *  the reference space of the tree (level 0) embedded in \f( [0,1]^3 \f).
+ *  the reference space of the tree (level 0) embedded in \f$ [0,1]^3 \f$.
  * \param [in]  elem       Input pyramid.
  * \param [in]  ref_coords The reference coordinates inside the
- *                         pyramid element \f( [0,1]^3 \f)
+ *                         pyramid element \f$ [0,1]^3 \f$
  * \param [out] out_coords An array of 3 doubles that will be filled with the
  *                         reference coordinates in the tree of the pyramid.
  */

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -797,13 +797,13 @@ t8_default_scheme_quad_c::t8_element_reference_coords (const t8_element_t
                                                        *elem,
                                                        const double
                                                        *ref_coords,
-                                                       const void *user_data,
+                                                       const int num_coords,
                                                        double *out_coords)
   const
 {
   T8_ASSERT (t8_element_is_valid (elem));
   t8_dquad_compute_reference_coords ((const t8_dquad_t *) elem, ref_coords,
-                                     out_coords);
+                                     num_coords, out_coords);
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -602,17 +602,19 @@ public:
                                                           double coords[])
     const;
 
-  /** Convert a point in the reference space of an element to a point in the
+  /** Convert points in the reference space of an element to points in the
    *  reference space of the tree.
    * 
    * \param [in] elem         The element.
-   * \param [in] coords_input The coordinates of the point in the reference space of the element.
-   * \param [in] user_data    User data.
-   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
+   *                          in the reference space of the element.
+   * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [out] out_coords  The coordinates of the points in the
+   *                          reference space of the tree.
    */
   virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
-                                                   const void *user_data,
+                                                   const int num_coords,
                                                    double *out_coords)
     const;
 

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c
@@ -26,15 +26,18 @@
 void
 t8_dquad_compute_reference_coords (const t8_dquad_t * elem,
                                    const double *ref_coords,
-                                   double *out_coords)
+                                   const int num_coords, double *out_coords)
 {
   const p4est_quadrant_t *q1 = (const p4est_quadrant_t *) elem;
 
   const p4est_qcoord_t h = P4EST_QUADRANT_LEN (q1->level);
 
-  out_coords[0] = q1->x + ref_coords[0] * h;
-  out_coords[1] = q1->y + ref_coords[1] * h;
+  for (int coord = 0; coord < num_coords; ++coord) {
+    const int           offset = coord * 2;
+    out_coords[offset + 0] = q1->x + ref_coords[offset + 0] * h;
+    out_coords[offset + 1] = q1->y + ref_coords[offset + 1] * h;
 
-  out_coords[0] /= (double) P4EST_ROOT_LEN;
-  out_coords[1] /= (double) P4EST_ROOT_LEN;
+    out_coords[offset + 0] /= (double) P4EST_ROOT_LEN;
+    out_coords[offset + 1] /= (double) P4EST_ROOT_LEN;
+  }
 }

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
@@ -33,9 +33,9 @@
 T8_EXTERN_C_BEGIN ();
 
 /** Convert a point in the reference space of a quad element to a point in the
- *  reference space of the tree (level 0) embedded in \f( [0,1]^2 \f).
+ *  reference space of the tree (level 0) embedded in \f$ [0,1]^2 \f$.
  * \param [in]  elem       Input quad.
- * \param [in]  ref_coords The reference coordinate on the quad \f( [0,1]^2 \f)
+ * \param [in]  ref_coords The reference coordinate on the quad \f$ [0,1]^2 \f$
  * \param [out] out_coords An array of 1 double that
  * 		                     will be filled with the reference coordinates
  *                         of the point on the quad.

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
@@ -32,18 +32,21 @@
 
 T8_EXTERN_C_BEGIN ();
 
-/** Convert a point in the reference space of a quad element to a point in the
+/** Convert points in the reference space of a quad element to points in the
  *  reference space of the tree (level 0) embedded in \f$ [0,1]^2 \f$.
  * \param [in]  elem       Input quad.
- * \param [in]  ref_coords The reference coordinate on the quad \f$ [0,1]^2 \f$
- * \param [out] out_coords An array of 1 double that
+ * \param [in]  ref_coords The reference coordinates in the quad
+ *                         (\a num_coords times \f$ [0,1]^2 \f$)
+ * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [out] out_coords An array of \a num_coords x 2 x double that
  * 		                     will be filled with the reference coordinates
- *                         of the point on the quad.
+ *                         of the points on the quad.
  */
 void                t8_dquad_compute_reference_coords (const t8_dquad_t *
                                                        elem,
                                                        const double
                                                        *ref_coords,
+                                                       const int num_coords,
                                                        double *out_coords);
 
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
@@ -33,9 +33,9 @@
 T8_EXTERN_C_BEGIN ();
 
 /** Convert a point in the reference space of a quad element to a point in the
- *  reference space of the tree (level 0) embedded in [0,1]^2.
+ *  reference space of the tree (level 0) embedded in \f( [0,1]^2 \f).
  * \param [in]  elem       Input quad.
- * \param [in]  ref_coords The reference coordinate on the quad [0, 1]^2
+ * \param [in]  ref_coords The reference coordinate on the quad \f( [0,1]^2 \f)
  * \param [out] out_coords An array of 1 double that
  * 		                     will be filled with the reference coordinates
  *                         of the point on the quad.

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
@@ -567,7 +567,7 @@ t8_default_scheme_tet_c::t8_element_reference_coords (const t8_element_t
 {
   T8_ASSERT (t8_element_is_valid (elem));
   t8_dtet_compute_reference_coords ((const t8_dtet_t *) elem, ref_coords,
-                                    num_coords, 0, out_coords);
+                                    num_coords, out_coords);
 }
 
 /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
@@ -561,13 +561,13 @@ t8_default_scheme_tet_c::t8_element_reference_coords (const t8_element_t
                                                       *elem,
                                                       const double
                                                       *ref_coords,
-                                                      const void *user_data,
+                                                      const int num_coords,
                                                       double *out_coords)
   const
 {
   T8_ASSERT (t8_element_is_valid (elem));
   t8_dtet_compute_reference_coords ((const t8_dtet_t *) elem, ref_coords,
-                                    out_coords);
+                                    num_coords, 0, out_coords);
 }
 
 /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
@@ -582,17 +582,19 @@ public:
                                                           double coords[])
     const;
 
-  /** Convert a point in the reference space of an element to a point in the
+  /** Convert points in the reference space of an element to points in the
    *  reference space of the tree.
    * 
    * \param [in] elem         The element.
-   * \param [in] coords_input The coordinates of the point in the reference space of the element.
-   * \param [in] user_data    User data.
-   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
+   *                          in the reference space of the element.
+   * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [out] out_coords  The coordinates of the points in the
+   *                          reference space of the tree.
    */
   virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
-                                                   const void *user_data,
+                                                   const int num_coords,
                                                    double *out_coords)
     const;
 

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
@@ -45,7 +45,7 @@ void                t8_dtet_compute_coords (const t8_dtet_t *elem, int vertex,
                                             t8_dtet_coord_t coordinates[3]);
 
 /** Compute the coordinates of a vertex of a tetrahedron when the 
- * tree (level 0 tetrahedron) is embedded in [0,1]^3.
+ * tree (level 0 tetrahedron) is embedded in \f( [0,1]^3 \f).
  * \param [in] elem         Input tetrahedron.
  * \param [in] vertex       The number of the vertex.
  * \param [out] coordinates An array of 3 double that
@@ -56,10 +56,10 @@ void                t8_dtet_compute_vertex_ref_coords (const t8_dtet_t *elem,
                                                        double coordinates[3]);
 
 /** Convert a point in the reference space of a tet element to a point in the
- *  reference space of the tree (level 0) embedded in [0,1]^3.
+ *  reference space of the tree (level 0) embedded in \f( [0,1]^3 \f).
  * \param [in]  elem       Input tetrahedron.
  * \param [in]  ref_coords The reference coordinates inside the
- *                         tet element [0,1]^2
+ *                         tet element \f( [0,1]^2 \f)
  * \param [out] out_coords An array of 3 doubles that will be filled with the
  *                         reference coordinates in the tree of the tet.
  */

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
@@ -45,7 +45,7 @@ void                t8_dtet_compute_coords (const t8_dtet_t *elem, int vertex,
                                             t8_dtet_coord_t coordinates[3]);
 
 /** Compute the coordinates of a vertex of a tetrahedron when the 
- * tree (level 0 tetrahedron) is embedded in \f( [0,1]^3 \f).
+ * tree (level 0 tetrahedron) is embedded in \f$ [0,1]^3 \f$.
  * \param [in] elem         Input tetrahedron.
  * \param [in] vertex       The number of the vertex.
  * \param [out] coordinates An array of 3 double that
@@ -56,10 +56,10 @@ void                t8_dtet_compute_vertex_ref_coords (const t8_dtet_t *elem,
                                                        double coordinates[3]);
 
 /** Convert a point in the reference space of a tet element to a point in the
- *  reference space of the tree (level 0) embedded in \f( [0,1]^3 \f).
+ *  reference space of the tree (level 0) embedded in \f$ [0,1]^3 \f$.
  * \param [in]  elem       Input tetrahedron.
  * \param [in]  ref_coords The reference coordinates inside the
- *                         tet element \f( [0,1]^2 \f)
+ *                         tet element \f$ [0,1]^2 \f$
  * \param [out] out_coords An array of 3 doubles that will be filled with the
  *                         reference coordinates in the tree of the tet.
  */

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
@@ -55,17 +55,20 @@ void                t8_dtet_compute_vertex_ref_coords (const t8_dtet_t *elem,
                                                        int vertex,
                                                        double coordinates[3]);
 
-/** Convert a point in the reference space of a tet element to a point in the
+/** Convert points in the reference space of a tet element to points in the
  *  reference space of the tree (level 0) embedded in \f$ [0,1]^3 \f$.
- * \param [in]  elem       Input tetrahedron.
- * \param [in]  ref_coords The reference coordinates inside the
- *                         tet element \f$ [0,1]^2 \f$
- * \param [out] out_coords An array of 3 doubles that will be filled with the
- *                         reference coordinates in the tree of the tet.
+ * \param [in]  elem       Input tet.
+ * \param [in]  ref_coords The reference coordinates in the tet
+ *                         (\a num_coords times \f$ [0,1]^3 \f$)
+ * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [out] out_coords An array of \a num_coords x 3 x double that
+ * 		                     will be filled with the reference coordinates
+ *                         of the points on the tet.
  */
 void                t8_dtet_compute_reference_coords (const t8_dtet_t *elem,
                                                       const double
                                                       *ref_coords,
+                                                      const int num_coords,
                                                       double out_coords[3]);
 
 /** Compute the coordinates of the four vertices of a tetrahedron.

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
@@ -586,7 +586,7 @@ t8_default_scheme_tri_c::t8_element_reference_coords (const t8_element_t
 {
   T8_ASSERT (t8_element_is_valid (elem));
   t8_dtri_compute_reference_coords ((const t8_dtri_t *) elem, ref_coords,
-                                    num_coords, out_coords);
+                                    num_coords, 0, out_coords);
 }
 
 int

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
@@ -580,13 +580,13 @@ t8_default_scheme_tri_c::t8_element_reference_coords (const t8_element_t
                                                       *elem,
                                                       const double
                                                       *ref_coords,
-                                                      const void *user_data,
+                                                      const int num_coords,
                                                       double *out_coords)
   const
 {
   T8_ASSERT (t8_element_is_valid (elem));
   t8_dtri_compute_reference_coords ((const t8_dtri_t *) elem, ref_coords,
-                                    out_coords);
+                                    num_coords, out_coords);
 }
 
 int

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
@@ -575,17 +575,19 @@ public:
                                                           double coords[])
     const;
 
-  /** Convert a point in the reference space of an element to a point in the
+  /** Convert points in the reference space of an element to points in the
    *  reference space of the tree.
    * 
    * \param [in] elem         The element.
-   * \param [in] coords_input The coordinates of the point in the reference space of the element.
-   * \param [in] user_data    User data.
-   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
+   *                          in the reference space of the element.
+   * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [out] out_coords  The coordinates of the points in the
+   *                          reference space of the tree.
    */
   virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
-                                                   const void *user_data,
+                                                   const int num_coords,
                                                    double *out_coords)
     const;
 

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
@@ -77,7 +77,7 @@ void                t8_dtri_compute_coords (const t8_dtri_t *elem,
                                             t8_dtri_coord_t coordinates[2]);
 
 /** Compute the reference coordinates of a vertex of a triangle when the 
- * tree (level 0 triangle) is embedded in \f( [0,1]^2 \f).
+ * tree (level 0 triangle) is embedded in \f$ [0,1]^2 \f$.
  * \param [in] elem         Input triangle.
  * \param [in] vertex       The number of the vertex.
  * \param [out] coordinates An array of 2 double that
@@ -88,10 +88,10 @@ void                t8_dtri_compute_vertex_ref_coords (const t8_dtri_t *elem,
                                                        double coordinates[2]);
 
 /** Convert a point in the reference space of a triangle element to a point in
- *  the reference space of the tree (level 0) embedded in \f( [0,1]^2 \f).
+ *  the reference space of the tree (level 0) embedded in \f$ [0,1]^2 \f$.
  * \param [in]  elem       Input triangle.
  * \param [in]  ref_coords The reference coordinates inside the
- *                         triangle element \f( [0,1]^2 \f)
+ *                         triangle element \f$ [0,1]^2 \f$
  * \param [out] out_coords An array of 2 doubles that will be filled with the
  *                         reference coordinates in the tree of the triangle.
  */

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
@@ -77,7 +77,7 @@ void                t8_dtri_compute_coords (const t8_dtri_t *elem,
                                             t8_dtri_coord_t coordinates[2]);
 
 /** Compute the reference coordinates of a vertex of a triangle when the 
- * tree (level 0 triangle) is embedded in [0,1]^2.
+ * tree (level 0 triangle) is embedded in \f( [0,1]^2 \f).
  * \param [in] elem         Input triangle.
  * \param [in] vertex       The number of the vertex.
  * \param [out] coordinates An array of 2 double that
@@ -88,10 +88,10 @@ void                t8_dtri_compute_vertex_ref_coords (const t8_dtri_t *elem,
                                                        double coordinates[2]);
 
 /** Convert a point in the reference space of a triangle element to a point in
- *  the reference space of the tree (level 0) embedded in [0,1]^2.
+ *  the reference space of the tree (level 0) embedded in \f( [0,1]^2 \f).
  * \param [in]  elem       Input triangle.
  * \param [in]  ref_coords The reference coordinates inside the
- *                         triangle element [0,1]^2
+ *                         triangle element \f( [0,1]^2 \f)
  * \param [out] out_coords An array of 2 doubles that will be filled with the
  *                         reference coordinates in the tree of the triangle.
  */

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
@@ -87,17 +87,25 @@ void                t8_dtri_compute_vertex_ref_coords (const t8_dtri_t *elem,
                                                        const int vertex,
                                                        double coordinates[2]);
 
-/** Convert a point in the reference space of a triangle element to a point in
- *  the reference space of the tree (level 0) embedded in \f$ [0,1]^2 \f$.
+/** Convert points in the reference space of a tri element to points in the
+ *  reference space of the tree (level 0) embedded in \f$ [0,1]^2 \f$.
  * \param [in]  elem       Input triangle.
- * \param [in]  ref_coords The reference coordinates inside the
- *                         triangle element \f$ [0,1]^2 \f$
- * \param [out] out_coords An array of 2 doubles that will be filled with the
- *                         reference coordinates in the tree of the triangle.
+ * \param [in]  ref_coords The reference coordinates in the triangle
+ *                         (\a num_coords times \f$ [0,1]^2 \f$)
+ * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [in]  skip_coords Only used for batch computation of prisms.
+ *                          In all other cases 0.
+ *                          Skip coordinates in the \a ref_coords and
+ *                          \a out_coords array.
+ * \param [out] out_coords An array of \a num_coords x 2 x double that
+ * 		                     will be filled with the reference coordinates
+ *                         of the points on the triangle.
  */
 void                t8_dtri_compute_reference_coords (const t8_dtri_t *elem,
                                                       const double
                                                       *ref_coords,
+                                                      const int num_coords,
+                                                      const int skip_coords,
                                                       double out_coords[2]);
 
 /** Compute the coordinates of the four vertices of a triangle.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
@@ -325,14 +325,13 @@ t8_default_scheme_vertex_c::t8_element_reference_coords (const t8_element_t
                                                          *elem,
                                                          const double
                                                          *ref_coords,
-                                                         const void
-                                                         *user_data,
+                                                         const int num_coords,
                                                          double *out_coords)
   const
 {
   T8_ASSERT (t8_element_is_valid (elem));
   t8_dvertex_compute_reference_coords ((const t8_dvertex_t *) elem,
-                                       ref_coords, out_coords);
+                                       ref_coords, num_coords, out_coords);
 }
 
 #ifdef T8_ENABLE_DEBUG

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
@@ -615,17 +615,19 @@ public:
                                                           double coords[])
     const;
 
-  /** Convert a point in the reference space of an element to a point in the
+  /** Convert points in the reference space of an element to points in the
    *  reference space of the tree.
    * 
    * \param [in] elem         The element.
-   * \param [in] coords_input The coordinates of the point in the reference space of the element.
-   * \param [in] user_data    User data.
-   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
+   *                          in the reference space of the element.
+   * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [out] out_coords  The coordinates of the points in the
+   *                          reference space of the tree.
    */
   virtual void        t8_element_reference_coords (const t8_element_t *elem,
                                                    const double *ref_coords,
-                                                   const void *user_data,
+                                                   const int num_coords,
                                                    double *out_coords)
     const;
 

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.c
@@ -176,11 +176,13 @@ t8_dvertex_vertex_ref_coords (const t8_dvertex_t *elem, const int vertex,
 void
 t8_dvertex_compute_reference_coords (const t8_dvertex_t *elem,
                                      const double *ref_coords,
-                                     double *out_coords)
+                                     const int num_coords, double *out_coords)
 {
   T8_ASSERT (abs (ref_coords[0]) <= T8_PRECISION_EPS);
   T8_ASSERT (t8_dvertex_is_valid (elem));
-  out_coords[0] = 0;
+  for (int coord = 0; coord < num_coords; ++coord) {
+    out_coords[coord] = 0;
+  }
 }
 
 t8_linearidx_t

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.h
@@ -195,16 +195,21 @@ void                t8_dvertex_vertex_ref_coords (const t8_dvertex_t *elem,
                                                   int vertex,
                                                   double coords[]);
 
-/** Compute the coordinates of a reference coordinate (always 0) inside the
- * [0,1]^0 reference space.
- * \param [in] elem         Vertex whose vertex is computed.
- * \param [in] ref_coords   The reference coordinate inside the vertex (must be 0).
- * \param [out] out_coords  The coordinates of the computed vertex, must have one entry (will be set to 0).
+/** Convert points in the reference space of a vertex element to points in the
+ *  reference space of the tree (level 0) embedded in \f$ [0,1]^1 \f$.
+ * \param [in]  elem       Input vertex.
+ * \param [in]  ref_coords The reference coordinates in the vertex
+ *                         (\a num_coords times \f$ [0,1]^1 \f$)
+ * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [out] out_coords An array of \a num_coords x 1 x double that
+ * 		                     will be filled with the reference coordinates
+ *                         of the points on the vertex (will be set to 0).
  */
 void                t8_dvertex_compute_reference_coords (const t8_dvertex_t
                                                          *elem,
                                                          const double
                                                          *ref_coords,
+                                                         const int num_coords,
                                                          double *out_coords);
 
 /** Computes the linear position of a vertex in an uniform grid.

--- a/test/t8_geometry/t8_gtest_geometry.cxx
+++ b/test/t8_geometry/t8_gtest_geometry.cxx
@@ -153,7 +153,7 @@ TEST_P (geometry, cmesh_geometry_linear)
     point[2] = (double) rand () / RAND_MAX;
 
     /* Evaluate the geometry */
-    t8_geometry_evaluate (cmesh, 0, point, point_mapped);
+    t8_geometry_evaluate (cmesh, 0, point, 1, point_mapped);
     /* Check that the first dim coordinates are the same */
     int                 idim;
     for (idim = 0; idim < dim; ++idim) {

--- a/test/t8_geometry/t8_gtest_geometry_occ.cxx
+++ b/test/t8_geometry/t8_gtest_geometry_occ.cxx
@@ -400,7 +400,7 @@ TEST (t8_gtest_geometry_occ, jacobian)
     0, 0, 1
   };
   cmesh = t8_create_occ_hypercube (rot_vec, -1, -1, NULL);
-  t8_geometry_jacobian (cmesh, 0, ref_coords, jacobian);
+  t8_geometry_jacobian (cmesh, 0, ref_coords, 1, jacobian);
   for (int i = 0; i < 9; ++i) {
     EXPECT_FLOAT_EQ (jacobian[i], jacobian_expect[i]);
   }

--- a/test/t8_geometry/t8_gtest_geometry_occ.cxx
+++ b/test/t8_geometry/t8_gtest_geometry_occ.cxx
@@ -267,7 +267,7 @@ t8_test_geometry_occ (double *rot_vec,
                      rotated_test_ref_coords, rotation_origin, 8);
   for (int i_coord = 0; i_coord < 8; ++i_coord) {
     t8_geometry_evaluate (cmesh, 0, rotated_test_ref_coords + i_coord * 3,
-                          out_coords);
+                          1, out_coords);
     EXPECT_NEAR (out_coords[0], test_return_coords[0 + i_coord * 3], tol);
     EXPECT_NEAR (out_coords[1], test_return_coords[1 + i_coord * 3], tol);
     EXPECT_NEAR (out_coords[2], test_return_coords[2 + i_coord * 3], tol);


### PR DESCRIPTION
**_Describe your changes here:_**



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
