### PR TITLE
Update indentation test-t8_IO

### DIFF
--- a/test/t8_IO/t8_gtest_vtk_reader.cxx
+++ b/test/t8_IO/t8_gtest_vtk_reader.cxx
@@ -35,7 +35,6 @@ const vtk_file_type_t gtest_vtk_filetypes[VTK_NUM_TYPES]
   = { VTK_FILE_ERROR, VTK_UNSTRUCTURED_FILE, VTK_POLYDATA_FILE, VTK_PARALLEL_UNSTRUCTURED_FILE,
       VTK_PARALLEL_POLYDATA_FILE };
 
-/* *INDENT-OFF* */
 class vtk_reader: public testing::TestWithParam<std::tuple<int, int, int>> {
  protected:
   void
@@ -68,7 +67,6 @@ class vtk_reader: public testing::TestWithParam<std::tuple<int, int, int>> {
   const int num_points[5] = { 0, 121, 24, 6144, 900 };
   const int num_trees[5] = { 0, 200, 12, 1024, 1680 };
 };
-/* *INDENT-ON* */
 
 /* All readers should fail properly with a non-existing file. */
 TEST_P (vtk_reader, vtk_to_cmesh_fail)
@@ -141,10 +139,8 @@ TEST_P (vtk_reader, vtk_to_pointSet)
 #endif
 }
 
-/* *INDENT-OFF* */
 /* Currently does not work for parallel files. Replace with VTK_NUM_TYPES as soon
  * as reading and constructing cmeshes from parallel files is enabled. */
 INSTANTIATE_TEST_SUITE_P (t8_gtest_vtk_reader, vtk_reader,
                           testing::Combine (testing::Range (VTK_FILE_ERROR + 1, (int) VTK_NUM_TYPES),
                                             testing::Values (0, 1), testing::Range (0, T8_VTK_TEST_NUM_PROCS)));
-/* *INDENT-ON* */


### PR DESCRIPTION
**_Describe your changes here:_**
Delete indent-off/on


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
