### PR TITLE
Add t8_element_destroy statements to improve memory management

### DIFF
--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1575,6 +1575,11 @@ t8_forest_free_trees (t8_forest_t forest)
   number_of_trees = forest->trees->elem_count;
   for (jt = 0; jt < number_of_trees; jt++) {
     tree = (t8_tree_t) t8_sc_array_index_locidx (forest->trees, jt);
+    if (t8_forest_get_tree_element_count (tree) < 1) {
+      /* if local tree is empty */
+      T8_ASSERT (forest->incomplete_trees);
+      continue;
+    }
     t8_element_array_reset (&tree->elements);
     t8_eclass_t         eclass = t8_forest_get_tree_class (forest, jt);
     t8_eclass_scheme_c *scheme = forest->scheme_cxx->eclass_schemes[eclass];

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1576,6 +1576,10 @@ t8_forest_free_trees (t8_forest_t forest)
   for (jt = 0; jt < number_of_trees; jt++) {
     tree = (t8_tree_t) t8_sc_array_index_locidx (forest->trees, jt);
     t8_element_array_reset (&tree->elements);
+    t8_eclass_t         eclass = t8_forest_get_tree_class (forest, jt);
+    t8_eclass_scheme_c *scheme = forest->scheme_cxx->eclass_schemes[eclass];
+    t8_element_destroy (scheme, 1, &tree->first_desc);
+    t8_element_destroy (scheme, 1, &tree->last_desc);
   }
   sc_array_destroy (forest->trees);
 }

--- a/src/t8_forest/t8_forest_balance.cxx
+++ b/src/t8_forest/t8_forest_balance.cxx
@@ -286,6 +286,15 @@ t8_forest_balance (t8_forest_t forest, int repartition)
   t8_forest_copy_trees (forest, forest_temp, 1);
   /* TODO: Also copy ghost elements if ghost creation is set */
 
+  /* t8_forest_copy_trees computes copies first/last descendant, but this is computed again outside */
+  int number_of_trees = forest->trees->elem_count;
+  for (int jt = 0; jt < number_of_trees; jt++) {
+    t8_tree_t tree = (t8_tree_t) t8_sc_array_index_locidx (forest->trees, jt);
+    t8_eclass_scheme_c *eclass_scheme = forest->scheme_cxx->eclass_schemes[tree->eclass];
+    eclass_scheme->t8_element_destroy(1,&tree->first_desc);
+    eclass_scheme->t8_element_destroy(1,&tree->last_desc);
+  }
+
   t8_log_indent_pop ();
   t8_global_productionf
     ("Done t8_forest_balance with %lli global elements.\n",

--- a/src/t8_forest/t8_forest_balance.cxx
+++ b/src/t8_forest/t8_forest_balance.cxx
@@ -286,15 +286,6 @@ t8_forest_balance (t8_forest_t forest, int repartition)
   t8_forest_copy_trees (forest, forest_temp, 1);
   /* TODO: Also copy ghost elements if ghost creation is set */
 
-  /* t8_forest_copy_trees computes copies first/last descendant, but this is computed again outside */
-  int number_of_trees = forest->trees->elem_count;
-  for (int jt = 0; jt < number_of_trees; jt++) {
-    t8_tree_t tree = (t8_tree_t) t8_sc_array_index_locidx (forest->trees, jt);
-    t8_eclass_scheme_c *eclass_scheme = forest->scheme_cxx->eclass_schemes[tree->eclass];
-    eclass_scheme->t8_element_destroy(1,&tree->first_desc);
-    eclass_scheme->t8_element_destroy(1,&tree->last_desc);
-  }
-
   t8_log_indent_pop ();
   t8_global_productionf
     ("Done t8_forest_balance with %lli global elements.\n",

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1452,7 +1452,7 @@ t8_forest_compute_desc (t8_forest_t forest)
       T8_ASSERT (forest->incomplete_trees);
       itree->first_desc = NULL;
       itree->last_desc = NULL;
-      break;
+      continue;
     }
     /* get the eclass scheme associated to tree */
     ts = forest->scheme_cxx->eclass_schemes[itree->eclass];
@@ -1763,11 +1763,6 @@ t8_forest_copy_trees (t8_forest_t forest, t8_forest_t from, int copy_elements)
     if (copy_elements) {
       t8_element_array_copy (&tree->elements, &fromtree->elements);
       tree->elements_offset = fromtree->elements_offset;
-      /* Copy the first and last descendant */
-      eclass_scheme->t8_element_new (1, &tree->first_desc);
-      eclass_scheme->t8_element_copy (fromtree->first_desc, tree->first_desc);
-      eclass_scheme->t8_element_new (1, &tree->last_desc);
-      eclass_scheme->t8_element_copy (fromtree->last_desc, tree->last_desc);
     }
     else {
       t8_element_array_truncate (&tree->elements);
@@ -3013,8 +3008,6 @@ t8_forest_element_owners_at_face_recursion (t8_forest_t forest,
                                                   lower_bound, upper_bound,
                                                   first_desc, last_desc);
     }
-    ts->t8_element_destroy (1, &first_face_desc);
-    ts->t8_element_destroy (1, &last_face_desc);
     ts->t8_element_destroy (num_children, face_children);
     T8_FREE (face_children);
   }

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -2166,7 +2166,7 @@ t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid,
     }
     if (gneigh_treeid < 0) {
       /* There exists no face neighbor across this face, we return with this info */
-      neigh_scheme->t8_element_destroy (1, neighbor_leafs);
+      neigh_scheme->t8_element_destroy (num_children_at_face, neighbor_leafs);
       T8_FREE (neighbor_leafs);
       T8_FREE (*dual_faces);
       *dual_faces = NULL;
@@ -3013,6 +3013,8 @@ t8_forest_element_owners_at_face_recursion (t8_forest_t forest,
                                                   lower_bound, upper_bound,
                                                   first_desc, last_desc);
     }
