### PR TITLE
Update t8_cmesh_readmshfile

### DIFF
--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -38,16 +38,22 @@
 #define T8_NUM_GMSH_ELEM_CLASSES 15
 /* look-up table to translate the gmsh tree class to a t8code tree class.
  */
+/* clang-format off */
 const t8_eclass_t t8_msh_tree_type_to_eclass[T8_NUM_GMSH_ELEM_CLASSES + 1] = {
-  T8_ECLASS_COUNT,                                                  /* 0 is not valid */
-  T8_ECLASS_LINE,                                                   /* 1 */
-  T8_ECLASS_TRIANGLE, T8_ECLASS_QUAD, T8_ECLASS_TET, T8_ECLASS_HEX, /* 5 */
-  T8_ECLASS_PRISM, T8_ECLASS_PYRAMID,                               /* 7 This is the last first order tree type,
-                                   except the Point, which is type 15 */
+  T8_ECLASS_COUNT,     /* 0 is not valid */
+  T8_ECLASS_LINE,      /* 1 */
+  T8_ECLASS_TRIANGLE, 
+  T8_ECLASS_QUAD, 
+  T8_ECLASS_TET, 
+  T8_ECLASS_HEX,        /* 5 */
+  T8_ECLASS_PRISM, 
+  T8_ECLASS_PYRAMID,    /* 7 This is the last first order tree type, except the Point, which is type 15 */
   /* We do not support type 8 to 14 */
-  T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT,
-  T8_ECLASS_VERTEX /* 15 */
+  T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, 
+  T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT,
+  T8_ECLASS_VERTEX      /* 15 */
 };
+/* clang-format on */
 
 /* translate the msh file vertex number to the t8code vertex number.
  * See also http://gmsh.info/doc/texinfo/gmsh.html#Node-ordering */
@@ -997,11 +1003,6 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp, sc_hash_t *vertices, 
           *(long **) sc_array_push (*vertex_indices) = stored_indices;
         }
 
-        /* The following code contains many long function names and some c++, 
-         * which gets unreadable when limited to 80 characters. We therefore
-         * deactivate the automatic indentation.
-         * TODO: Indent after switching to other indentation rules */
-        /* *INDENT-OFF* */
         if (!use_occ_geometry) {
           /* Set the geometry of the tree to be linear.
            * If we use an occ geometry, we set the geometry in accordance,
@@ -1349,8 +1350,7 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp, sc_hash_t *vertices, 
                 /* Some error checking */
                 if (edge_nodes[i_edge_node].entity_dim == 2
                     && edge_nodes[i_edge_node].entity_tag != edge_geometry_tag) {
-                  t8_global_errorf ("Error: Node %i should lie on a specific face, "
-                                    "but it lies on another face.\n",
+                  t8_global_errorf ("Error: Node %i should lie on a specific face, but it lies on another face.\n",
                                     edge_nodes[i_edge_node].index);
                   goto die_ele;
                 }
@@ -1437,7 +1437,6 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp, sc_hash_t *vertices, 
           SC_ABORTF ("OCC not linked");
 #endif /* T8_WITH_OCC */
         }
-        /* *INDENT-ON* */
       }
     }
   }
@@ -1806,8 +1805,7 @@ t8_cmesh_from_msh_file (const char *fileprefix, int partition, sc_MPI_Comm comm,
     case 2:
       if (use_occ_geometry) {
         fclose (file);
-        t8_errorf ("WARNING: The occ geometry is only supported for msh files of "
-                   "version 4\n");
+        t8_errorf ("WARNING: The occ geometry is only supported for msh files of version 4\n");
         t8_cmesh_destroy (&cmesh);
         if (partition) {
           /* Communicate to the other processes that reading failed. */


### PR DESCRIPTION
Remove INDENT-ON/OFF
reformat look-up-table

**_Describe your changes here:_**



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
