### PR TITLE
Feature batch processing t8 forest element point inside

### DIFF
--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1145,7 +1145,7 @@ t8_line_point_inside (const double *p_0, const double *vec, const double *point,
  * 
  * \param[in] p_0         The first vertex of a triangle
  * \param[in] v           The vector from p_0 to p_1 (second vertex in the triangle)
- * \param[in] w           The vector from p_0 to p_2 (second vertex in the triangle)
+ * \param[in] w           The vector from p_0 to p_2 (third vertex in the triangle)
  * \param[in] point       The coordinates of the point to check
  * \param[in] tolerance   A double > 0 defining the tolerance
  * \return                0 if the point is outside, 1 otherwise.  

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1103,10 +1103,10 @@ t8_line_point_inside (const double *p_0, const double *vec, const double *point,
   double x = 0; /* Initialized to prevent compiler warning. */
   int i;
   /* So x is the solution to
-  * vx = b.
+  * vec * x = b.
   * We can compute it as
-  * x = b[i] / v[i]
-  * if any v[i] is not 0.
+  * x = b[i] / vec[i]
+  * if any vec[i] is not 0.
   *
   * Otherwise the line is degenerated (which should not happen).
   */
@@ -1117,7 +1117,7 @@ t8_line_point_inside (const double *p_0, const double *vec, const double *point,
     }
   }
 
-  /* If i == 3 here, then v = 0 and hence the line is degenerated. */
+  /* If i == 3 here, then vec = 0 and hence the line is degenerated. */
   SC_CHECK_ABORT (i < 3, "Degenerated line element. Both endpoints are the same.");
 
   if (x < -tolerance || x > 1 + tolerance) {
@@ -1127,7 +1127,7 @@ t8_line_point_inside (const double *p_0, const double *vec, const double *point,
 
   /* we can check whether x gives us a solution by
      * checking whether
-     *  vx = b
+     *  vec * x = b
      * is actually true.
      */
   double vec_check[3] = { vec[0], vec[1], vec[2] };
@@ -1155,8 +1155,8 @@ t8_triangle_point_inside (const double p_0[3], const double v[3], const double w
                           const double tolerance)
 {
   /* A point p is inside the triangle that is spanned
-   * by the vectors p_0 p_1 p_2 if and only if the linear system
-   * (p_1 - p_0)x + (p_2 - p_0)y = p - p_0
+   * by the point p_0 and vectors v and w if and only if the linear system
+   * vx + wy = point - p_0
    * has a solution with 0 <= x,y and x + y <= 1.
    *
    * We check whether such a solution exists by computing
@@ -1167,7 +1167,7 @@ t8_triangle_point_inside (const double p_0[3], const double v[3], const double w
 
   T8_ASSERT (tolerance > 0); /* negative values and zero are not allowed */
   double b[3];
-  /* b = p - p_0 */
+  /* b = point - p_0 */
   t8_vec_axpyz (p_0, point, b, -1);
 
   /* Let d = det (v w e_3) */
@@ -1204,8 +1204,8 @@ t8_triangle_point_inside (const double p_0[3], const double v[3], const double w
   return 1;
 }
 
-/** Check if a point lays on the inner side of a plane of bilinearly interpolated volume element. 
- * the plane is described by a point an the normal of the face. 
+/** Check if a point lays on the inner side of a plane of a bilinearly interpolated volume element. 
+ * the plane is described by a point and the normal of the face. 
  * \param[in] point_on_face   A point on the plane
  * \param[in] face_normal     The normal of the face
  * \param[in] point           The point to check
@@ -1220,7 +1220,7 @@ t8_plane_point_inside (const double point_on_face[3], const double face_normal[3
   /* Compute <x-p,n> */
   const double dot_product = t8_vec_dot (pof, face_normal);
   if (dot_product < 0) {
-    /* The point is outside of the plane */
+    /* The point is on the wrong side of the plane */
     return 0;
   }
   return 1;

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1342,15 +1342,13 @@ t8_forest_element_point_batch_inside (t8_forest_t forest, t8_locidx_t ltreeid, c
      * The inner side is defined as the side where the outside normal vector does not
      * point to.
      * The point is on this inner side if and only if the scalar product of
-     * a point on the plane minus the point
-     *                with
-     * the outer normal of the face
+     * a point on the plane minus the point with the outer normal of the face
      * is >= 0.
      *
      * In other words, let p be the point to check, n the outer normal and x a point
      * on the plane, then p is on the inner side if and only if
      *  <x - p, n> >= 0
-     **/
+     */
 
     const int num_faces = ts->t8_element_num_faces (element);
     /* Assume that every point is inside of the element */

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1133,7 +1133,7 @@ t8_triangle_point_inside (const double p_0[3], const double p_1[3], const double
 
 int
 t8_forest_element_point_inside (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
-                                const double point[3], const double tolerance)
+                                const double *points, const double tolerance)
 {
   const t8_eclass_t tree_class = t8_forest_get_tree_class (forest, ltreeid);
   t8_eclass_scheme_c *ts = t8_forest_get_eclass_scheme (forest, tree_class);
@@ -1162,7 +1162,7 @@ t8_forest_element_point_inside (t8_forest_t forest, t8_locidx_t ltreeid, const t
     t8_forest_element_coordinate (forest, ltreeid, element, 0, vertex_coords);
     /* Check whether the point and the vertex are within tolerance distance
        * to each other */
-    if (t8_vec_dist (vertex_coords, point) > tolerance) {
+    if (t8_vec_dist (vertex_coords, points) > tolerance) {
       return 0;
     }
     return 1;
@@ -1185,7 +1185,7 @@ t8_forest_element_point_inside (t8_forest_t forest, t8_locidx_t ltreeid, const t
     /* v = p_1 - p_0 */
     t8_vec_axpy (p_0, v, -1);
     /* b = p - p_0 */
-    t8_vec_axpyz (p_0, point, b, -1);
+    t8_vec_axpyz (p_0, points, b, -1);
 
     /* So x is the solution to
      * vx = b.
@@ -1239,11 +1239,11 @@ t8_forest_element_point_inside (t8_forest_t forest, t8_locidx_t ltreeid, const t
     }
 #endif
     /* Check whether the point is inside the first triangle. */
-    point_inside = t8_triangle_point_inside (p_0, p_1, p_2, point, tolerance);
+    point_inside = t8_triangle_point_inside (p_0, p_1, p_2, points, tolerance);
 
     if (!point_inside) {
       /* If not, check whether the point is inside the second triangle. */
-      point_inside = t8_triangle_point_inside (p_1, p_2, p_3, point, tolerance);
+      point_inside = t8_triangle_point_inside (p_1, p_2, p_3, points, tolerance);
     }
     /* point_inside is true if the point was inside the first or second triangle. Otherwise it is false. */
     return point_inside;
@@ -1256,7 +1256,7 @@ t8_forest_element_point_inside (t8_forest_t forest, t8_locidx_t ltreeid, const t
     t8_forest_element_coordinate (forest, ltreeid, element, 1, p_1);
     t8_forest_element_coordinate (forest, ltreeid, element, 2, p_2);
 
-    return t8_triangle_point_inside (p_0, p_1, p_2, point, tolerance);
+    return t8_triangle_point_inside (p_0, p_1, p_2, points, tolerance);
   }
   case T8_ECLASS_TET:
   case T8_ECLASS_HEX:
@@ -1286,7 +1286,7 @@ t8_forest_element_point_inside (t8_forest_t forest, t8_locidx_t ltreeid, const t
       t8_forest_element_coordinate (forest, ltreeid, element, afacecorner, point_on_face);
 
       /* Set x = x - p */
-      t8_vec_axpy (point, point_on_face, -1);
+      t8_vec_axpy (points, point_on_face, -1);
       /* Compute <x-p,n> */
       dot_product = t8_vec_dot (point_on_face, face_normal);
       if (dot_product < 0) {

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -759,7 +759,7 @@ t8_forest_iterate (t8_forest_t forest);
  */
 int
 t8_forest_element_point_inside (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
-                                const double point[3], const double tolerance);
+                                const double *points, const double tolerance);
 
 /* TODO: if set level and partition/adapt/balance all give NULL, then
  * refine uniformly and partition/adapt/balance the unfiform forest. */

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -761,7 +761,7 @@ int
 t8_forest_element_point_inside (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
                                 const double point[3], const double tolerance);
 
-/** Query whether a batch of point lies inside an element or not. For bilinearly interpolated elements.
+/** Query whether a batch of points lies inside an element. For bilinearly interpolated elements.
  * \note For 2D quadrilateral elements this function is only an approximation. It is correct
  *  if the four vertices lie in the same plane, but it may produce only approximate results if 
  *  the vertices do not lie in the same plane.
@@ -770,11 +770,11 @@ t8_forest_element_point_inside (t8_forest_t forest, t8_locidx_t ltreeid, const t
  * \param [in]      element     The element.
  * \param [in]      points      3-dimensional coordinates of the points to check
  * \param [in]      num_points  The number of points to check
- * \param [in, out] is_inside   An array of length num_points, filled with 0/1 on output. True (non-zero) if \a point 
- *                              lies within \a element, false otherwise. The return value is also true if the point 
+ * \param [in, out] is_inside   An array of length \a num_points, filled with 0/1 on output. True (non-zero) if a \a point 
+ *                              lies within an \a element, false otherwise. The return value is also true if the point 
  *                              lies on the element boundary. Thus, this function may return true for different leaf 
  *                              elements, if they are neighbors and the point lies on the common boundary.
- * \param [in]      tolerance   tolerance that we allow the point to not exactly match the element.
+ * \param [in]      tolerance   Tolerance that we allow the point to not exactly match the element.
  *                              If this value is larger we detect more points.
  *                              If it is zero we probably do not detect points even if they are inside
  *                              due to rounding errors.

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -759,7 +759,29 @@ t8_forest_iterate (t8_forest_t forest);
  */
 int
 t8_forest_element_point_inside (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
-                                const double *points, const double tolerance);
+                                const double point[3], const double tolerance);
+
+/** Query whether a batch of point lies inside an element or not. For bilinearly interpolated elements.
+ * \note For 2D quadrilateral elements this function is only an approximation. It is correct
+ *  if the four vertices lie in the same plane, but it may produce only approximate results if 
+ *  the vertices do not lie in the same plane.
+ * \param [in]      forest      The forest.
+ * \param [in]      ltree_id    The forest local id of the tree in which the element is.
+ * \param [in]      element     The element.
+ * \param [in]      points      3-dimensional coordinates of the points to check
+ * \param [in]      num_points  The number of points to check
+ * \param [in, out] is_inside   An array of length num_points, filled with 0/1 on output. True (non-zero) if \a point 
+ *                              lies within \a element, false otherwise. The return value is also true if the point 
+ *                              lies on the element boundary. Thus, this function may return true for different leaf 
+ *                              elements, if they are neighbors and the point lies on the common boundary.
+ * \param [in]      tolerance   tolerance that we allow the point to not exactly match the element.
+ *                              If this value is larger we detect more points.
+ *                              If it is zero we probably do not detect points even if they are inside
+ *                              due to rounding errors.
+ */
+void
+t8_forest_element_point_batch_inside (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
+                                      const double *points, int num_points, int *is_inside, const double tolerance);
 
 /* TODO: if set level and partition/adapt/balance all give NULL, then
  * refine uniformly and partition/adapt/balance the unfiform forest. */

--- a/test/t8_geometry/t8_gtest_point_inside.cxx
+++ b/test/t8_geometry/t8_gtest_point_inside.cxx
@@ -143,8 +143,6 @@ class geometry_point_inside: public testing::TestWithParam<std::tuple<t8_eclass,
 
 TEST_P (geometry_point_inside, test_point_inside)
 {
-
-  double test_point[3];
   double element_vertices[T8_ECLASS_MAX_CORNERS][3];
   const double barycentric_range_lower_bound = 0.1; /* Must be > 0 */
   const double barycentric_range_upper_bound = 1.1; /* Should be > 1 */
@@ -233,6 +231,9 @@ TEST_P (geometry_point_inside, test_point_inside)
       }
       /* Corrected number of points due to possible rounding errors in pow */
       const int num_points = sc_intpow (num_steps, num_corners - 1);
+      double *test_point = T8_ALLOC (double, num_points * 3);
+      int *point_is_inside = T8_ALLOC (int, num_points);
+      int *point_is_recognized_as_inside = T8_ALLOC (int, num_points);
       double step = (barycentric_range_upper_bound - barycentric_range_lower_bound) / (num_steps - 1);
       //t8_debugf ("step size %g, steps %i, points %i (corners %i)\n", step,
       //           num_steps, num_points, num_corners);
@@ -243,11 +244,11 @@ TEST_P (geometry_point_inside, test_point_inside)
        * is correctly detected to be in/outside the element. */
       for (int ipoint = 0; ipoint < num_points; ++ipoint) {
         double Sum = 0;
-        int point_is_inside = 1;
+        point_is_inside[ipoint] = 1;
 
         /* Set the coordinates of the test point to 0 */
         for (int icoord = 0; icoord < 3; ++icoord) {
-          test_point[icoord] = 0;
+          test_point[ipoint * 3 + icoord] = 0;
         }
         for (int icorner = 0; icorner < num_corners - 1; ++icorner) {
           int this_step = (ipoint / sc_intpow (num_steps, icorner)) % num_steps;
@@ -260,11 +261,11 @@ TEST_P (geometry_point_inside, test_point_inside)
 
           /* Construct the actual test point from the barycentric coordinate */
           for (int icoord = 0; icoord < 3; ++icoord) {
-            test_point[icoord] += barycentric_coordinates[icorner] * element_vertices[icorner][icoord];
+            test_point[ipoint * 3 + icoord] += barycentric_coordinates[icorner] * element_vertices[icorner][icoord];
           }
 
           /* The point is inside if and only if all barycentric coordinates are >= 0. */
-          point_is_inside = point_is_inside && barycentric_coordinates[icorner] >= 0;
+          point_is_inside[ipoint] = point_is_inside[ipoint] && barycentric_coordinates[icorner] >= 0;
         }
 
         /* Ensure that sum over all bar. coordinates is 1 */
@@ -272,24 +273,29 @@ TEST_P (geometry_point_inside, test_point_inside)
 
         /* Add this last barycentric coordinate to the test point */
         for (int icoord = 0; icoord < 3; ++icoord) {
-          test_point[icoord] += barycentric_coordinates[num_corners - 1] * element_vertices[num_corners - 1][icoord];
+          test_point[ipoint * 3 + icoord]
+            += barycentric_coordinates[num_corners - 1] * element_vertices[num_corners - 1][icoord];
         }
         /* The point is inside if and only if all barycentric coordinates are >= 0. */
-        point_is_inside = point_is_inside && barycentric_coordinates[num_corners - 1] >= 0;
+        point_is_inside[ipoint] = point_is_inside[ipoint] && barycentric_coordinates[num_corners - 1] >= 0;
 
         num_in += point_is_inside ? 1 : 0;
-
-        /* We now check whether the point inside function correctly sees whether
+      }
+      /* We now check whether the point inside function correctly sees whether
          * the point is inside the element or not. */
-        int point_is_recognized_as_inside = t8_forest_element_point_inside (forest, 0, element, test_point, tolerance);
-
-        ASSERT_EQ (!point_is_recognized_as_inside, !point_is_inside)
+      t8_forest_element_point_batch_inside (forest, 0, element, test_point, num_points, point_is_recognized_as_inside,
+                                            tolerance);
+      for (int ipoint = 0; ipoint < num_points; ipoint++) {
+        ASSERT_EQ (!point_is_recognized_as_inside[ipoint], !point_is_inside[ipoint])
           << "Testing point #" << ipoint << "(" << test_point[0] << "," << test_point[1] << "," << test_point[2]
-          << ") should " << (point_is_inside ? "" : "not") << "be inside the " << t8_eclass_to_string[eclass]
+          << ") should " << (point_is_inside[ipoint] ? "" : "not") << "be inside the " << t8_eclass_to_string[eclass]
           << " element, but is not detected as such.";
       } /* End loop over points. */
       t8_debugf ("%i (%.2f%%) test points are inside the element\n", num_in, (100.0 * num_in) / num_points);
       T8_FREE (barycentric_coordinates);
+      T8_FREE (test_point);
+      T8_FREE (point_is_inside);
+      T8_FREE (point_is_recognized_as_inside);
     } /* End loop over elements */
   }   /* End loop over trees */
   t8_forest_unref (&forest);


### PR DESCRIPTION
Implemented a batched version of the function t8_forest_element_point_inside. 
With the updated implementation we avoid computations that prepare the actuall inside-check for each point check. 
instead this preparing step is done once and then all points are checked. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] New Datatypes are added to t8indent_custom_datatypes.txt
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