+    ts->t8_element_destroy (1, &first_face_desc);
+    ts->t8_element_destroy (1, &last_face_desc);
     ts->t8_element_destroy (num_children, face_children);
     T8_FREE (face_children);
   }
@@ -3083,6 +3085,9 @@ t8_forest_element_owners_bounds (t8_forest_t forest, t8_gloidx_t gtreeid,
   *upper =
     t8_forest_element_find_owner_ext (forest, gtreeid, last_desc, eclass,
                                       *lower, *upper, *upper, 1);
+  ts->t8_element_destroy (1, &first_desc);
+  ts->t8_element_destroy (1, &last_desc);
+
 }
 
 void
@@ -3273,6 +3278,7 @@ t8_forest_element_has_leaf_desc (t8_forest_t forest, t8_gloidx_t gtreeid,
       }
     }
   }
+  ts->t8_element_destroy (1, &last_desc);
   return 0;
 }
 

--- a/src/t8_forest/t8_forest_iterate.cxx
+++ b/src/t8_forest/t8_forest_iterate.cxx
@@ -375,6 +375,7 @@ t8_forest_search_tree (t8_forest_t forest, t8_locidx_t ltreeid,
   if (queries != NULL) {
     sc_array_destroy (active_queries);
   }
+  ts->t8_element_destroy (1, &nca);
 }
 
 void

--- a/src/t8_forest/t8_forest_iterate.cxx
+++ b/src/t8_forest/t8_forest_iterate.cxx
@@ -471,6 +471,7 @@ t8_forest_iterate_replace (t8_forest_t forest_new,
           else {
             /* elem_old got removed */
             el_removed = 1;
+            ts->t8_element_destroy (1, &elem_parent);
           }
         }
         else if (level_old > level_new) {
@@ -521,6 +522,7 @@ t8_forest_iterate_replace (t8_forest_t forest_new,
           else {
             /* elem_old got removed */
             el_removed = 1;
+            ts->t8_element_destroy (1, &elem_parent);
           }
         }
         else {

--- a/src/t8_forest/t8_forest_partition.cxx
+++ b/src/t8_forest/t8_forest_partition.cxx
@@ -159,6 +159,7 @@ t8_forest_partition_test_desc (t8_forest_t forest)
     T8_ASSERT (ts->t8_element_get_linear_id (elem_desc, level) >=
                first_desc_id);
   }
+  ts->t8_element_destroy (1, &elem_desc);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.cxx
@@ -51,6 +51,7 @@ static void         t8_default_mempool_free (sc_mempool_t * ts_context,
 t8_default_scheme_common_c::~t8_default_scheme_common_c ()
 {
   T8_ASSERT (ts_context != NULL);
+  SC_ASSERT(((sc_mempool_t *) ts_context)->elem_count == 0);
   sc_mempool_destroy ((sc_mempool_t *) ts_context);
 }
 

--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.cxx
@@ -51,7 +51,7 @@ static void         t8_default_mempool_free (sc_mempool_t * ts_context,
 t8_default_scheme_common_c::~t8_default_scheme_common_c ()
 {
   T8_ASSERT (ts_context != NULL);
-  SC_ASSERT(((sc_mempool_t *) ts_context)->elem_count == 0);
+  SC_ASSERT (((sc_mempool_t *) ts_context)->elem_count == 0);
   sc_mempool_destroy ((sc_mempool_t *) ts_context);
 }
 

--- a/test/t8_forest/t8_gtest_half_neighbors.cxx
+++ b/test/t8_forest/t8_gtest_half_neighbors.cxx
@@ -148,6 +148,7 @@ TEST_P (forest_half_neighbors, test_half_neighbors)
           T8_FREE (child_ids);
           T8_FREE (neighbor_face_children);
         }
+        neigh_scheme->t8_element_destroy (1, &neighbor);
         neigh_scheme->t8_element_destroy (num_face_neighs, half_neighbors);
         T8_FREE (half_neighbors);
       }

--- a/test/t8_schemes/t8_gtest_ancestor.cxx
+++ b/test/t8_schemes/t8_gtest_ancestor.cxx
@@ -97,6 +97,7 @@ TEST_P (ancestor, root_recursive_check)
   ts->t8_element_new (1, &parent);
   ts->t8_element_copy (correct_anc, parent);
   t8_recursive_ancestor (correct_anc, desc_a, parent, check, ts, max_lvl);
+  ts->t8_element_destroy (1, &parent);
 }
 
 TEST_P (ancestor, multi_level_recursive_check)
