### PR TITLE
Improve forest vtk writer api

### DIFF
--- a/src/t8_forest/t8_forest_vtk.cxx
+++ b/src/t8_forest/t8_forest_vtk.cxx
@@ -552,12 +552,6 @@ t8_forest_to_vtkUnstructuredGrid (t8_forest_t forest, vtkSmartPointer<vtkUnstruc
     dataArrays[idata]->SetNumberOfComponents (num_components); /* Each tuples has 3 values */
     dataArrays[idata]->SetVoidArray (data[idata].data, num_elements * num_components, 1);
     unstructuredGrid->GetCellData ()->AddArray (dataArrays[idata]);
-    if (num_components == 1) {
-      unstructuredGrid->GetCellData ()->SetScalars (dataArrays[idata]);
-    }
-    else {
-      unstructuredGrid->GetCellData ()->SetVectors (dataArrays[idata]);
-    }
   }
 
   /* We have to free the allocated memory for the cellTypes Array and the other arrays we allocated memory for. */

--- a/src/t8_forest/t8_forest_vtk.cxx
+++ b/src/t8_forest/t8_forest_vtk.cxx
@@ -551,6 +551,7 @@ t8_forest_to_vtkUnstructuredGrid (t8_forest_t forest, vtkSmartPointer<vtkUnstruc
     dataArrays[idata]->SetNumberOfTuples (num_elements);       /* We want number of tuples=number of elements */
     dataArrays[idata]->SetNumberOfComponents (num_components); /* Each tuples has 3 values */
     dataArrays[idata]->SetVoidArray (data[idata].data, num_elements * num_components, 1);
+    unstructuredGrid->GetCellData ()->AddArray (dataArrays[idata]);
     if (num_components == 1) {
       unstructuredGrid->GetCellData ()->SetScalars (dataArrays[idata]);
     }


### PR DESCRIPTION
The SetScalars()/SetVectors() function lead to only activating the last dataarray. This fixes it by using AddArray() instead. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
