### PR TITLE
Fix issue #773

### DIFF
--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -446,7 +446,6 @@ t8_forest_element_diam (t8_forest_t forest, t8_locidx_t ltreeid, const t8_elemen
 void
 t8_forest_element_centroid (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element, double *coordinates)
 {
-  double corner_coords[3];
   t8_eclass_scheme_c *ts;
 
   T8_ASSERT (t8_forest_is_committed (forest));
@@ -457,11 +456,11 @@ t8_forest_element_centroid (t8_forest_t forest, t8_locidx_t ltreeid, const t8_el
   T8_ASSERT (ts->t8_element_is_valid (element));
 
   /* Initialize the centroid with (0, 0, 0). */
-  memset (coordinates, 0, 3 * sizeof (double));
   /* Get the number of corners of the element. */
-  int num_corners = ts->t8_element_num_corners (element);
+  const int num_corners = ts->t8_element_num_corners (element);
   for (int icorner = 0; icorner < num_corners; icorner++) {
     /* For each corner, add its coordinates to the centroids coordinates. */
+    double corner_coords[3] = { 0.0 };
     t8_forest_element_coordinate (forest, ltreeid, element, icorner, corner_coords);
     /* coordinates = coordinates + corner_coords */
     t8_vec_axpy (corner_coords, coordinates, 1);

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -456,11 +456,11 @@ t8_forest_element_centroid (t8_forest_t forest, t8_locidx_t ltreeid, const t8_el
   T8_ASSERT (ts->t8_element_is_valid (element));
 
   /* Initialize the centroid with (0, 0, 0). */
+  double corner_coords[3] = { 0.0 };
   /* Get the number of corners of the element. */
   const int num_corners = ts->t8_element_num_corners (element);
   for (int icorner = 0; icorner < num_corners; icorner++) {
     /* For each corner, add its coordinates to the centroids coordinates. */
-    double corner_coords[3] = { 0.0 };
     t8_forest_element_coordinate (forest, ltreeid, element, icorner, corner_coords);
     /* coordinates = coordinates + corner_coords */
     t8_vec_axpy (corner_coords, coordinates, 1);

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -446,22 +446,28 @@ t8_forest_element_diam (t8_forest_t forest, t8_locidx_t ltreeid, const t8_elemen
 void
 t8_forest_element_centroid (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element, double *coordinates)
 {
-  t8_eclass_t tree_class;
-  t8_element_shape_t element_shape;
+  double corner_coords[3];
   t8_eclass_scheme_c *ts;
 
   T8_ASSERT (t8_forest_is_committed (forest));
 
-  /* Get the tree's eclass and scheme */
-  tree_class = t8_forest_get_tree_class (forest, ltreeid);
+  /* Get the tree's eclass and scheme. */
+  t8_eclass_t tree_class = t8_forest_get_tree_class (forest, ltreeid);
   ts = t8_forest_get_eclass_scheme (forest, tree_class);
   T8_ASSERT (ts->t8_element_is_valid (element));
 
-  /* Get the element class and calculate the centroid using its element
-   * reference coordinates */
-  element_shape = t8_element_shape (ts, element);
-  t8_forest_element_from_ref_coords (forest, ltreeid, element, t8_element_centroid_ref_coords[element_shape], 1,
-                                     coordinates, NULL);
+  /* Initialize the centroid with (0, 0, 0). */
+  memset (coordinates, 0, 3 * sizeof (double));
+  /* Get the number of corners of the element. */
+  int num_corners = ts->t8_element_num_corners (element);
+  for (int icorner = 0; icorner < num_corners; icorner++) {
+    /* For each corner, add its coordinates to the centroids coordinates. */
+    t8_forest_element_coordinate (forest, ltreeid, element, icorner, corner_coords);
+    /* coordinates = coordinates + corner_coords */
+    t8_vec_axpy (corner_coords, coordinates, 1);
+  }
+  /* Divide each coordinate by num_corners */
+  t8_vec_ax (coordinates, 1. / num_corners);
 }
 
 /* Compute the length of the line from one corner to a second corner in an element */

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -447,6 +447,7 @@ void
 t8_forest_element_centroid (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element, double *coordinates)
 {
   t8_eclass_scheme_c *ts;
+  double corner_coords[3] = { 0.0 };
 
   T8_ASSERT (t8_forest_is_committed (forest));
 
@@ -456,7 +457,7 @@ t8_forest_element_centroid (t8_forest_t forest, t8_locidx_t ltreeid, const t8_el
   T8_ASSERT (ts->t8_element_is_valid (element));
 
   /* Initialize the centroid with (0, 0, 0). */
-  double corner_coords[3] = { 0.0 };
+  memset (coordinates, 0, 3 * sizeof (double));
   /* Get the number of corners of the element. */
   const int num_corners = ts->t8_element_num_corners (element);
   for (int icorner = 0; icorner < num_corners; icorner++) {


### PR DESCRIPTION
**_Describe your changes here:_**

The PR restores the former calculation of the element centroid in t8_forest_cxx.cxx.
This solves the problems regarding triangular meshes used in the advection example, as described in issue #773.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
