### PR TITLE
Update indentation example-common

### DIFF
--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -70,8 +70,7 @@ t8_common_within_levelset (t8_forest_t forest, t8_locidx_t ltreeid, t8_element_t
 
   T8_ASSERT (band_width >= 0);
   if (band_width == 0) {
-    /* If bandwidth = 0, we only refine the elements that are intersected by the
-     * zero level-set */
+    /* If bandwidth = 0, we only refine the elements that are intersected by the zero level-set */
     int num_corners = ts->t8_element_num_corners (element);
     int sign = 1, icorner;
     double coords[3];

--- a/example/common/t8_example_common.h
+++ b/example/common/t8_example_common.h
@@ -52,8 +52,7 @@ typedef struct
 typedef double (*t8_scalar_function_1d_fn) (double x, double t);
 typedef double (*t8_scalar_function_2d_fn) (const double x[2], double t);
 typedef double (*t8_scalar_function_3d_fn) (const double x[3], double t);
-/** Function pointer for a vector valued function
- *  f: R^3 x R -> R */
+/** Function pointer for a vector valued function f: R^3 x R -> R */
 typedef void (*t8_flow_function_3d_fn) (const double x_in[3], double t, double x_out[3]);
 
 T8_EXTERN_C_BEGIN ();


### PR DESCRIPTION
**_Describe your changes here:_**
Change indentation of comments from two to one lines


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
