### PR TITLE
Add cmesh example quadrangulated spherical surface.

### DIFF
--- a/example/cmesh/t8_cmesh_geometry_examples.cxx
+++ b/example/cmesh/t8_cmesh_geometry_examples.cxx
@@ -143,6 +143,26 @@ main (int argc, char **argv)
     t8_forest_unref (&forest);
   }
 
+  {
+    const char *prefix_cmesh = "t8_quadrangulated_spherical_surface_cmesh";
+    const char *prefix_forest = "t8_quadrangulated_spherical_surface_forest";
+
+    const int uniform_level = 5;
+    const double radius = 1.0;
+
+    t8_cmesh_t cmesh = t8_cmesh_new_quadrangulated_spherical_surface (radius, comm);
+
+    t8_forest_t forest = t8_forest_new_uniform (cmesh, t8_scheme_new_default_cxx (), uniform_level, 0, comm);
+
+    t8_cmesh_vtk_write_file (cmesh, prefix_cmesh, 1.0);
+    t8_global_productionf ("Wrote %s.\n", prefix_cmesh);
+
+    t8_write_forest_to_vtu (forest, prefix_forest);
+    t8_global_productionf ("Wrote %s.\n\n", prefix_forest);
+
+    t8_forest_unref (&forest);
+  }
+
   /* More examples will be added soon. */
 
   t8_global_productionf ("Done!\n");

--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -2808,3 +2808,69 @@ t8_cmesh_new_triangulated_spherical_surface (const double radius, sc_MPI_Comm co
   t8_cmesh_commit (cmesh, comm);
   return cmesh;
 }
+
+t8_cmesh_t
+t8_cmesh_new_quadrangulated_spherical_surface (const double radius, sc_MPI_Comm comm)
+{
+  /* Initialization of the mesh */
+  t8_cmesh_t cmesh;
+  t8_cmesh_init (&cmesh);
+
+  t8_geometry_c *geometry = t8_geometry_quadrangulated_spherical_surface_new ();
+
+  t8_cmesh_register_geometry (cmesh, geometry); /* Use linear geometry */
+
+  const int ntrees = 6; /* Number of cmesh elements resp. trees. */
+  const int nverts = 4; /* Number of cmesh element vertices. */
+
+  /* Arrays for the face connectivity computations via vertices. */
+  double all_verts[ntrees * T8_ECLASS_MAX_CORNERS * T8_ECLASS_MAX_DIM];
+  t8_eclass_t all_eclasses[ntrees];
+
+  /* Defitition of the tree class. */
+  for (int itree = 0; itree < 6; itree++) {
+    t8_cmesh_set_tree_class (cmesh, itree, T8_ECLASS_QUAD);
+    all_eclasses[itree] = T8_ECLASS_QUAD;
+  }
+
+  const double _SQRT3 = 1.7320508075688772;
+  const double r = radius / _SQRT3;
+
+  const double vertices[4][3] = { { -r, -r, r }, { r, -r, r }, { -r, r, r }, { r, r, r } };
+
+  const double angles[] = { 0.0, 0.5 * M_PI, 0.5 * M_PI, M_PI, -0.5 * M_PI, -0.5 * M_PI };
+  const int rot_axis[] = { 0, 0, 1, 1, 0, 1 };
+
+  /* Set the vertices. */
+  for (int itree = 0; itree < ntrees; itree++) {
+    double rot_mat[3][3];
+    double rot_vertices[4][3];
+
+    if (rot_axis[itree] == 0) {
+      t8_mat_init_xrot (rot_mat, angles[itree]);
+    }
+    else {
+      t8_mat_init_yrot (rot_mat, angles[itree]);
+    }
+
+    for (int ivert = 0; ivert < nverts; ivert++) {
+      t8_mat_mult_vec (rot_mat, &(vertices[ivert][0]), &(rot_vertices[ivert][0]));
+    }
+
+    t8_cmesh_set_tree_vertices (cmesh, itree, (double *) rot_vertices, nverts);
+
+    for (int ivert = 0; ivert < nverts; ivert++) {
+      for (int icoord = 0; icoord < T8_ECLASS_MAX_DIM; icoord++) {
+        all_verts[T8_3D_TO_1D (ntrees, T8_ECLASS_MAX_CORNERS, T8_ECLASS_MAX_DIM, itree, ivert, icoord)]
+          = rot_vertices[ivert][icoord];
+      }
+    }
+  }
+
+  /* Face connectivity. */
+  t8_cmesh_set_join_by_vertices (cmesh, ntrees, all_eclasses, all_verts, NULL, 0);
+
+  /* Commit the mesh */
+  t8_cmesh_commit (cmesh, comm);
+  return cmesh;
+}

