### PR TITLE
From GNU-indent to clang-format

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,8 +11,8 @@ The purpose of the indentation scripts is to help t8code developers to indent th
 Apply this script to a `.c`, `.cxx`, `.h` or `.hxx` file to indent it according to the guidelines.
 You can also provide a list of files and all will get indented.
 
-This script uses the `GNU indent` program with t8code specific settings.
-Sometimes `t8indent` does produce undesired results. Therefore, after indenting use `git add -p` or similar to check all changes before committing. You can protect code lines from being changed by the script by enclosing them in `/* *INDENT-ON* */` and `/* *INDENT-OFF* */` comments.
+This script uses the `clang-format` program with t8code specific settings.
+Sometimes `t8indent` does produce undesired results. Therefore, after indenting use `git add -p` or similar to check all changes before committing. You can protect code lines from being changed by the script by enclosing them in `/* clang-format off */` and `/* clang-format on */` comments.
 See also [Known issues with indent](https://github.com/holke/t8code/wiki/Known-issues-with-the-indent-script).
 
 #### pre-commit
@@ -34,10 +34,6 @@ This script indents all t8code source files at once. This script should only be 
 #### find_all_source_files.scp
 
 List all source files of t8code in the `src/` `example/` and `test/` subfolders.
-
-#### remove_double_const.scp
-
-One of the [Known issues with indent](https://github.com/holke/t8code/wiki/Known-issues-with-the-indent-script) is that it duplicates the `const` keyword in `C++` files in some cases. This script iterates over all `C++` files and tries to fix these duplicates. Handle with care.
 
 ## Others
 


### PR DESCRIPTION
Replaced GNU-Indent text-parts with clang-format

Deleted a section about GNU-Indent specific problems. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] New Datatypes are added to t8indent_custom_datatypes.txt
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