@@ -118,6 +119,8 @@ TEST_P (ancestor, multi_level_recursive_check)
     ts->t8_element_copy (correct_anc_high_level, parent);
     t8_recursive_ancestor (correct_anc, desc_a, parent, check, ts, i);
   }
+  ts->t8_element_destroy (1, &parent);
+  ts->t8_element_destroy (1, &correct_anc_high_level);
 }
 
 /* *INDENT-OFF* */

--- a/test/t8_schemes/t8_gtest_nca.cxx
+++ b/test/t8_schemes/t8_gtest_nca.cxx
@@ -315,9 +315,9 @@ TEST_P (nca, recursive_check_higher_level)
       }
     }
     else {
-  ts->t8_element_destroy (1, &parent_a);
-  ts->t8_element_destroy (1, &parent_b);
-  ts->t8_element_destroy (1, &correct_nca_high_level);
+      ts->t8_element_destroy (1, &parent_a);
+      ts->t8_element_destroy (1, &parent_b);
+      ts->t8_element_destroy (1, &correct_nca_high_level);
       GTEST_SKIP ();
     }
   }

--- a/test/t8_schemes/t8_gtest_nca.cxx
+++ b/test/t8_schemes/t8_gtest_nca.cxx
@@ -242,9 +242,9 @@ TEST_P (nca, recursive_check)
   int                 num_children;
   num_children = ts->t8_element_num_children (correct_nca);
   int                 i, j;
-  ts->t8_element_new (1, &parent_a);
-  ts->t8_element_new (1, &parent_b);
   if (num_children > 1) {
+    ts->t8_element_new (1, &parent_a);
+    ts->t8_element_new (1, &parent_b);
     ts->t8_element_child (correct_nca, 0, parent_a);
     ts->t8_element_child (correct_nca, 1, parent_b);
     for (i = 0; i < num_children - 1; i++) {
@@ -315,6 +315,9 @@ TEST_P (nca, recursive_check_higher_level)
       }
     }
     else {
+  ts->t8_element_destroy (1, &parent_a);
+  ts->t8_element_destroy (1, &parent_b);
+  ts->t8_element_destroy (1, &correct_nca_high_level);
       GTEST_SKIP ();
     }
   }

--- a/tutorials/general/memory_usage.h
+++ b/tutorials/general/memory_usage.h
@@ -5,36 +5,34 @@
 // NOTE: LINUS ONLY
 
 /* system header files */
-#  include <math.h>
-#  include <t8.h>
-#  include <stdlib.h>
-#  include <malloc.h>
+#include <math.h>
+#include <t8.h>
+#include <stdlib.h>
+#include <malloc.h>
 