--- a/src/t8_cmesh/t8_cmesh_examples.h
+++ b/src/t8_cmesh/t8_cmesh_examples.h
@@ -330,6 +330,14 @@ t8_cmesh_new_squared_disk (const double radius, sc_MPI_Comm comm);
 t8_cmesh_t
 t8_cmesh_new_triangulated_spherical_surface (const double radius, sc_MPI_Comm comm);
 
+/** Construct a quadrangulated spherical surface of given radius.
+ * \param [in] radius        Radius of the sphere.
+ * \param [in] comm          The MPI communicator used to commit the cmesh
+ * \return                   A cmesh representing the spherical surface.
+ */
+t8_cmesh_t
+t8_cmesh_new_quadrangulated_spherical_surface (const double radius, sc_MPI_Comm comm);
+
 T8_EXTERN_C_END ();
 
 #endif /* !T8_CMESH_EXAMPLES */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.cxx
@@ -331,6 +331,78 @@ t8_geometry_triangulated_spherical_surface::t8_geom_evaluate (t8_cmesh_t cmesh, 
   }
 }
 
+/**
+ * Map the faces of a unit cube to a spherical surface.
+ * \param [in]  cmesh      The cmesh in which the point lies.
+ * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
+ * \param [in]  ref_coords  Array of \a dimension many entries, specifying a point in [0,1]^dimension.
+ * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords.
+ */
+void
+t8_geometry_quadrangulated_spherical_surface::t8_geom_evaluate (t8_cmesh_t cmesh, t8_gloidx_t gtreeid,
+                                                                const double *ref_coords, const size_t num_coords,
+                                                                double *out_coords) const
+{
+  double n[3]; /* Normal vector. */
+  double r[3]; /* Radial vector. */
+  double p[3]; /* Vector on the plane. */
+
+  t8_locidx_t ltreeid = t8_cmesh_get_local_id (cmesh, gtreeid);
+  double *tree_vertices = t8_cmesh_get_tree_vertices (cmesh, ltreeid);
+
+  {
+    const double center_ref[3] = { 0.5, 0.5, 0.0 };
+    t8_geom_linear_interpolation (center_ref, tree_vertices, 3, 2, n);
+
+    /* Normalize vector `n`. */
+    const double norm = sqrt (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]);
+    n[0] = n[0] / norm;
+    n[1] = n[1] / norm;
+    n[2] = n[2] / norm;
+  }
+
+  r[0] = tree_vertices[0];
+  r[1] = tree_vertices[1];
+  r[2] = tree_vertices[2];
+
+  {
+    /* Normalize vector `r`. */
+    const double norm = sqrt (r[0] * r[0] + r[1] * r[1] + r[2] * r[2]);
+    r[0] = r[0] / norm;
+    r[1] = r[1] / norm;
+    r[2] = r[2] / norm;
+  }
+
+  {
+    double corr_ref_coords[3]; /* Corrected reference coordinates. */
+
+    const double x = ref_coords[0];
+    const double y = ref_coords[1];
+    const double z = ref_coords[2];
+
+    /* Correction in order to rectify elements near the corners. */
+    corr_ref_coords[0] = tan (0.5 * M_PI * (x - 0.5)) * 0.5 + 0.5;
+    corr_ref_coords[1] = tan (0.5 * M_PI * (y - 0.5)) * 0.5 + 0.5;
+    corr_ref_coords[2] = z;
+
+    t8_geom_linear_interpolation (corr_ref_coords, tree_vertices, 3, 2, p);
+  }
+
+  const double R = (p[0] * n[0] + p[1] * n[1] + p[2] * n[2]) / (r[0] * n[0] + r[1] * n[1] + r[2] * n[2]);
+
+  {
+    /* Normalize vector `p`. */
+    const double norm = sqrt (p[0] * p[0] + p[1] * p[1] + p[2] * p[2]);
+    p[0] = p[0] / norm;
+    p[1] = p[1] / norm;
+    p[2] = p[2] / norm;
+  }
+
+  out_coords[0] = R * p[0];
+  out_coords[1] = R * p[1];
+  out_coords[2] = R * p[2];
+}
+
 T8_EXTERN_C_BEGIN ();
 
 void
