### PR TITLE
Add t8_element_destroy statements to improve memory management

### DIFF
--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1575,6 +1575,11 @@ t8_forest_free_trees (t8_forest_t forest)
   number_of_trees = forest->trees->elem_count;
   for (jt = 0; jt < number_of_trees; jt++) {
     tree = (t8_tree_t) t8_sc_array_index_locidx (forest->trees, jt);
+    if (t8_forest_get_tree_element_count (tree) < 1) {
+      /* if local tree is empty */
+      T8_ASSERT (forest->incomplete_trees);
+      continue;
+    }
     t8_element_array_reset (&tree->elements);
     /* destroy first and last descendant */
     t8_eclass_t         eclass = t8_forest_get_tree_class (forest, jt);

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1582,8 +1582,8 @@ t8_forest_free_trees (t8_forest_t forest)
     }
     t8_element_array_reset (&tree->elements);
     /* destroy first and last descendant */
-    t8_eclass_t         eclass = t8_forest_get_tree_class (forest, jt);
-    t8_eclass_scheme_c *scheme = forest->scheme_cxx->eclass_schemes[eclass];
+   const t8_eclass_t         eclass = t8_forest_get_tree_class (forest, jt);
+    const t8_eclass_scheme_c *scheme = forest->scheme_cxx->eclass_schemes[eclass];
     t8_element_destroy (scheme, 1, &tree->first_desc);
     t8_element_destroy (scheme, 1, &tree->last_desc);
   }

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1582,7 +1582,7 @@ t8_forest_free_trees (t8_forest_t forest)
     }
     t8_element_array_reset (&tree->elements);
     /* destroy first and last descendant */
-   const t8_eclass_t         eclass = t8_forest_get_tree_class (forest, jt);
+    const t8_eclass_t         eclass = t8_forest_get_tree_class (forest, jt);
     const t8_eclass_scheme_c *scheme = forest->scheme_cxx->eclass_schemes[eclass];
     t8_element_destroy (scheme, 1, &tree->first_desc);
     t8_element_destroy (scheme, 1, &tree->last_desc);

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1576,6 +1576,11 @@ t8_forest_free_trees (t8_forest_t forest)
   for (jt = 0; jt < number_of_trees; jt++) {
     tree = (t8_tree_t) t8_sc_array_index_locidx (forest->trees, jt);
     t8_element_array_reset (&tree->elements);
+    /* destroy first and last descendant */
+    t8_eclass_t         eclass = t8_forest_get_tree_class (forest, jt);
+    t8_eclass_scheme_c *scheme = forest->scheme_cxx->eclass_schemes[eclass];
+    t8_element_destroy (scheme, 1, &tree->first_desc);
+    t8_element_destroy (scheme, 1, &tree->last_desc);
   }
   sc_array_destroy (forest->trees);
 }

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1582,8 +1582,9 @@ t8_forest_free_trees (t8_forest_t forest)
     }
     t8_element_array_reset (&tree->elements);
     /* destroy first and last descendant */
-    const t8_eclass_t         eclass = t8_forest_get_tree_class (forest, jt);
-    const t8_eclass_scheme_c *scheme = forest->scheme_cxx->eclass_schemes[eclass];
+    const t8_eclass_t   eclass = t8_forest_get_tree_class (forest, jt);
+    const t8_eclass_scheme_c *scheme =
+      forest->scheme_cxx->eclass_schemes[eclass];
     t8_element_destroy (scheme, 1, &tree->first_desc);
     t8_element_destroy (scheme, 1, &tree->last_desc);
   }

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1452,7 +1452,7 @@ t8_forest_compute_desc (t8_forest_t forest)
       T8_ASSERT (forest->incomplete_trees);
       itree->first_desc = NULL;
       itree->last_desc = NULL;
