### PR TITLE
Delete filter after usage

### DIFF
--- a/src/t8_vtk/t8_vtk_reader.cxx
+++ b/src/t8_vtk/t8_vtk_reader.cxx
@@ -450,6 +450,7 @@ t8_vtkGrid_to_vtkPointSet (vtkSmartPointer < vtkDataSet >vtkGrid)
   c2p->SetInputData (vtkGrid);
   c2p->Update ();
   cloud->DeepCopy (c2p->GetOutput ());
+  c2p->Delete ();
   //cloud->DeepCopy (vtkPointSet::SafeDownCast (c2p->GetOutput ()));
 
   return cloud;


### PR DESCRIPTION
Free the memory of the filter itself. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [x] Should this use case be added to the github action?
  - [x] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] New Datatypes are added to t8indent_custom_datatypes.txt
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