@@ -354,6 +426,13 @@ t8_geometry_c *
 t8_geometry_triangulated_spherical_surface_new ()
 {
   t8_geometry_triangulated_spherical_surface *geom = new t8_geometry_triangulated_spherical_surface ();
+  return (t8_geometry_c *) geom;
+}
+
+t8_geometry_c *
+t8_geometry_quadrangulated_spherical_surface_new ()
+{
+  t8_geometry_quadrangulated_spherical_surface *geom = new t8_geometry_quadrangulated_spherical_surface ();
   return (t8_geometry_c *) geom;
 }
 

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.h
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.h
@@ -50,6 +50,12 @@ t8_geometry_squared_disk_new ();
 t8_geometry_c *
 t8_geometry_triangulated_spherical_surface_new ();
 
+/** Create a new quadrangulated_spherical_surface geometry.
+ * \return          A pointer to an allocated geometry struct.
+ */
+t8_geometry_c *
+t8_geometry_quadrangulated_spherical_surface_new ();
+
 T8_EXTERN_C_END ();
 
 #endif /* T8_GEOMETRY_EXAMPLE_H */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.hxx
@@ -115,4 +115,39 @@ class t8_geometry_triangulated_spherical_surface: public t8_geometry_with_vertic
   /* Load tree data is inherited from t8_geometry_with_vertices. */
 };
 
+/** This geometry maps the faces of a cube to a spherical surface.
+ */
+class t8_geometry_quadrangulated_spherical_surface: public t8_geometry_with_vertices {
+ public:
+  /* Basic constructor that sets the dimension and the name. */
+  t8_geometry_quadrangulated_spherical_surface (): t8_geometry_with_vertices (2, "t8_quadrangulated_spherical_surface")
+  {
+  }
+
+  /**
+   * Map the faces of a cube to a spherical surface.
+   * \param [in]  cmesh      The cmesh in which the point lies.
+   * \param [in]  gtreeid    The global tree (of the cmesh) in which the reference point is.
+   * \param [in]  ref_coords  Array of \a dimension x \a num_coords many entries, specifying a point in /f$ [0,1]^\mathrm{dim} /f$.
+   * \param [in]  num_coords  The number of points to map.
+   * \param [out] out_coords  The mapped coordinates in physical space of \a ref_coords. The length is \a num_coords * 3.
+   *
+   * This routine expects an input mesh of six quadrangles arranged into a cube.
+   *
+   */
+  void
+  t8_geom_evaluate (t8_cmesh_t cmesh, t8_gloidx_t gtreeid, const double *ref_coords, const size_t num_coords,
+                    double out_coords[3]) const;
+
+  /* Jacobian, not implemented. */
+  void
+  t8_geom_evaluate_jacobian (t8_cmesh_t cmesh, t8_gloidx_t gtreeid, const double *ref_coords, const size_t num_coords,
+                             double *jacobian) const
+  {
+    SC_ABORT_NOT_REACHED ();
+  }
+
+  /* Load tree data is inherited from t8_geometry_with_vertices. */
+};
+
 #endif /* T8_GEOMETRY_EXAMPLES_HXX */


### PR DESCRIPTION
**_Describe your changes here:_**

Added quadrangulated spherical surface cmesh example.
![grafik](https://github.com/DLR-AMR/t8code/assets/10619309/6d20d79b-98b1-4f04-8d0b-cb7137b9c890)

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
