### PR TITLE
Update t8_cmesh_examples

### DIFF
--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -167,7 +167,12 @@ static t8_cmesh_t
 t8_cmesh_new_line (sc_MPI_Comm comm)
 {
   t8_cmesh_t cmesh;
-  double vertices[6] = { 0, 0, 0, 1, 0, 0 };
+  /* clang-format off */
+  double vertices[6] = { 
+    0, 0, 0, 
+    1, 0, 0 
+  };
+  /* clang-format on */
   t8_geometry_c *linear_geom = t8_geometry_linear_new (1);
 
   t8_cmesh_init (&cmesh);
@@ -183,7 +188,13 @@ static t8_cmesh_t
 t8_cmesh_new_tri (sc_MPI_Comm comm)
 {
   t8_cmesh_t cmesh;
-  double vertices[9] = { 0, 0, 0, 1, 0, 0, 1, 1, 0 };
+  /* clang-format off */
+  double vertices[9] = { 
+    0, 0, 0, 
+    1, 0, 0, 
+    1, 1, 0 
+  };
+  /* clang-format on */
   t8_geometry_c *linear_geom = t8_geometry_linear_new (2);
 
   t8_cmesh_init (&cmesh);
@@ -199,7 +210,14 @@ static t8_cmesh_t
 t8_cmesh_new_tet (sc_MPI_Comm comm)
 {
   t8_cmesh_t cmesh;
-  double vertices[12] = { 1, 1, 1, 1, -1, -1, -1, 1, -1, -1, -1, 1 };
+  /* clang-format off */
+  double vertices[12] = { 
+    1, 1, 1, 
+    1, -1, -1, 
+    -1, 1, -1, 
+    -1, -1, 1 
+  };
+  /* clang-format on */
   t8_geometry_c *linear_geom = t8_geometry_linear_new (3);
 
   t8_cmesh_init (&cmesh);
@@ -215,9 +233,14 @@ static t8_cmesh_t
 t8_cmesh_new_quad (sc_MPI_Comm comm)
 {
   t8_cmesh_t cmesh;
+  /* clang-format off */
   double vertices[12] = {
-    0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0,
+    0, 0, 0, 
+    1, 0, 0, 
+    0, 1, 0, 
+    1, 1, 0,
   };
+  /* clang-format on */
   t8_geometry_c *linear_geom = t8_geometry_linear_new (2);
 
   t8_cmesh_init (&cmesh);
@@ -233,7 +256,18 @@ static t8_cmesh_t
 t8_cmesh_new_hex (sc_MPI_Comm comm)
 {
   t8_cmesh_t cmesh;
-  double vertices[24] = { 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1 };
+  /* clang-format off */
+  double vertices[24] = { 
+    0, 0, 0, 
+    1, 0, 0, 
+    0, 1, 0, 
+    1, 1, 0, 
+    0, 0, 1, 
+    1, 0, 1, 
+    0, 1, 1, 
+    1, 1, 1 
+  };
+  /* clang-format on */
   t8_geometry_c *linear_geom = t8_geometry_linear_new (3);
 
   t8_cmesh_init (&cmesh);
@@ -249,7 +283,15 @@ t8_cmesh_t
 t8_cmesh_new_pyramid_deformed (sc_MPI_Comm comm)
 {
   t8_cmesh_t cmesh;
-  double vertices[15] = { -1, -2, 0.5, 2, -1, 0, -1, 2, -0.5, 2, 2, 0, 3, 3, sqrt (3) };
+  /* clang-format off */
+  double vertices[15] = { 
+    -1, -2, 0.5, 
+    2, -1, 0, 
+    -1, 2, -0.5, 
+    2, 2, 0, 
+    3, 3, sqrt (3) 
+  };
+  /* clang-format on */
   t8_geometry_c *linear_geom = t8_geometry_linear_new (3);
 
   t8_cmesh_init (&cmesh);
@@ -265,7 +307,15 @@ static t8_cmesh_t
 t8_cmesh_new_pyramid (sc_MPI_Comm comm)
 {
   t8_cmesh_t cmesh;
-  double vertices[15] = { -1, -1, 0, 1, -1, 0, -1, 1, 0, 1, 1, 0, 0, 0, sqrt (2) };
+  /* clang-format off */
+  double vertices[15] = { 
+    -1, -1, 0, 
+    1, -1, 0, 
+    -1, 1, 0, 
+    1, 1, 0, 
+    0, 0, sqrt (2) 
+  };
+  /* clang-format on */
   t8_geometry_c *linear_geom = t8_geometry_linear_new (3);
 
   t8_cmesh_init (&cmesh);
@@ -281,7 +331,17 @@ static t8_cmesh_t
 t8_cmesh_new_prism (sc_MPI_Comm comm)
 {
   t8_cmesh_t cmesh;
-  double vertices[18] = { 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1 };
+  /* clang-format off */
+  double vertices[18] = { 
+    0, 0, 0, 
+    1, 0, 0, 
+    1, 1, 0, 
+    0, 0, 1, 
+    1, 0, 1, 
+    1, 1, 1 
+  };
+  /* clang-format on */
+
   t8_geometry_c *linear_geom = t8_geometry_linear_new (3);
 
   t8_cmesh_init (&cmesh);
@@ -347,10 +407,29 @@ t8_cmesh_new_hypercube_hybrid (sc_MPI_Comm comm, int do_partition, int periodic)
   t8_locidx_t vertices[8];
   double vertices_coords_temp[24];
   double attr_vertices[24];
+  /* clang-format off */
   double null_vec[3] = { 0, 0, 0 };
-  double shift[7][3] = { { 0.5, 0, 0 },   { 0, 0.5, 0 },     { 0, 0, 0.5 },  { 0.5, 0.5 },
-                         { 0.5, 0, 0.5 }, { 0.5, 0.5, 0.5 }, { 0, 0.5, 0.5 } };
-  double vertices_coords[24] = { 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1 };
+  double shift[7][3] = { 
+    { 0.5, 0, 0 },   
+    { 0, 0.5, 0 },     
+    { 0, 0, 0.5 },  
+    { 0.5, 0.5 },
+    { 0.5, 0, 0.5 }, 
+    { 0.5, 0.5, 0.5 }, 
+    { 0, 0.5, 0.5 } 
+  };
+  double vertices_coords[24] = { 
+    0, 0, 0, 
+    1, 0, 0, 
+    0, 1, 0, 
+    1, 1, 0,
+    0, 0, 1, 
+    1, 0, 1,
+    0, 1, 1, 
+    1, 1, 1 
+  };
+  /* clang-format on */
+
   t8_geometry_c *linear_geom = t8_geometry_linear_new (3);
 
   t8_cmesh_init (&cmesh);
@@ -540,7 +619,19 @@ t8_cmesh_new_hypercube (t8_eclass_t eclass, sc_MPI_Comm comm, int do_bcast, int 
   t8_locidx_t vertices[8];
   double attr_vertices[24];
   int mpirank, mpiret;
-  const double vertices_coords[24] = { 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1 };
+  /* clang-format off */
+  const double vertices_coords[24] = { 
+    0, 0, 0, 
+    1, 0, 0, 
+    0, 1, 0, 
+    1, 1, 0, 
+    0, 0, 1, 
+    1, 0, 1, 
+    0, 1, 1,
+    1, 1, 1 
+  };
+  /* clang-format on */
+
   int dim = t8_eclass_to_dimension[eclass];
   t8_geometry_c *linear_geom = t8_geometry_linear_new (dim);
 
@@ -1292,8 +1383,15 @@ t8_cmesh_t
 t8_cmesh_new_periodic_line_more_trees (sc_MPI_Comm comm)
 {
   t8_cmesh_t cmesh;
+  /* clang-format off */
+  double vertices[12] = { 
+    0, 0, 0, 
+    0.2, 0, 0, 
+    0.6, 0, 0, 
+    1, 0, 0 
+  };
+  /* clang-format on */
 
-  double vertices[12] = { 0, 0, 0, 0.2, 0, 0, 0.6, 0, 0, 1, 0, 0 };
   t8_geometry_c *linear_geom = t8_geometry_linear_new (1);
 
   t8_cmesh_init (&cmesh);
@@ -1315,7 +1413,17 @@ t8_cmesh_new_periodic_line_more_trees (sc_MPI_Comm comm)
 t8_cmesh_t
 t8_cmesh_new_periodic_tri (sc_MPI_Comm comm)
 {
-  double vertices[18] = { 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0 };
+  /* clang-format off */
+  double vertices[18] = { 
+    0, 0, 0, 
+    1, 0, 0, 
+    1, 1, 0, 
+    0, 0, 0, 
+    1, 1, 0, 
+    0, 1, 0 
+  };
+  /* clang-format on */
+
   t8_cmesh_t cmesh;
   t8_geometry_c *linear_geom = t8_geometry_linear_new (2);
 
@@ -1337,15 +1445,30 @@ t8_cmesh_new_periodic_tri (sc_MPI_Comm comm)
 t8_cmesh_t
 t8_cmesh_new_periodic_hybrid (sc_MPI_Comm comm)
 {
+  /* clang-format off */
   double vertices[60] = {                                        /* Just all vertices of all trees. partly duplicated */
-                          0,   0,   0,                           /* tree 0, triangle */
-                          0.5, 0,   0, 0.5, 0.5, 0, 0,   0,   0, /* tree 1, triangle */
-                          0.5, 0.5, 0, 0,   0.5, 0, 0.5, 0,   0, /* tree 2, quad */
-                          1,   0,   0, 0.5, 0.5, 0, 1,   0.5, 0, 0,   0.5, 0, /* tree 3, quad */
-                          0.5, 0.5, 0, 0,   1,   0, 0.5, 1,   0, 0.5, 0.5, 0, /* tree 4, triangle */
-                          1,   0.5, 0, 1,   1,   0, 0.5, 0.5, 0,              /* tree 5, triangle */
-                          1,   1,   0, 0.5, 1,   0
+    0, 0, 0,              /* tree 0, triangle */
+    0.5, 0, 0, 
+    0.5, 0.5, 0, 
+    0, 0, 0,              /* tree 1, triangle */
+    0.5, 0.5, 0, 
+    0, 0.5, 0,
+    0.5, 0, 0,            /* tree 2, quad */
+    1, 0, 0, 0.5, 
+    0.5, 0, 1, 0.5, 
+    0, 0, 0.5, 0,         /* tree 3, quad */
+    0.5, 0.5, 0, 
+    0, 1, 0, 
+    0.5, 1, 0, 
+    0.5, 0.5, 0,          /* tree 4, triangle */
+    1, 0.5, 0, 
+    1, 1, 0, 
+    0.5, 0.5, 0,          /* tree 5, triangle */
+    1, 1, 0, 
+    0.5, 1, 0
   };
+  /* clang-format on */
+
   t8_cmesh_t cmesh;
   t8_geometry_c *linear_geom = t8_geometry_linear_new (2);
 
@@ -1405,7 +1528,19 @@ t8_cmesh_new_periodic (sc_MPI_Comm comm, int dim)
 {
   t8_cmesh_t cmesh;
   t8_eclass_t tree_class;
-  double vertices[24] = { 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1 };
+  /* clang-format off */
+  double vertices[24] = { 
+    0, 0, 0, 
+    1, 0, 0, 
+    0, 1, 0, 
+    1, 1, 0, 
+    0, 0, 1, 
+    1, 0, 1, 
+    0, 1, 1, 
+    1, 1, 1 
+  };
+  /* clang-format on */
+
   t8_geometry_c *linear_geom = t8_geometry_linear_new (dim);
 
   T8_ASSERT (dim == 1 || dim == 2 || dim == 3);
@@ -1464,7 +1599,17 @@ t8_cmesh_t
 t8_cmesh_new_line_zigzag (sc_MPI_Comm comm)
 {
   int i;
-  double vertices[18] = { 1, 2, 0, 2, 4, 1, 1, 1, 2, 2, 4, 1, 1, 1, 2, 3, 2, 5 };
+  /* clang-format off */
+  double vertices[18] = { 
+    1, 2, 0, 
+    2, 4, 1, 
+    1, 1, 2, 
+    2, 4, 1, 
+    1, 1, 2, 
+    3, 2, 5 
+  };
+  /* clang-format on */
+
   t8_cmesh_t cmesh;
   t8_geometry_c *linear_geom = t8_geometry_linear_new (1);
 
@@ -1544,7 +1689,17 @@ t8_cmesh_t
 t8_cmesh_new_prism_deformed (sc_MPI_Comm comm)
 {
   t8_cmesh_t cmesh;
-  double vertices[18] = { -1, -0.5, 0.25, 1, 0, 0, 1, 1, 0, 0, 0, 0.75, 1.25, 0, 1, 2, 2, 2 };
+  /* clang-format off */
+  double vertices[18] = {
+    -1, -0.5, 0.25, 
+    1, 0, 0, 
+    1, 1, 0, 
+    0, 0, 0.75, 
+    1.25, 0, 1, 
+    2, 2, 2 
+  };
+  /* clang-format on */
+
   t8_geometry_c *linear_geom = t8_geometry_linear_new (3);
 
   t8_cmesh_init (&cmesh);
@@ -1827,8 +1982,15 @@ t8_cmesh_new_tet_orientation_test (sc_MPI_Comm comm)
 {
   t8_cmesh_t cmesh;
   int i;
+  /* clang-format off */
+  double vertices_coords[12] = { 
+    0, 0, 0, 
+    1, 0, 0, 
+    1, 0, 1, 
+    1, 1, 1 
+  };
+  /* clang-format on */
 
-  double vertices_coords[12] = { 0, 0, 0, 1, 0, 0, 1, 0, 1, 1, 1, 1 };
   double translated_coords[12];
   double translate[3] = { 1, 0, 0 };
   const t8_gloidx_t num_trees = 24;
@@ -1892,12 +2054,9 @@ t8_cmesh_new_tet_orientation_test (sc_MPI_Comm comm)
   /* Set the coordinates. Each tet is just a translated version of
    * the root tet */
   for (i = 0; i < num_trees; i++) {
-    /* *INDENT-OFF* */
-    /* Indent fails at '!!' */
     translate[0] = (i & 1) + 2 * !!(i & 8);
     translate[1] = !!(i & 2) + 2 * !!(i & 16);
     translate[2] = !!(i & 4) + 2 * !!(i & 32);
-    /* *INDENT-ON* */
     t8_debugf ("%i  %.0f %.0f %.0f\n", i, translate[0], translate[1], translate[2]);
     t8_cmesh_translate_coordinates (vertices_coords, translated_coords, 4, translate);
     t8_cmesh_set_tree_vertices (cmesh, i, translated_coords, 4);
@@ -2359,7 +2518,19 @@ t8_cmesh_new_long_brick_pyramid (sc_MPI_Comm comm, int num_cubes)
   t8_locidx_t vertices[5];
   double attr_vertices[15];
   int mpirank, mpiret;
-  double vertices_coords[24] = { 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1 };
+  /* clang-format off */
+  double vertices_coords[24] = { 
+    0, 0, 0, 
+    1, 0, 0, 
+    0, 1, 0, 
+    1, 1, 0, 
+    0, 0, 1, 
+    1, 0, 1, 
+    0, 1, 1, 
+    1, 1, 1 
+  };
+  /* clang-format on */
+
   int dim = t8_eclass_to_dimension[T8_ECLASS_PYRAMID];
   t8_geometry_c *linear_geom = t8_geometry_linear_new (dim);
   mpiret = sc_MPI_Comm_rank (comm, &mpirank);
@@ -2432,10 +2603,19 @@ t8_cmesh_new_row_of_cubes (t8_locidx_t num_trees, const int set_attributes, cons
   const t8_geometry_c *linear_geom = t8_geometry_linear_new (3);
   t8_cmesh_register_geometry (cmesh, linear_geom);
 
+  /* clang-format off */
   /* Vertices of first cube in row. */
   double vertices[24] = {
-    0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1,
+    0, 0, 0, 
+    1, 0, 0, 
+    0, 1, 0, 
+    1, 1, 0, 
+    0, 0, 1, 
+    1, 0, 1, 
+    0, 1, 1, 
+    1, 1, 1
   };
+  /* clang-format on */
 
   /* Set each tree in cmesh. */
   for (t8_locidx_t tree_id = 0; tree_id < num_trees; tree_id++) {

--- a/src/t8_cmesh/t8_cmesh_helpers.c
+++ b/src/t8_cmesh/t8_cmesh_helpers.c
@@ -77,12 +77,10 @@ t8_cmesh_set_join_by_vertices (t8_cmesh_t cmesh, const int ntrees, const t8_ecla
 
           /* If we already checked the two faces, we can
            * skip the computations here since we only need the connectivity in one direction. */
-          /* *INDENT-OFF* */
           if (!do_both_directions
               && conn[T8_3D_TO_1D (ntrees, T8_ECLASS_MAX_FACES, 3, neigh_itree, neigh_iface, 0)] > -1) {
             continue;
           }
-          /* *INDENT-ON* */
 
           /* Get the number of vertices per face of potentially neighboring element. */
           const int neigh_nface_verts = t8_eclass_num_vertices[t8_eclass_face_types[neigh_eclass][neigh_iface]];
@@ -115,12 +113,10 @@ t8_cmesh_set_join_by_vertices (t8_cmesh_t cmesh, const int ntrees, const t8_ecla
                 /* Retrieve the x, y or z component of the face vertex
                  * coordinate from the vertices array. */
 
-                /* *INDENT-OFF* */
                 const double face_vert
                   = vertices[T8_3D_TO_1D (ntrees, T8_ECLASS_MAX_CORNERS, T8_ECLASS_MAX_DIM, itree, ivert, icoord)];
                 const double neigh_face_vert = vertices[T8_3D_TO_1D (ntrees, T8_ECLASS_MAX_CORNERS, T8_ECLASS_MAX_DIM,
                                                                      neigh_itree, neigh_ivert, icoord)];
-                /* *INDENT-ON* */
 
                 /* Compare the coordinates with some tolerance. */
                 if (fabs (face_vert - neigh_face_vert) < 10.0 * T8_PRECISION_EPS) {
@@ -177,11 +173,9 @@ t8_cmesh_set_join_by_vertices (t8_cmesh_t cmesh, const int ntrees, const t8_ecla
 
             /* Store the results. */
 
-            /* *INDENT-OFF* */
             conn[T8_3D_TO_1D (ntrees, T8_ECLASS_MAX_FACES, 3, itree, iface, 0)] = neigh_itree;
             conn[T8_3D_TO_1D (ntrees, T8_ECLASS_MAX_FACES, 3, itree, iface, 1)] = neigh_iface;
             conn[T8_3D_TO_1D (ntrees, T8_ECLASS_MAX_FACES, 3, itree, iface, 2)] = orientation;
-            /* *INDENT-ON* */
 
             break;
           }

--- a/src/t8_cmesh/t8_cmesh_occ.cxx
+++ b/src/t8_cmesh/t8_cmesh_occ.cxx
@@ -120,8 +120,6 @@ t8_cmesh_new_hollow_cylinder (sc_MPI_Comm comm, int num_tangential_trees, int nu
         t8_cmesh_set_tree_class (
           cmesh, (i_tangential_trees * num_axial_trees + i_axial_trees) * num_radial_trees + i_radial_trees,
           T8_ECLASS_HEX);
-
-        /* *INDENT-OFF* */
         const int current_tree_vertices
           = ((i_tangential_trees * num_axial_trees + i_axial_trees) * num_radial_trees + i_radial_trees) * 24;
         vertices[current_tree_vertices + 0]
@@ -160,7 +158,6 @@ t8_cmesh_new_hollow_cylinder (sc_MPI_Comm comm, int num_tangential_trees, int nu
         vertices[current_tree_vertices + 21] = cos (i_tangential_trees * dphi) * (radius_inner + i_radial_trees * dr);
         vertices[current_tree_vertices + 22] = sin (i_tangential_trees * dphi) * (radius_inner + i_radial_trees * dr);
         vertices[current_tree_vertices + 23] = -0.5 + (i_axial_trees + 1) * dh;
-        /* *INDENT-ON* */
 
         t8_cmesh_set_tree_vertices (
           cmesh, (i_tangential_trees * num_axial_trees + i_axial_trees) * num_radial_trees + i_radial_trees,
@@ -173,7 +170,6 @@ t8_cmesh_new_hollow_cylinder (sc_MPI_Comm comm, int num_tangential_trees, int nu
           /* Calculate parameters if cell lies on boundary */
           const int current_tree_parameters = (i_tangential_trees * num_axial_trees + i_axial_trees) * 8;
           if (i_radial_trees == 0 || i_radial_trees == num_radial_trees - 1) {
-            /* *INDENT-OFF* */
             parameters[current_tree_parameters + 0] = (i_tangential_trees + 1) * dphi;
             parameters[current_tree_parameters + 1] = 0.5 - i_axial_trees * dh;
             parameters[current_tree_parameters + 2] = i_tangential_trees * dphi;
@@ -182,7 +178,6 @@ t8_cmesh_new_hollow_cylinder (sc_MPI_Comm comm, int num_tangential_trees, int nu
             parameters[current_tree_parameters + 5] = 0.5 + -(i_axial_trees + 1) * dh;
             parameters[current_tree_parameters + 6] = i_tangential_trees * dphi;
             parameters[current_tree_parameters + 7] = 0.5 - (i_axial_trees + 1) * dh;
-            /* *INDENT-ON* */
           }
           int edges[24] = { 0 };
 

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -38,16 +38,22 @@
 #define T8_NUM_GMSH_ELEM_CLASSES 15
 /* look-up table to translate the gmsh tree class to a t8code tree class.
  */
+/* clang-format off */
 const t8_eclass_t t8_msh_tree_type_to_eclass[T8_NUM_GMSH_ELEM_CLASSES + 1] = {
-  T8_ECLASS_COUNT,                                                  /* 0 is not valid */
-  T8_ECLASS_LINE,                                                   /* 1 */
-  T8_ECLASS_TRIANGLE, T8_ECLASS_QUAD, T8_ECLASS_TET, T8_ECLASS_HEX, /* 5 */
-  T8_ECLASS_PRISM, T8_ECLASS_PYRAMID,                               /* 7 This is the last first order tree type,
-                                   except the Point, which is type 15 */
+  T8_ECLASS_COUNT,     /* 0 is not valid */
+  T8_ECLASS_LINE,      /* 1 */
+  T8_ECLASS_TRIANGLE, 
+  T8_ECLASS_QUAD, 
+  T8_ECLASS_TET, 
+  T8_ECLASS_HEX,        /* 5 */
+  T8_ECLASS_PRISM, 
+  T8_ECLASS_PYRAMID,    /* 7 This is the last first order tree type, except the Point, which is type 15 */
   /* We do not support type 8 to 14 */
-  T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT,
-  T8_ECLASS_VERTEX /* 15 */
+  T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, 
+  T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT,
+  T8_ECLASS_VERTEX      /* 15 */
 };
+/* clang-format on */
 
 /* translate the msh file vertex number to the t8code vertex number.
  * See also http://gmsh.info/doc/texinfo/gmsh.html#Node-ordering */
@@ -997,11 +1003,6 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp, sc_hash_t *vertices, 
           *(long **) sc_array_push (*vertex_indices) = stored_indices;
         }
 
-        /* The following code contains many long function names and some c++, 
-         * which gets unreadable when limited to 80 characters. We therefore
-         * deactivate the automatic indentation.
-         * TODO: Indent after switching to other indentation rules */
-        /* *INDENT-OFF* */
         if (!use_occ_geometry) {
           /* Set the geometry of the tree to be linear.
            * If we use an occ geometry, we set the geometry in accordance,
@@ -1349,8 +1350,7 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp, sc_hash_t *vertices, 
                 /* Some error checking */
                 if (edge_nodes[i_edge_node].entity_dim == 2
                     && edge_nodes[i_edge_node].entity_tag != edge_geometry_tag) {
-                  t8_global_errorf ("Error: Node %i should lie on a specific face, "
-                                    "but it lies on another face.\n",
+                  t8_global_errorf ("Error: Node %i should lie on a specific face, but it lies on another face.\n",
                                     edge_nodes[i_edge_node].index);
                   goto die_ele;
                 }
@@ -1437,7 +1437,6 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp, sc_hash_t *vertices, 
           SC_ABORTF ("OCC not linked");
 #endif /* T8_WITH_OCC */
         }
-        /* *INDENT-ON* */
       }
     }
   }
@@ -1806,8 +1805,7 @@ t8_cmesh_from_msh_file (const char *fileprefix, int partition, sc_MPI_Comm comm,
     case 2:
       if (use_occ_geometry) {
         fclose (file);
-        t8_errorf ("WARNING: The occ geometry is only supported for msh files of "
-                   "version 4\n");
+        t8_errorf ("WARNING: The occ geometry is only supported for msh files of version 4\n");
         t8_cmesh_destroy (&cmesh);
         if (partition) {
           /* Communicate to the other processes that reading failed. */

--- a/src/t8_cmesh/t8_cmesh_refine.cxx
+++ b/src/t8_cmesh/t8_cmesh_refine.cxx
@@ -604,11 +604,9 @@ t8_cmesh_refine_ghost (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, t8_child_id_to_l
     lghost_id = idarray[ghostid][ichild].local_id;
     newghost = t8_cmesh_trees_get_ghost_ext (cmesh->trees, lghost_id, &nghost_neighbors, &nttf);
     /* Set all face_neighbors of the child ghost */
-    /* *INDENT-OFF* */
     t8_cmesh_refine_new_neighbors (cmesh_from, ghostid,
                                    t8_cmesh_get_global_id (cmesh_from, cmesh_from->num_local_trees + ghostid),
                                    newghost->eclass, idarray, (int) child_id, NULL, nghost_neighbors, nttf, factor);
-    /* *INDENT-ON* */
     child_id = idarray[ghostid][ichild + 1].child_id;
   }
 }

--- a/src/t8_cmesh/t8_cmesh_save.c
+++ b/src/t8_cmesh/t8_cmesh_save.c
@@ -324,8 +324,7 @@ t8_cmesh_save_trees (t8_cmesh_t cmesh, FILE *fp)
       /* TODO: We currently do not support saving of attributes different
        * to the tree vertices */
       fclose (fp);
-      t8_errorf ("We do not support saving cmeshes with trees that "
-                 "have attributes different to the tree vertices.\n");
+      t8_errorf ("We do not support saving cmeshes with trees that have attributes different to the tree vertices.\n");
       return 0;
     }
     ret = fprintf (fp, "num_attributes %i\nSize of attributes %zd\n\n", tree->num_attributes,

--- a/src/t8_cmesh/t8_cmesh_stash.c
+++ b/src/t8_cmesh/t8_cmesh_stash.c
@@ -123,11 +123,8 @@ t8_stash_add_facejoin (t8_stash_t stash, t8_gloidx_t gid1, t8_gloidx_t gid2, int
    * the two ids */
   sjoin->face1 = gid1 <= gid2 ? face1 : face2;
   sjoin->face2 = gid1 <= gid2 ? face2 : face1;
-  ;
   sjoin->id1 = gid1 <= gid2 ? gid1 : gid2;
-  ;
   sjoin->id2 = gid1 <= gid2 ? gid2 : gid1;
-  ;
   sjoin->orientation = orientation;
 }
 

--- a/src/t8_cmesh/t8_cmesh_types.h
+++ b/src/t8_cmesh/t8_cmesh_types.h
@@ -56,7 +56,7 @@ typedef struct t8_cprofile t8_cprofile_t; /* Defined below */
 #define T8_CMESH_OCC_EDGE_PARAMETERS_ATTRIBUTE_KEY 3 /* Used to store edge parameters */
 #define T8_CMESH_OCC_FACE_ATTRIBUTE_KEY \
   T8_CMESH_OCC_EDGE_PARAMETERS_ATTRIBUTE_KEY \
-    + T8_ECLASS_MAX_EDGES /* Used to store which face is linked to which surface */
+  +T8_ECLASS_MAX_EDGES /* Used to store which face is linked to which surface */
 #define T8_CMESH_OCC_FACE_PARAMETERS_ATTRIBUTE_KEY \
   T8_CMESH_OCC_FACE_ATTRIBUTE_KEY + 1 /* Used to store face parameters */
 #define T8_CMESH_NEXT_POSSIBLE_KEY \
@@ -101,19 +101,19 @@ typedef struct t8_cmesh
                                            refinement pattern. See \ref t8_cmesh_set_refine. */
   t8_scheme_cxx_t *set_partition_scheme; /**< If the cmesh is to be partitioned according to a uniform level,
                                                 the scheme that describes the refinement pattern. See \ref t8_cmesh_set_partition. */
-  int8_t set_partition_level; /**< Non-negative if the cmesh should be partitioned from an already existing cmesh
+  int8_t set_partition_level;  /**< Non-negative if the cmesh should be partitioned from an already existing cmesh
                                          with an assumed \a level uniform mesh underneath. */
-  struct t8_cmesh *set_from;  /**< If this cmesh shall be derived from an
+  struct t8_cmesh *set_from;   /**< If this cmesh shall be derived from an
                                   existing cmesh by copy or more elaborate
                                   modification, we store a pointer to this
                                   other cmesh here. */
-  int mpirank;                /**< Number of this MPI process. */
-  int mpisize;                /**< Number of MPI processes. */
-  t8_refcount_t rc;           /**< The reference count of the cmesh. */
-  t8_gloidx_t num_trees;      /**< The global number of trees */
-  t8_locidx_t
-    num_local_trees; /**< If partitioned the number of trees on this process. Otherwise the global number of trees. */
-  t8_locidx_t num_ghosts; /**< If partitioned the number of neighbor trees
+  int mpirank;                 /**< Number of this MPI process. */
+  int mpisize;                 /**< Number of MPI processes. */
+  t8_refcount_t rc;            /**< The reference count of the cmesh. */
+  t8_gloidx_t num_trees;       /**< The global number of trees */
+  t8_locidx_t num_local_trees; /**< If partitioned the number of trees on this process. 
+                                    Otherwise the global number of trees. */
+  t8_locidx_t num_ghosts;      /**< If partitioned the number of neighbor trees
                                     owned by different processes. */
   /* TODO: wouldnt a local num_trees_per_eclass be better?
    *       only as an additional info. we need the global count. i.e. for forest_maxlevel computation.
@@ -127,12 +127,11 @@ typedef struct t8_cmesh
 
   t8_cmesh_trees_t trees; /**< structure that holds all local trees and ghosts */
 
-  t8_gloidx_t first_tree; /**< The global index of the first local tree on this process. 
+  t8_gloidx_t first_tree;   /**< The global index of the first local tree on this process. 
                                        Zero if the cmesh is not partitioned. -1 if this processor is empty.
                                        See also https://github.com/DLR-AMR/t8code/wiki/Tree-indexing */
-  int8_t
-    first_tree_shared; /**< If partitioned true if the first tree on this process is also the last tree on the next process.
-                                             Always zero if num_local_trees = 0 */
+  int8_t first_tree_shared; /**< If partitioned true if the first tree on this process is also the last tree 
+                                  on the next process. Always zero if num_local_trees = 0 */
 
   t8_shmem_array_t tree_offsets; /**< If partitioned for each process the global index of its first local tree
                                         or -(first local tree) - 1


### PR DESCRIPTION
break the vertices-arrays into coordinate-tuples

**_Describe your changes here:_**



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