-static inline
-double
-memory_usage(int display){
-    /* get malloc info structure */
-    struct mallinfo my_mallinfo = mallinfo();
+static              inline double
+memory_usage (int display)
+{
+  /* get malloc info structure */
+  struct mallinfo     my_mallinfo = mallinfo ();
 
-    /*total memory reserved by the system for malloc currently */
-    double reserved_mem = (double) my_mallinfo.arena;
+  /*total memory reserved by the system for malloc currently */
+  double              reserved_mem = (double) my_mallinfo.arena;
 
-    /* get all the memory currently allocated to user by malloc, etc. */
-    double used_mem = (double) my_mallinfo.hblkhd
-                  + (double) my_mallinfo.usmblks
-                  + (double) my_mallinfo.uordblks;
+  /* get all the memory currently allocated to user by malloc, etc. */
+  double              used_mem = (double) my_mallinfo.hblkhd
+    + (double) my_mallinfo.usmblks + (double) my_mallinfo.uordblks;
 
-    /* get memory not currently allocated to user but malloc controls */
-    double free_mem = (double) my_mallinfo.fsmblks
-                  + (double) my_mallinfo.fordblks;
+  /* get memory not currently allocated to user but malloc controls */
+  double              free_mem = (double) my_mallinfo.fsmblks
+    + (double) my_mallinfo.fordblks;
 
-    /* Print out concise malloc info line */
-    if (display) {
-        t8_global_essentialf("MEMORY USAGE: %f MB(%.0f) malloc: %f MB reserved (%.0f unused)\n",
-              used_mem / (1024.0 * 1024.0),
-              used_mem,
-              reserved_mem / (1024.0 * 1024.0),
-              free_mem);
-    }
-    return used_mem;
+  /* Print out concise malloc info line */
+  if (display) {
+    t8_global_essentialf
+      ("MEMORY USAGE: %f MB(%.0f) malloc: %f MB reserved (%.0f unused)\n",
+       used_mem / (1024.0 * 1024.0), used_mem,
+       reserved_mem / (1024.0 * 1024.0), free_mem);
+  }
+  return used_mem;
 }

--- a/tutorials/general/memory_usage.h
+++ b/tutorials/general/memory_usage.h
@@ -1,0 +1,40 @@
+/* file: memory_usage.h
+ *   >> captures the number of bytes used by malloc
+ */
+
+// NOTE: LINUS ONLY
+
+/* system header files */
+#  include <math.h>
+#  include <t8.h>
+#  include <stdlib.h>
+#  include <malloc.h>
+
+static inline
+double
+memory_usage(int display){
+    /* get malloc info structure */
+    struct mallinfo my_mallinfo = mallinfo();
+
+    /*total memory reserved by the system for malloc currently */
+    double reserved_mem = (double) my_mallinfo.arena;
+
+    /* get all the memory currently allocated to user by malloc, etc. */
+    double used_mem = (double) my_mallinfo.hblkhd
+                  + (double) my_mallinfo.usmblks
+                  + (double) my_mallinfo.uordblks;
+
+    /* get memory not currently allocated to user but malloc controls */
+    double free_mem = (double) my_mallinfo.fsmblks
+                  + (double) my_mallinfo.fordblks;
+
+    /* Print out concise malloc info line */
+    if (display) {
+        t8_global_essentialf("MEMORY USAGE: %f MB(%.0f) malloc: %f MB reserved (%.0f unused)\n",
+              used_mem / (1024.0 * 1024.0),
+              used_mem,
+              reserved_mem / (1024.0 * 1024.0),
+              free_mem);
+    }
+    return used_mem;
+}

--- a/tutorials/general/t8_step3_adapt_forest.cxx
+++ b/tutorials/general/t8_step3_adapt_forest.cxx
@@ -142,7 +142,7 @@ t8_step3_adapt_forest (t8_forest_t forest)
   };
 
   t8_forest_init (&forest_adapt);
-  t8_forest_set_adapt (forest_adapt, NULL, t8_step3_adapt_callback, 0);
+  t8_forest_set_adapt (forest_adapt, forest, t8_step3_adapt_callback, 0);
   t8_forest_set_ghost (forest_adapt, 1, T8_GHOST_FACES);
   t8_forest_set_balance (forest_adapt, forest, 1);
   t8_forest_set_user_data (forest_adapt, &adapt_data);

--- a/tutorials/general/t8_step3_adapt_forest.cxx
+++ b/tutorials/general/t8_step3_adapt_forest.cxx
@@ -147,8 +147,9 @@ t8_step3_adapt_forest (t8_forest_t forest)
   t8_forest_set_balance (forest_adapt, forest, 1);
   t8_forest_set_user_data (forest_adapt, &adapt_data);
   t8_forest_commit (forest_adapt);
-    return forest_adapt;
+  return forest_adapt;
 }
+
 /* Print the local and global number of elements of a forest. */
 void
 t8_step3_print_forest_information (t8_forest_t forest)
@@ -233,12 +234,11 @@ t8_step3_main (int argc, char **argv)
    * forest will take ownership of the old forest and destroy it.
    * Note that the adapted forest is a new forest, though. */
 
-  memory_usage(1);
-  for (int i= 0; i<1000; i++){
+  memory_usage (1);
+  for (int i = 0; i < 1000; i++) {
     forest = t8_step3_adapt_forest (forest);
-    memory_usage(1);
+    memory_usage (1);
   }
-
 
   /*
    *  Output.


### PR DESCRIPTION
**_Describe your changes here:_**
See discussion in #672: Memory that is allocated by t8_element_new, but not destroyed by t8_element_destroy, stays in the memory pool until the scheme is destroyed. This leads to an increasing memory footprint that doesn't show up as an error with the `sc` library or with `valgrind`.

This is a first batch of occurrences that I found, there still seem to be more during a balance call.  


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
