### PR TITLE
Update t8_cmesh_refine

### DIFF
--- a/src/t8_cmesh/t8_cmesh_helpers.c
+++ b/src/t8_cmesh/t8_cmesh_helpers.c
@@ -77,12 +77,10 @@ t8_cmesh_set_join_by_vertices (t8_cmesh_t cmesh, const int ntrees, const t8_ecla
 
           /* If we already checked the two faces, we can
            * skip the computations here since we only need the connectivity in one direction. */
-          /* *INDENT-OFF* */
           if (!do_both_directions
               && conn[T8_3D_TO_1D (ntrees, T8_ECLASS_MAX_FACES, 3, neigh_itree, neigh_iface, 0)] > -1) {
             continue;
           }
-          /* *INDENT-ON* */
 
           /* Get the number of vertices per face of potentially neighboring element. */
           const int neigh_nface_verts = t8_eclass_num_vertices[t8_eclass_face_types[neigh_eclass][neigh_iface]];
@@ -115,12 +113,10 @@ t8_cmesh_set_join_by_vertices (t8_cmesh_t cmesh, const int ntrees, const t8_ecla
                 /* Retrieve the x, y or z component of the face vertex
                  * coordinate from the vertices array. */
 
-                /* *INDENT-OFF* */
                 const double face_vert
                   = vertices[T8_3D_TO_1D (ntrees, T8_ECLASS_MAX_CORNERS, T8_ECLASS_MAX_DIM, itree, ivert, icoord)];
                 const double neigh_face_vert = vertices[T8_3D_TO_1D (ntrees, T8_ECLASS_MAX_CORNERS, T8_ECLASS_MAX_DIM,
                                                                      neigh_itree, neigh_ivert, icoord)];
-                /* *INDENT-ON* */
 
                 /* Compare the coordinates with some tolerance. */
                 if (fabs (face_vert - neigh_face_vert) < 10.0 * T8_PRECISION_EPS) {
@@ -177,11 +173,9 @@ t8_cmesh_set_join_by_vertices (t8_cmesh_t cmesh, const int ntrees, const t8_ecla
 
             /* Store the results. */
 
-            /* *INDENT-OFF* */
             conn[T8_3D_TO_1D (ntrees, T8_ECLASS_MAX_FACES, 3, itree, iface, 0)] = neigh_itree;
             conn[T8_3D_TO_1D (ntrees, T8_ECLASS_MAX_FACES, 3, itree, iface, 1)] = neigh_iface;
             conn[T8_3D_TO_1D (ntrees, T8_ECLASS_MAX_FACES, 3, itree, iface, 2)] = orientation;
-            /* *INDENT-ON* */
 
             break;
           }

--- a/src/t8_cmesh/t8_cmesh_occ.cxx
+++ b/src/t8_cmesh/t8_cmesh_occ.cxx
@@ -120,8 +120,6 @@ t8_cmesh_new_hollow_cylinder (sc_MPI_Comm comm, int num_tangential_trees, int nu
         t8_cmesh_set_tree_class (
           cmesh, (i_tangential_trees * num_axial_trees + i_axial_trees) * num_radial_trees + i_radial_trees,
           T8_ECLASS_HEX);
-
-        /* *INDENT-OFF* */
         const int current_tree_vertices
           = ((i_tangential_trees * num_axial_trees + i_axial_trees) * num_radial_trees + i_radial_trees) * 24;
         vertices[current_tree_vertices + 0]
@@ -160,7 +158,6 @@ t8_cmesh_new_hollow_cylinder (sc_MPI_Comm comm, int num_tangential_trees, int nu
         vertices[current_tree_vertices + 21] = cos (i_tangential_trees * dphi) * (radius_inner + i_radial_trees * dr);
         vertices[current_tree_vertices + 22] = sin (i_tangential_trees * dphi) * (radius_inner + i_radial_trees * dr);
         vertices[current_tree_vertices + 23] = -0.5 + (i_axial_trees + 1) * dh;
-        /* *INDENT-ON* */
 
         t8_cmesh_set_tree_vertices (
           cmesh, (i_tangential_trees * num_axial_trees + i_axial_trees) * num_radial_trees + i_radial_trees,
@@ -173,7 +170,6 @@ t8_cmesh_new_hollow_cylinder (sc_MPI_Comm comm, int num_tangential_trees, int nu
           /* Calculate parameters if cell lies on boundary */
           const int current_tree_parameters = (i_tangential_trees * num_axial_trees + i_axial_trees) * 8;
           if (i_radial_trees == 0 || i_radial_trees == num_radial_trees - 1) {
-            /* *INDENT-OFF* */
             parameters[current_tree_parameters + 0] = (i_tangential_trees + 1) * dphi;
             parameters[current_tree_parameters + 1] = 0.5 - i_axial_trees * dh;
             parameters[current_tree_parameters + 2] = i_tangential_trees * dphi;
@@ -182,7 +178,6 @@ t8_cmesh_new_hollow_cylinder (sc_MPI_Comm comm, int num_tangential_trees, int nu
             parameters[current_tree_parameters + 5] = 0.5 + -(i_axial_trees + 1) * dh;
             parameters[current_tree_parameters + 6] = i_tangential_trees * dphi;
             parameters[current_tree_parameters + 7] = 0.5 - (i_axial_trees + 1) * dh;
-            /* *INDENT-ON* */
           }
           int edges[24] = { 0 };
 

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -38,16 +38,22 @@
 #define T8_NUM_GMSH_ELEM_CLASSES 15
 /* look-up table to translate the gmsh tree class to a t8code tree class.
  */
+/* clang-format off */
 const t8_eclass_t t8_msh_tree_type_to_eclass[T8_NUM_GMSH_ELEM_CLASSES + 1] = {
-  T8_ECLASS_COUNT,                                                  /* 0 is not valid */
-  T8_ECLASS_LINE,                                                   /* 1 */
-  T8_ECLASS_TRIANGLE, T8_ECLASS_QUAD, T8_ECLASS_TET, T8_ECLASS_HEX, /* 5 */
-  T8_ECLASS_PRISM, T8_ECLASS_PYRAMID,                               /* 7 This is the last first order tree type,
-                                   except the Point, which is type 15 */
+  T8_ECLASS_COUNT,     /* 0 is not valid */
+  T8_ECLASS_LINE,      /* 1 */
+  T8_ECLASS_TRIANGLE, 
+  T8_ECLASS_QUAD, 
+  T8_ECLASS_TET, 
+  T8_ECLASS_HEX,        /* 5 */
+  T8_ECLASS_PRISM, 
+  T8_ECLASS_PYRAMID,    /* 7 This is the last first order tree type, except the Point, which is type 15 */
   /* We do not support type 8 to 14 */
-  T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT,
-  T8_ECLASS_VERTEX /* 15 */
+  T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, 
+  T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT,
+  T8_ECLASS_VERTEX      /* 15 */
 };
+/* clang-format on */
 
 /* translate the msh file vertex number to the t8code vertex number.
  * See also http://gmsh.info/doc/texinfo/gmsh.html#Node-ordering */
@@ -997,11 +1003,6 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp, sc_hash_t *vertices, 
           *(long **) sc_array_push (*vertex_indices) = stored_indices;
         }
 
-        /* The following code contains many long function names and some c++, 
-         * which gets unreadable when limited to 80 characters. We therefore
-         * deactivate the automatic indentation.
-         * TODO: Indent after switching to other indentation rules */
-        /* *INDENT-OFF* */
         if (!use_occ_geometry) {
           /* Set the geometry of the tree to be linear.
            * If we use an occ geometry, we set the geometry in accordance,
@@ -1349,8 +1350,7 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp, sc_hash_t *vertices, 
                 /* Some error checking */
                 if (edge_nodes[i_edge_node].entity_dim == 2
                     && edge_nodes[i_edge_node].entity_tag != edge_geometry_tag) {
-                  t8_global_errorf ("Error: Node %i should lie on a specific face, "
-                                    "but it lies on another face.\n",
+                  t8_global_errorf ("Error: Node %i should lie on a specific face, but it lies on another face.\n",
                                     edge_nodes[i_edge_node].index);
                   goto die_ele;
                 }
@@ -1437,7 +1437,6 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp, sc_hash_t *vertices, 
           SC_ABORTF ("OCC not linked");
 #endif /* T8_WITH_OCC */
         }
-        /* *INDENT-ON* */
       }
     }
   }
@@ -1806,8 +1805,7 @@ t8_cmesh_from_msh_file (const char *fileprefix, int partition, sc_MPI_Comm comm,
     case 2:
       if (use_occ_geometry) {
         fclose (file);
-        t8_errorf ("WARNING: The occ geometry is only supported for msh files of "
-                   "version 4\n");
+        t8_errorf ("WARNING: The occ geometry is only supported for msh files of version 4\n");
         t8_cmesh_destroy (&cmesh);
         if (partition) {
           /* Communicate to the other processes that reading failed. */

--- a/src/t8_cmesh/t8_cmesh_refine.cxx
+++ b/src/t8_cmesh/t8_cmesh_refine.cxx
@@ -604,11 +604,9 @@ t8_cmesh_refine_ghost (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, t8_child_id_to_l
     lghost_id = idarray[ghostid][ichild].local_id;
     newghost = t8_cmesh_trees_get_ghost_ext (cmesh->trees, lghost_id, &nghost_neighbors, &nttf);
     /* Set all face_neighbors of the child ghost */
-    /* *INDENT-OFF* */
     t8_cmesh_refine_new_neighbors (cmesh_from, ghostid,
                                    t8_cmesh_get_global_id (cmesh_from, cmesh_from->num_local_trees + ghostid),
                                    newghost->eclass, idarray, (int) child_id, NULL, nghost_neighbors, nttf, factor);
-    /* *INDENT-ON* */
     child_id = idarray[ghostid][ichild + 1].child_id;
   }
 }

--- a/src/t8_cmesh/t8_cmesh_save.c
+++ b/src/t8_cmesh/t8_cmesh_save.c
@@ -324,8 +324,7 @@ t8_cmesh_save_trees (t8_cmesh_t cmesh, FILE *fp)
       /* TODO: We currently do not support saving of attributes different
        * to the tree vertices */
       fclose (fp);
-      t8_errorf ("We do not support saving cmeshes with trees that "
-                 "have attributes different to the tree vertices.\n");
+      t8_errorf ("We do not support saving cmeshes with trees that have attributes different to the tree vertices.\n");
       return 0;
     }
     ret = fprintf (fp, "num_attributes %i\nSize of attributes %zd\n\n", tree->num_attributes,


### PR DESCRIPTION
Remove indent-on/off

**_Describe your changes here:_**



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
