### PR TITLE
Fix t8 forest leaf face neighbors memleak

### DIFF
--- a/doc/author_kirby.txt
+++ b/doc/author_kirby.txt
@@ -1,0 +1,1 @@
+I place my contributions to t8code under the FreeBSD license. Andrew Kirby (akirby@uwyo.edu)

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -2012,6 +2012,8 @@ t8_forest_element_face_neighbor (t8_forest_t forest,
       neighbor_scheme->t8_element_extrude_face (face_element,
                                                 boundary_scheme, neigh,
                                                 tree_neigh_face);
+    /* Free the face_element */
+    boundary_scheme->t8_element_destroy (1, &face_element);
 
     return global_neigh_id;
   }


### PR DESCRIPTION
**_Describe your changes here:_**
Fix memory leak in t8_forest_leaf_face_neighbors: `face_element` was not destroyed.
Closes #672.
Added BSD license for contributions.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] New Datatypes are added to t8indent_custom_datatypes.txt
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [x] The author added a BSD statement to `doc/` (or already has one)