-      break;
+      continue;
     }
     /* get the eclass scheme associated to tree */
     ts = forest->scheme_cxx->eclass_schemes[itree->eclass];

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -2162,7 +2162,7 @@ t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid,
     }
     if (gneigh_treeid < 0) {
       /* There exists no face neighbor across this face, we return with this info */
-      neigh_scheme->t8_element_destroy (1, neighbor_leafs);
+      neigh_scheme->t8_element_destroy (num_children_at_face, neighbor_leafs);
       T8_FREE (neighbor_leafs);
       T8_FREE (*dual_faces);
       *dual_faces = NULL;
@@ -3079,6 +3079,8 @@ t8_forest_element_owners_bounds (t8_forest_t forest, t8_gloidx_t gtreeid,
   *upper =
     t8_forest_element_find_owner_ext (forest, gtreeid, last_desc, eclass,
                                       *lower, *upper, *upper, 1);
+  ts->t8_element_destroy (1, &first_desc);
+  ts->t8_element_destroy (1, &last_desc);
 }
 
 void
@@ -3269,6 +3271,7 @@ t8_forest_element_has_leaf_desc (t8_forest_t forest, t8_gloidx_t gtreeid,
       }
     }
   }
+  ts->t8_element_destroy (1, &last_desc);
   return 0;
 }
 

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1731,6 +1731,7 @@ t8_forest_last_tree_shared (t8_forest_t forest)
 /* Allocate memory for trees and set their values as in from.
  * For each tree allocate enough element memory to fit the elements of from.
  * If copy_elements is true, copy the elements of from into the element memory.
+ * Do not copy the first and last desc for each tree, as this is done outside in commit
  */
 void
 t8_forest_copy_trees (t8_forest_t forest, t8_forest_t from, int copy_elements)
@@ -1763,11 +1764,6 @@ t8_forest_copy_trees (t8_forest_t forest, t8_forest_t from, int copy_elements)
     if (copy_elements) {
       t8_element_array_copy (&tree->elements, &fromtree->elements);
       tree->elements_offset = fromtree->elements_offset;
-      /* Copy the first and last descendant */
-      eclass_scheme->t8_element_new (1, &tree->first_desc);
-      eclass_scheme->t8_element_copy (fromtree->first_desc, tree->first_desc);
-      eclass_scheme->t8_element_new (1, &tree->last_desc);
-      eclass_scheme->t8_element_copy (fromtree->last_desc, tree->last_desc);
     }
     else {
       t8_element_array_truncate (&tree->elements);

--- a/src/t8_forest/t8_forest_iterate.cxx
+++ b/src/t8_forest/t8_forest_iterate.cxx
@@ -375,6 +375,7 @@ t8_forest_search_tree (t8_forest_t forest, t8_locidx_t ltreeid,
   if (queries != NULL) {
     sc_array_destroy (active_queries);
   }
+  ts->t8_element_destroy (1, &nca);
 }
 
 void
@@ -470,6 +471,7 @@ t8_forest_iterate_replace (t8_forest_t forest_new,
           else {
             /* elem_old got removed */
             el_removed = 1;
+            ts->t8_element_destroy (1, &elem_parent);
           }
         }
         else if (level_old > level_new) {
@@ -520,6 +522,7 @@ t8_forest_iterate_replace (t8_forest_t forest_new,
           else {
             /* elem_old got removed */
             el_removed = 1;
+            ts->t8_element_destroy (1, &elem_parent);
           }
         }
         else {

--- a/src/t8_forest/t8_forest_partition.cxx
+++ b/src/t8_forest/t8_forest_partition.cxx
@@ -159,6 +159,7 @@ t8_forest_partition_test_desc (t8_forest_t forest)
     T8_ASSERT (ts->t8_element_get_linear_id (elem_desc, level) >=
                first_desc_id);
   }
+  ts->t8_element_destroy (1, &elem_desc);
 }
 #endif
 

--- a/src/t8_forest/t8_forest_private.h
+++ b/src/t8_forest/t8_forest_private.h
@@ -130,6 +130,7 @@ int                 t8_forest_last_tree_shared (t8_forest_t forest);
 /* Allocate memory for trees and set their values as in from.
  * For each tree allocate enough element memory to fit the elements of from.
  * If copy_elements is true, copy the elements of from into the element memory.
+ * Do not copy the first and last desc for each tree, as this is done outside in commit
  */
 void                t8_forest_copy_trees (t8_forest_t forest,
                                           t8_forest_t from,

--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.cxx
@@ -51,6 +51,7 @@ static void         t8_default_mempool_free (sc_mempool_t * ts_context,
 t8_default_scheme_common_c::~t8_default_scheme_common_c ()
 {
   T8_ASSERT (ts_context != NULL);
+  SC_ASSERT (((sc_mempool_t *) ts_context)->elem_count == 0);
   sc_mempool_destroy ((sc_mempool_t *) ts_context);
 }
 

--- a/test/t8_forest/t8_gtest_half_neighbors.cxx
+++ b/test/t8_forest/t8_gtest_half_neighbors.cxx
@@ -148,6 +148,7 @@ TEST_P (forest_half_neighbors, test_half_neighbors)
           T8_FREE (child_ids);
           T8_FREE (neighbor_face_children);
         }
+        neigh_scheme->t8_element_destroy (1, &neighbor);
         neigh_scheme->t8_element_destroy (num_face_neighs, half_neighbors);
         T8_FREE (half_neighbors);
       }

--- a/test/t8_schemes/t8_gtest_ancestor.cxx
+++ b/test/t8_schemes/t8_gtest_ancestor.cxx
@@ -97,6 +97,7 @@ TEST_P (ancestor, root_recursive_check)
   ts->t8_element_new (1, &parent);
   ts->t8_element_copy (correct_anc, parent);
   t8_recursive_ancestor (correct_anc, desc_a, parent, check, ts, max_lvl);
+  ts->t8_element_destroy (1, &parent);
 }
 
 TEST_P (ancestor, multi_level_recursive_check)
