### PR TITLE
Update t8_cmesh_types

### DIFF
--- a/src/t8_cmesh/t8_cmesh_types.h
+++ b/src/t8_cmesh/t8_cmesh_types.h
@@ -56,7 +56,7 @@ typedef struct t8_cprofile t8_cprofile_t; /* Defined below */
 #define T8_CMESH_OCC_EDGE_PARAMETERS_ATTRIBUTE_KEY 3 /* Used to store edge parameters */
 #define T8_CMESH_OCC_FACE_ATTRIBUTE_KEY \
   T8_CMESH_OCC_EDGE_PARAMETERS_ATTRIBUTE_KEY \
-    + T8_ECLASS_MAX_EDGES /* Used to store which face is linked to which surface */
+  +T8_ECLASS_MAX_EDGES /* Used to store which face is linked to which surface */
 #define T8_CMESH_OCC_FACE_PARAMETERS_ATTRIBUTE_KEY \
   T8_CMESH_OCC_FACE_ATTRIBUTE_KEY + 1 /* Used to store face parameters */
 #define T8_CMESH_NEXT_POSSIBLE_KEY \
@@ -101,19 +101,19 @@ typedef struct t8_cmesh
                                            refinement pattern. See \ref t8_cmesh_set_refine. */
   t8_scheme_cxx_t *set_partition_scheme; /**< If the cmesh is to be partitioned according to a uniform level,
                                                 the scheme that describes the refinement pattern. See \ref t8_cmesh_set_partition. */
-  int8_t set_partition_level; /**< Non-negative if the cmesh should be partitioned from an already existing cmesh
+  int8_t set_partition_level;  /**< Non-negative if the cmesh should be partitioned from an already existing cmesh
                                          with an assumed \a level uniform mesh underneath. */
-  struct t8_cmesh *set_from;  /**< If this cmesh shall be derived from an
+  struct t8_cmesh *set_from;   /**< If this cmesh shall be derived from an
                                   existing cmesh by copy or more elaborate
                                   modification, we store a pointer to this
                                   other cmesh here. */
-  int mpirank;                /**< Number of this MPI process. */
-  int mpisize;                /**< Number of MPI processes. */
-  t8_refcount_t rc;           /**< The reference count of the cmesh. */
-  t8_gloidx_t num_trees;      /**< The global number of trees */
-  t8_locidx_t
-    num_local_trees; /**< If partitioned the number of trees on this process. Otherwise the global number of trees. */
-  t8_locidx_t num_ghosts; /**< If partitioned the number of neighbor trees
+  int mpirank;                 /**< Number of this MPI process. */
+  int mpisize;                 /**< Number of MPI processes. */
+  t8_refcount_t rc;            /**< The reference count of the cmesh. */
+  t8_gloidx_t num_trees;       /**< The global number of trees */
+  t8_locidx_t num_local_trees; /**< If partitioned the number of trees on this process. 
+                                    Otherwise the global number of trees. */
+  t8_locidx_t num_ghosts;      /**< If partitioned the number of neighbor trees
                                     owned by different processes. */
   /* TODO: wouldnt a local num_trees_per_eclass be better?
    *       only as an additional info. we need the global count. i.e. for forest_maxlevel computation.
@@ -127,12 +127,11 @@ typedef struct t8_cmesh
 
   t8_cmesh_trees_t trees; /**< structure that holds all local trees and ghosts */
 
-  t8_gloidx_t first_tree; /**< The global index of the first local tree on this process. 
+  t8_gloidx_t first_tree;   /**< The global index of the first local tree on this process. 
                                        Zero if the cmesh is not partitioned. -1 if this processor is empty.
                                        See also https://github.com/DLR-AMR/t8code/wiki/Tree-indexing */
-  int8_t
-    first_tree_shared; /**< If partitioned true if the first tree on this process is also the last tree on the next process.
-                                             Always zero if num_local_trees = 0 */
+  int8_t first_tree_shared; /**< If partitioned true if the first tree on this process is also the last tree 
+                                  on the next process. Always zero if num_local_trees = 0 */
 
   t8_shmem_array_t tree_offsets; /**< If partitioned for each process the global index of its first local tree
                                         or -(first local tree) - 1


### PR DESCRIPTION
Split comments into two lines

**_Describe your changes here:_**



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
