### PR TITLE
indent test_t8_forest_incomplete files

### DIFF
--- a/test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
@@ -36,7 +36,6 @@
  * The two resulting forests must be equal.
  * */
 
-/* *INDENT-OFF* */
 class global_tree: public testing::TestWithParam<std::tuple<t8_eclass, int>> {
  protected:
   void
@@ -58,7 +57,6 @@ class global_tree: public testing::TestWithParam<std::tuple<t8_eclass, int>> {
   t8_eclass_t eclass;
   t8_forest_t forest;
 };
-/* *INDENT-ON* */
 
 /** Removes all elements of local trees if they belong to the corresponding
  *  global trees which are defined by the current testcase of test. */
@@ -169,7 +167,5 @@ TEST_P (global_tree, test_empty_global_tree)
   t8_forest_unref (&forest_adapt_b);
 }
 
-/* *INDENT-OFF* */
 INSTANTIATE_TEST_SUITE_P (t8_gtest_empty_global_tree, global_tree,
                           testing::Combine (testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT), testing::Range (0, 6)));
-/* *INDENT-ON* */

--- a/test/t8_forest_incomplete/t8_gtest_empty_local_tree.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_empty_local_tree.cxx
@@ -53,7 +53,6 @@
  * The two resulting forests must be equal.
  */
 
-/* *INDENT-OFF* */
 class local_tree: public testing::TestWithParam<t8_eclass_t> {
  protected:
   void
@@ -78,7 +77,6 @@ class local_tree: public testing::TestWithParam<t8_eclass_t> {
   t8_eclass_t eclass;
   t8_forest_t forest;
 };
-/* *INDENT-ON* */
 
 /** This structure contains a bitset with all 
  * local trees on all processes to be removed.
@@ -132,12 +130,10 @@ TEST_P (local_tree, test_empty_local_tree)
     /* Remove all local elements for every process \a remove[rank] == 0 */
     std::bitset<MAX_NUM_RANKS> remove (instances);
 
-    /* *INDENT-OFF* */
     struct t8_trees_to_remove data
     {
       remove
     };
-    /* *INDENT-ON* */
 
     t8_forest_ref (forest);
     /* Do adapt and partition in one step */
@@ -160,6 +156,4 @@ TEST_P (local_tree, test_empty_local_tree)
   }
 }
 
-/* *INDENT-OFF* */
 INSTANTIATE_TEST_SUITE_P (t8_gtest_empty_local_tree, local_tree, testing::Range (T8_ECLASS_LINE, T8_ECLASS_COUNT));
-/* *INDENT-ON* */

--- a/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
@@ -34,7 +34,6 @@
  * t8_forest_iterate_replace if it is passed the correct values.
  */
 
-/* *INDENT-OFF* */
 class forest_iterate: public testing::TestWithParam<int> {
  protected:
   void
@@ -54,7 +53,6 @@ class forest_iterate: public testing::TestWithParam<int> {
   int cmesh_id;
   t8_forest_t forest;
 };
-/* *INDENT-ON* */
 
 /** This structure contains an array with all return values of all
  * callback function calls in the adaptation process of a forest.
@@ -220,12 +218,10 @@ TEST_P (forest_iterate, test_iterate_replace)
     for (t8_locidx_t elidx = 0; elidx < num_elements; elidx++) {
       adapt_callbacks[elidx] = -3;
     }
-    /* *INDENT-OFF* */
     struct t8_return_data data
     {
       adapt_callbacks
     };
-    /* *INDENT-ON* */
 
     t8_forest_ref (forest);
     t8_forest_t forest_adapt;
@@ -243,7 +239,5 @@ TEST_P (forest_iterate, test_iterate_replace)
   }
 }
 
-/* *INDENT-OFF* */
 INSTANTIATE_TEST_SUITE_P (t8_gtest_iterate_replace, forest_iterate,
                           testing::Range (0, t8_get_number_of_all_testcases ()));
-/* *INDENT-ON* */

--- a/test/t8_forest_incomplete/t8_gtest_permute_hole.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_permute_hole.cxx
@@ -58,7 +58,6 @@
  * Note, this test runs only on one rank.
  */
 
-/* *INDENT-OFF* */
 class forest_permute: public testing::TestWithParam<t8_eclass_t> {
  protected:
   void
@@ -89,7 +88,6 @@ class forest_permute: public testing::TestWithParam<t8_eclass_t> {
   t8_forest_t forest;
   t8_cmesh_t cmesh;
 };
-/* *INDENT-ON* */
 
 /** This structure contains a bitset with all 
  *  elements to be removed.
@@ -148,12 +146,10 @@ TEST_P (forest_permute, test_permute_hole)
   for (uint32_t permutation = 1; permutation < num_permutation; permutation++) {
     std::bitset<MAX_NUM_ELEMENTS> remove (permutation);
 
-    /* *INDENT-OFF* */
     struct t8_elements data
     {
       remove
     };
-    /* *INDENT-ON* */
 
     t8_forest_ref (forest);
     /* Remove elements for every 0 bit in \a removes */
@@ -179,6 +175,4 @@ TEST_P (forest_permute, test_permute_hole)
   }
 }
 
-/* *INDENT-OFF* */
 INSTANTIATE_TEST_SUITE_P (t8_gtest_permute_hole, forest_permute, testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));
-/* *INDENT-ON* */

--- a/test/t8_forest_incomplete/t8_gtest_recursive.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_recursive.cxx
@@ -36,7 +36,6 @@
  * Note, that each rank has its own local/global tree. No trees are shared.
  */
 
-/* *INDENT-OFF* */
 class recursive_tree: public testing::TestWithParam<t8_eclass_t> {
  protected:
   void
@@ -70,7 +69,6 @@ class recursive_tree: public testing::TestWithParam<t8_eclass_t> {
   t8_forest_t forest;
   t8_forest_t forest_base;
 };
-/* *INDENT-ON* */
 
 /** Remove every element except last and first of a family. */
 static int
@@ -143,6 +141,4 @@ TEST_P (recursive_tree, test_recursive)
   ASSERT_TRUE (t8_forest_is_equal (forest, forest_base));
 }
 
-/* *INDENT-OFF* */
 INSTANTIATE_TEST_SUITE_P (t8_gtest_recursive, recursive_tree, testing::Range (T8_ECLASS_LINE, T8_ECLASS_COUNT));
-/* *INDENT-ON* */


### PR DESCRIPTION
**_Describe your changes here:_**
Delete indent-off/on lines


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