@@ -118,6 +119,8 @@ TEST_P (ancestor, multi_level_recursive_check)
     ts->t8_element_copy (correct_anc_high_level, parent);
     t8_recursive_ancestor (correct_anc, desc_a, parent, check, ts, i);
   }
+  ts->t8_element_destroy (1, &parent);
+  ts->t8_element_destroy (1, &correct_anc_high_level);
 }
 
 /* *INDENT-OFF* */

--- a/test/t8_schemes/t8_gtest_nca.cxx
+++ b/test/t8_schemes/t8_gtest_nca.cxx
@@ -242,9 +242,9 @@ TEST_P (nca, recursive_check)
   int                 num_children;
   num_children = ts->t8_element_num_children (correct_nca);
   int                 i, j;
-  ts->t8_element_new (1, &parent_a);
-  ts->t8_element_new (1, &parent_b);
   if (num_children > 1) {
+    ts->t8_element_new (1, &parent_a);
+    ts->t8_element_new (1, &parent_b);
     ts->t8_element_child (correct_nca, 0, parent_a);
     ts->t8_element_child (correct_nca, 1, parent_b);
     for (i = 0; i < num_children - 1; i++) {
@@ -315,6 +315,9 @@ TEST_P (nca, recursive_check_higher_level)
       }
     }
     else {
+      ts->t8_element_destroy (1, &parent_a);
+      ts->t8_element_destroy (1, &parent_b);
+      ts->t8_element_destroy (1, &correct_nca_high_level);
       GTEST_SKIP ();
     }
   }


### PR DESCRIPTION
**_Describe your changes here:_**
Clean version of #676, closes #672 
Memory that is allocated by `t8_element_new`, but not destroyed by `t8_element_destroy`, stays in the memory pool until the scheme is destroyed. This leads to an increasing memory footprint that doesn't show up as an error with the `sc` library or with `valgrind`.
Therefore, an assertion is introduced in the destructor of the scheme, that all elements were explicitely given back to the memory pool.
Additionally, many occurences of missing `t8_element_destroy` statements were found and fixed.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] New Datatypes are added to t8indent_custom_datatypes.txt
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
