### PR TITLE
Feature face connectivity test

### DIFF
--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -162,7 +162,6 @@ t8_cmesh_new_vertex (sc_MPI_Comm comm)
   t8_cmesh_register_geometry (cmesh, linear_geom);
   t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_VERTEX);
   t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 1);
-  t8_cmesh_commit (cmesh, comm);
   return cmesh;
 }
 
@@ -183,7 +182,6 @@ t8_cmesh_new_line (sc_MPI_Comm comm)
   t8_cmesh_register_geometry (cmesh, linear_geom);
   t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_LINE);
   t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 2);
-  t8_cmesh_commit (cmesh, comm);
   return cmesh;
 }
 
@@ -205,7 +203,6 @@ t8_cmesh_new_tri (sc_MPI_Comm comm)
   t8_cmesh_register_geometry (cmesh, linear_geom);
   t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_TRIANGLE);
   t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 3);
-  t8_cmesh_commit (cmesh, comm);
   return cmesh;
 }
 
@@ -228,7 +225,6 @@ t8_cmesh_new_tet (sc_MPI_Comm comm)
   t8_cmesh_register_geometry (cmesh, linear_geom);
   t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_TET);
   t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 4);
-  t8_cmesh_commit (cmesh, comm);
   return cmesh;
 }
 
@@ -251,7 +247,6 @@ t8_cmesh_new_quad (sc_MPI_Comm comm)
   t8_cmesh_register_geometry (cmesh, linear_geom);
   t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_QUAD);
   t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 4);
-  t8_cmesh_commit (cmesh, comm);
   return cmesh;
 }
 
@@ -278,7 +273,6 @@ t8_cmesh_new_hex (sc_MPI_Comm comm)
   t8_cmesh_register_geometry (cmesh, linear_geom);
   t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_HEX);
   t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 8);
-  t8_cmesh_commit (cmesh, comm);
   return cmesh;
 }
 
@@ -326,7 +320,6 @@ t8_cmesh_new_pyramid (sc_MPI_Comm comm)
   t8_cmesh_register_geometry (cmesh, linear_geom);
   t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_PYRAMID);
   t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 15);
-  t8_cmesh_commit (cmesh, comm);
   return cmesh;
 }
 
@@ -352,42 +345,44 @@ t8_cmesh_new_prism (sc_MPI_Comm comm)
   t8_cmesh_register_geometry (cmesh, linear_geom);
   t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_PRISM);
   t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 6);
-  t8_cmesh_commit (cmesh, comm);
   return cmesh;
 }
 
 t8_cmesh_t
 t8_cmesh_new_from_class (t8_eclass_t eclass, sc_MPI_Comm comm)
 {
+  t8_cmesh_t cmesh;
   switch (eclass) {
   case T8_ECLASS_VERTEX:
-    return t8_cmesh_new_vertex (comm);
+    cmesh = t8_cmesh_new_vertex (comm);
     break;
   case T8_ECLASS_LINE:
-    return t8_cmesh_new_line (comm);
+    cmesh = t8_cmesh_new_line (comm);
     break;
   case T8_ECLASS_TRIANGLE:
-    return t8_cmesh_new_tri (comm);
+    cmesh = t8_cmesh_new_tri (comm);
     break;
   case T8_ECLASS_QUAD:
-    return t8_cmesh_new_quad (comm);
+    cmesh = t8_cmesh_new_quad (comm);
     break;
   case T8_ECLASS_TET:
-    return t8_cmesh_new_tet (comm);
+    cmesh = t8_cmesh_new_tet (comm);
     break;
   case T8_ECLASS_HEX:
-    return t8_cmesh_new_hex (comm);
+    cmesh = t8_cmesh_new_hex (comm);
     break;
   case T8_ECLASS_PYRAMID:
-    return t8_cmesh_new_pyramid (comm);
+    cmesh = t8_cmesh_new_pyramid (comm);
     break;
   case T8_ECLASS_PRISM:
-    return t8_cmesh_new_prism (comm);
+    cmesh = t8_cmesh_new_prism (comm);
     break;
   default:
     SC_ABORT ("Invalid eclass\n");
     return NULL;
   }
+  t8_cmesh_commit (cmesh, comm);
+  return cmesh;
 }
 
 t8_cmesh_t

--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -2634,12 +2634,13 @@ t8_tri_shift_vertices_along_face (double *vertices, const int face)
   const int v_2 = face;
   double ortho[3];
   t8_vec_orthogonal_through_point (vertices + 3 * v_0, vertices + 3 * v_1, vertices + 3 * v_2, ortho);
+
   double tmp[3];
   memcpy (tmp, vertices + 3 * v_2, 3 * sizeof (double));
   memcpy (vertices + 3 * v_2, vertices + 3 * v_1, 3 * sizeof (double));
   memcpy (vertices + 3 * v_1, vertices + 3 * v_0, 3 * sizeof (double));
 
-  t8_vec_axpyz (ortho, tmp, vertices + 3 * v_0, 2.0);
+  t8_vec_axpyz (ortho, tmp, vertices + 3 * v_0, -2.0);
 }
 
 static void

--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -2838,6 +2838,7 @@ t8_hex_shift_vertices_along_face (double *vertices, const int face, const int or
   T8_ASSERT (v_5 != -1);
   T8_ASSERT (v_6 != -1);
   T8_ASSERT (v_7 != -1);
+  const int v[8] = { v_0, v_1, v_2, v_3, v_4, v_5, v_6, v_7 };
 
 #if T8_ENABLE_DEBUG
   /* Check that every vertex is used exactly once. */
@@ -2851,6 +2852,7 @@ t8_hex_shift_vertices_along_face (double *vertices, const int face, const int or
   every_vertex_set[v_6] += 1;
   every_vertex_set[v_7] += 1;
   for (int i = 0; i < 8; i++) {
+    t8_debugf ("[D] %i: %i %f %f %f\n", i, v[i], vertices[3 * v[i]], vertices[3 * v[i] + 1], vertices[3 * v[i] + 2]);
     T8_ASSERT (every_vertex_set[i] == 1);
   }
 #endif
@@ -2898,15 +2900,18 @@ t8_hex_shift_vertices_along_face (double *vertices, const int face, const int or
   t8_vec_axpy (normal, vertices + 3 * v_3, dist_3);
 
   for (int i = 0; i < orientation; i++) {
-    t8_swap_vec (vertices + 3 * v_0, vertices + 3 * v_1);
-    t8_swap_vec (vertices + 3 * v_1, vertices + 3 * v_3);
-    t8_swap_vec (vertices + 3 * v_2, vertices + 3 * v_3);
+    t8_swap_vec (vertices + 3 * v_1, vertices + 3 * v_0);
+    t8_swap_vec (vertices + 3 * v_2, vertices + 3 * v_1);
+    t8_swap_vec (vertices + 3 * v_3, vertices + 3 * v_2);
 
-    t8_swap_vec (vertices + 3 * v_4, vertices + 3 * v_5);
-    t8_swap_vec (vertices + 3 * v_5, vertices + 3 * v_7);
-    t8_swap_vec (vertices + 3 * v_6, vertices + 3 * v_7);
+    t8_swap_vec (vertices + 3 * v_5, vertices + 3 * v_4);
+    t8_swap_vec (vertices + 3 * v_6, vertices + 3 * v_5);
+    t8_swap_vec (vertices + 3 * v_7, vertices + 3 * v_6);
   }
   const int face_correction = (face % 2 == 0) ? 1 : -1;
+  for (int i = 0; i < 8; i++) {
+    t8_debugf ("[D] %i: %i %f %f %f\n", i, v[i], vertices[3 * v[i]], vertices[3 * v[i] + 1], vertices[3 * v[i] + 2]);
+  }
   return face + face_correction;
 }
 
@@ -3004,8 +3009,8 @@ t8_pyra_shift_vertices_along_face (double *vertices, const int face, const int o
       t8_swap_vec (vertices + 3 * v_0, vertices + 3 * v_1);
       t8_swap_vec (vertices + 3 * v_1, vertices + 3 * v_3);
       t8_swap_vec (vertices + 3 * v_2, vertices + 3 * v_3);
-      return face;
     }
+    return face;
   }
 }
 

--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -2839,7 +2839,7 @@ t8_pyra_shift_vertices_along_face (double *vertices, const int face)
 
   if (face == 4) {
     v_3 = t8_face_vertex_to_tree_vertex[T8_ECLASS_QUAD][face][3];
-    v_4 = 5;
+    v_4 = 4;
   }
   double span_vec_0[3];
   double span_vec_1[3];
@@ -2867,7 +2867,8 @@ t8_pyra_shift_vertices_along_face (double *vertices, const int face)
 
   t8_vec_axpyz (vertices + 3 * v_4, vertices + 3 * v_0, tmp, -1.0);
   n_p = t8_vec_dot (tmp, normal);
-  const double dist_1 = (face == 4) ? 0 : t8_vec_dist (vertices + 3 * v_0, vertices + 3 * v_3);
+  const double dist_1 = (face == 4) ? t8_vec_dist (vertices + 3 * v_0, vertices + 3 * v_4)
+                                    : t8_vec_dist (vertices + 3 * v_0, vertices + 3 * v_3);
 
   if (face != 4) {
     memcpy (vertices + 3 * v_3, vertices + 3 * v_0, 3 * sizeof (double));
@@ -2877,8 +2878,15 @@ t8_pyra_shift_vertices_along_face (double *vertices, const int face)
     t8_vec_axpy (normal, vertices + 3 * v_1, dist_1);
   }
   else {
+
     /*Todo: shuffle v_0 - v_3 to avoid negative volume */
-    t8_vec_axpy (normal, vertices + 3 * v_4, 2 + dist_1);
+    memcpy (tmp, vertices + 3 * v_0, 3 * sizeof (double));
+    memcpy (vertices + 3 * v_0, vertices + 3 * v_1, 3 * sizeof (double));
+    memcpy (vertices + 3 * v_1, vertices + 3 * v_2, 3 * sizeof (double));
+    memcpy (vertices + 3 * v_2, vertices + 3 * v_3, 3 * sizeof (double));
+    memcpy (vertices + 3 * v_3, tmp, 3 * sizeof (double));
+
+    t8_vec_axpy (normal, vertices + 3 * v_4, 2 * dist_1);
   }
 }
 
@@ -2937,5 +2945,6 @@ t8_cmesh_new_two_trees_face_orientation (const t8_eclass_t eclass, const int fac
   t8_cmesh_mirror_tree_along_face (vertices, eclass, face_num);
   t8_cmesh_set_tree_vertices (cmesh, 1, vertices, num_vertices);
   t8_cmesh_commit (cmesh, comm);
+  T8_FREE (vertices);
   return cmesh;
 }

--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -192,12 +192,10 @@ vertices_single_tree (const t8_eclass_t eclass, double *vertices)
     memcpy (vertices, vertices_coords, 12 * sizeof (double));
     break;
   case T8_ECLASS_TET:
-    /* v_0*/
-    memcpy (vertices, vertices_coords + 21, 3 * sizeof (double));
-    /* v_1 - v_2*/
-    memcpy (vertices + 3, vertices_coords + 3, 6 * sizeof (double));
+    /* v_0 - v_2*/
+    memcpy (vertices + 3, vertices_coords, 9 * sizeof (double));
     /* v_3*/
-    memcpy (vertices + 9, vertices_coords + 12, 3 * sizeof (double));
+    memcpy (vertices + 0, vertices_coords + 21, 3 * sizeof (double));
     break;
   case T8_ECLASS_HEX:
     /* v_0 - v_8*/
@@ -2709,7 +2707,6 @@ t8_tet_shift_vertices_along_face (double *vertices, const int face)
 
   double normal[3];
   t8_vec_cross (span_vec_0, span_vec_1, normal);
-  t8_vec_cross (span_vec_0, span_vec_1, normal);
   const double norm = t8_vec_norm (normal);
   T8_ASSERT (norm > 1e-14);
   double tmp[3];
@@ -2720,10 +2717,14 @@ t8_tet_shift_vertices_along_face (double *vertices, const int face)
   t8_vec_ax (normal, n_p > 0 ? 1. / norm : -1. / norm);
 
   const double dist = fabs (n_p) / norm;
-  t8_vec_axpyz (vertices + 3 * v_3, normal, tmp, 2 * dist);
+  t8_vec_axpyz (normal, vertices + 3 * v_3, tmp, 2 * dist);
 
-  /* TODO: maybe reorder vertices to avoid negative volume */
   memcpy (vertices + 3 * v_3, tmp, 3 * sizeof (double));
+
+  /* Reorder vertices to avoid negative volume */
+  memcpy (tmp, vertices + 3 * v_1, 3 * sizeof (double));
+  memcpy (vertices + 3 * v_1, vertices + 3 * v_2, 3 * sizeof (double));
+  memcpy (vertices + 3 * v_2, tmp, 3 * sizeof (double));
 }
 
 static void

--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -2831,8 +2831,10 @@ t8_pyra_shift_vertices_along_face (double *vertices, const int face)
   int v_3 = -1;
   int v_4 = -1;
   if (face != 4) {
-    v_3 = t8_face_vertex_to_tree_vertex[T8_ECLASS_PYRAMID][face + 1][0];
-    v_4 = t8_face_vertex_to_tree_vertex[T8_ECLASS_PYRAMID][face + 1][1];
+    int counterface = face;
+    counterface += ((face % 2) == 0) ? 1 : -1;
+    v_3 = t8_face_vertex_to_tree_vertex[T8_ECLASS_PYRAMID][counterface][0];
+    v_4 = t8_face_vertex_to_tree_vertex[T8_ECLASS_PYRAMID][counterface][1];
   }
 
   if (face == 4) {
@@ -2846,7 +2848,6 @@ t8_pyra_shift_vertices_along_face (double *vertices, const int face)
   t8_vec_axpyz (vertices + 3 * v_2, vertices + 3 * v_0, span_vec_1, -1.0);
 
   double normal[3];
-  t8_vec_cross (span_vec_0, span_vec_1, normal);
   t8_vec_cross (span_vec_0, span_vec_1, normal);
   const double norm = t8_vec_norm (normal);
   T8_ASSERT (norm > 1e-14);
@@ -2862,11 +2863,11 @@ t8_pyra_shift_vertices_along_face (double *vertices, const int face)
 
   /* we want the normal facing from v_3 to the face */
   t8_vec_ax (normal, n_p > 0 ? 1. / norm : -1. / norm);
-  const double dist_0 = fabs (n_p) / norm;
+  const double dist_0 = t8_vec_dist (vertices + 3 * v_0, vertices + 3 * v_3);
 
   t8_vec_axpyz (vertices + 3 * v_4, vertices + 3 * v_0, tmp, -1.0);
   n_p = t8_vec_dot (tmp, normal);
-  const double dist_1 = (face == 4) ? 0 : fabs (n_p) / norm;
+  const double dist_1 = (face == 4) ? 0 : t8_vec_dist (vertices + 3 * v_0, vertices + 3 * v_3);
 
   if (face != 4) {
     memcpy (vertices + 3 * v_3, vertices + 3 * v_0, 3 * sizeof (double));

--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -150,130 +150,75 @@ t8_cmesh_new_from_p8est (p8est_connectivity_t *conn, sc_MPI_Comm comm, int do_pa
   return t8_cmesh_new_from_p4est_ext (conn, 3, comm, do_partition, 0);
 }
 
-static t8_cmesh_t
-t8_cmesh_new_vertex (sc_MPI_Comm comm)
+/**
+ * Construct the coordinates of all vertices of a single tree inside the unit-cube
+ * 
+ * @param eclass 
+ * @param vertices 
+ */
+static void
+vertices_single_tree (const t8_eclass_t eclass, double *vertices)
 {
-  t8_cmesh_t cmesh;
-  double vertices[3] = { 0, 0, 0 };
-  t8_geometry_c *linear_geom = t8_geometry_linear_new (0);
-
-  t8_cmesh_init (&cmesh);
-  /* Use linear geometry */
-  t8_cmesh_register_geometry (cmesh, linear_geom);
-  t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_VERTEX);
-  t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 1);
-  return cmesh;
-}
-
-static t8_cmesh_t
-t8_cmesh_new_line (sc_MPI_Comm comm)
-{
-  t8_cmesh_t cmesh;
   /* clang-format off */
-  double vertices[6] = { 
-    0, 0, 0, 
-    1, 0, 0 
-  };
-  /* clang-format on */
-  t8_geometry_c *linear_geom = t8_geometry_linear_new (1);
-
-  t8_cmesh_init (&cmesh);
-  /* Use linear geometry */
-  t8_cmesh_register_geometry (cmesh, linear_geom);
-  t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_LINE);
-  t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 2);
-  return cmesh;
-}
-
-static t8_cmesh_t
-t8_cmesh_new_tri (sc_MPI_Comm comm)
-{
-  t8_cmesh_t cmesh;
-  /* clang-format off */
-  double vertices[9] = { 
-    0, 0, 0, 
-    1, 0, 0, 
-    1, 1, 0 
-  };
-  /* clang-format on */
-  t8_geometry_c *linear_geom = t8_geometry_linear_new (2);
-
-  t8_cmesh_init (&cmesh);
-  /* Use linear geometry */
-  t8_cmesh_register_geometry (cmesh, linear_geom);
-  t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_TRIANGLE);
-  t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 3);
-  return cmesh;
-}
-
-static t8_cmesh_t
-t8_cmesh_new_tet (sc_MPI_Comm comm)
-{
-  t8_cmesh_t cmesh;
-  /* clang-format off */
-  double vertices[12] = { 
-    1, 1, 1, 
-    1, -1, -1, 
-    -1, 1, -1, 
-    -1, -1, 1 
-  };
-  /* clang-format on */
-  t8_geometry_c *linear_geom = t8_geometry_linear_new (3);
-
-  t8_cmesh_init (&cmesh);
-  /* Use linear geometry */
-  t8_cmesh_register_geometry (cmesh, linear_geom);
-  t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_TET);
-  t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 4);
-  return cmesh;
-}
-
-static t8_cmesh_t
-t8_cmesh_new_quad (sc_MPI_Comm comm)
-{
-  t8_cmesh_t cmesh;
-  /* clang-format off */
-  double vertices[12] = {
-    0, 0, 0, 
-    1, 0, 0, 
-    0, 1, 0, 
-    1, 1, 0,
-  };
-  /* clang-format on */
-  t8_geometry_c *linear_geom = t8_geometry_linear_new (2);
-
-  t8_cmesh_init (&cmesh);
-  /* Use linear geometry */
-  t8_cmesh_register_geometry (cmesh, linear_geom);
-  t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_QUAD);
-  t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 4);
-  return cmesh;
-}
-
-static t8_cmesh_t
-t8_cmesh_new_hex (sc_MPI_Comm comm)
-{
-  t8_cmesh_t cmesh;
-  /* clang-format off */
-  double vertices[24] = { 
+  const double vertices_coords[24] = { 
     0, 0, 0, 
     1, 0, 0, 
     0, 1, 0, 
     1, 1, 0, 
     0, 0, 1, 
     1, 0, 1, 
-    0, 1, 1, 
+    0, 1, 1,
     1, 1, 1 
   };
   /* clang-format on */
-  t8_geometry_c *linear_geom = t8_geometry_linear_new (3);
 
-  t8_cmesh_init (&cmesh);
-  /* Use linear geometry */
-  t8_cmesh_register_geometry (cmesh, linear_geom);
-  t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_HEX);
-  t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 8);
-  return cmesh;
+  switch (eclass) {
+  case T8_ECLASS_VERTEX:
+    /* v_0*/
+    memcpy (vertices, vertices_coords, 3 * sizeof (double));
+    break;
+  case T8_ECLASS_LINE:
+    /* v_0, v_1*/
+    memcpy (vertices, vertices_coords, 6 * sizeof (double));
+    break;
+  case T8_ECLASS_TRIANGLE:
+    /* v_0 - v_1*/
+    memcpy (vertices, vertices_coords, 6 * sizeof (double));
+    /* v_2*/
+    memcpy (vertices + 6, vertices_coords + 9, 3 * sizeof (double));
+    break;
+  case T8_ECLASS_QUAD:
+    /* v_0 - v_3*/
+    memcpy (vertices, vertices_coords, 12 * sizeof (double));
+    break;
+  case T8_ECLASS_TET:
+    /* v_0*/
+    memcpy (vertices, vertices_coords + 21, 3 * sizeof (double));
+    /* v_1 - v_2*/
+    memcpy (vertices + 3, vertices_coords + 3, 6 * sizeof (double));
+    /* v_3*/
+    memcpy (vertices + 9, vertices_coords + 12, 3 * sizeof (double));
+    break;
+  case T8_ECLASS_HEX:
+    /* v_0 - v_8*/
+    memcpy (vertices, vertices_coords, 24 * sizeof (double));
+    break;
+  case T8_ECLASS_PYRAMID:
+    /* v_0 - v_3*/
+    memcpy (vertices, vertices_coords, 12 * sizeof (double));
+    /* v_4*/
+    memcpy (vertices + 12, vertices_coords + 21, 3 * sizeof (double));
+    break;
+  case T8_ECLASS_PRISM:
+    /* v_0 - v_2*/
+    memcpy (vertices, vertices_coords, 9 * sizeof (double));
+    /* v_3 - v_5*/
+    memcpy (vertices + 9, vertices_coords + 12, 9 * sizeof (double));
+    break;
+  default:
+    SC_ABORT ("Invalid eclass\n");
+    return;
+  }
 }
 
 t8_cmesh_t
@@ -300,88 +245,24 @@ t8_cmesh_new_pyramid_deformed (sc_MPI_Comm comm)
   return cmesh;
 }
 
-static t8_cmesh_t
-t8_cmesh_new_pyramid (sc_MPI_Comm comm)
-{
-  t8_cmesh_t cmesh;
-  /* clang-format off */
-  double vertices[15] = { 
-    -1, -1, 0, 
-    1, -1, 0, 
-    -1, 1, 0, 
-    1, 1, 0, 
-    0, 0, sqrt (2) 
-  };
-  /* clang-format on */
-  t8_geometry_c *linear_geom = t8_geometry_linear_new (3);
-
-  t8_cmesh_init (&cmesh);
-  /* Use linear geometry */
-  t8_cmesh_register_geometry (cmesh, linear_geom);
-  t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_PYRAMID);
-  t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 15);
-  return cmesh;
-}
-
-static t8_cmesh_t
-t8_cmesh_new_prism (sc_MPI_Comm comm)
-{
-  t8_cmesh_t cmesh;
-  /* clang-format off */
-  double vertices[18] = { 
-    0, 0, 0, 
-    1, 0, 0, 
-    1, 1, 0, 
-    0, 0, 1, 
-    1, 0, 1, 
-    1, 1, 1 
-  };
-  /* clang-format on */
-
-  t8_geometry_c *linear_geom = t8_geometry_linear_new (3);
-
-  t8_cmesh_init (&cmesh);
-  /* Use linear geometry */
-  t8_cmesh_register_geometry (cmesh, linear_geom);
-  t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_PRISM);
-  t8_cmesh_set_tree_vertices (cmesh, 0, vertices, 6);
-  return cmesh;
-}
-
 t8_cmesh_t
-t8_cmesh_new_from_class (t8_eclass_t eclass, sc_MPI_Comm comm)
+t8_cmesh_new_from_class (const t8_eclass_t eclass, sc_MPI_Comm comm)
 {
   t8_cmesh_t cmesh;
-  switch (eclass) {
-  case T8_ECLASS_VERTEX:
-    cmesh = t8_cmesh_new_vertex (comm);
-    break;
-  case T8_ECLASS_LINE:
-    cmesh = t8_cmesh_new_line (comm);
-    break;
-  case T8_ECLASS_TRIANGLE:
-    cmesh = t8_cmesh_new_tri (comm);
-    break;
-  case T8_ECLASS_QUAD:
-    cmesh = t8_cmesh_new_quad (comm);
-    break;
-  case T8_ECLASS_TET:
-    cmesh = t8_cmesh_new_tet (comm);
-    break;
-  case T8_ECLASS_HEX:
-    cmesh = t8_cmesh_new_hex (comm);
-    break;
-  case T8_ECLASS_PYRAMID:
-    cmesh = t8_cmesh_new_pyramid (comm);
-    break;
-  case T8_ECLASS_PRISM:
-    cmesh = t8_cmesh_new_prism (comm);
-    break;
-  default:
-    SC_ABORT ("Invalid eclass\n");
-    return NULL;
-  }
+  const int num_vertices = t8_eclass_num_vertices[eclass];
+  /* Get the vertices of the tree*/
+  double *vertices = T8_ALLOC (double, num_vertices * 3);
+  vertices_single_tree (eclass, vertices);
+  /* Dimension of the class */
+  const int dim = t8_eclass_to_dimension[eclass];
+  t8_geometry_c *linear_geom = t8_geometry_linear_new (dim);
+  /* Construct cmesh */
+  t8_cmesh_init (&cmesh);
+  t8_cmesh_register_geometry (cmesh, linear_geom);
+  t8_cmesh_set_tree_class (cmesh, 0, eclass);
+  t8_cmesh_set_tree_vertices (cmesh, 0, vertices, num_vertices);
   t8_cmesh_commit (cmesh, comm);
+  T8_FREE (vertices);
   return cmesh;
 }
 
@@ -2730,6 +2611,329 @@ t8_cmesh_new_squared_disk (const double radius, sc_MPI_Comm comm)
   t8_cmesh_set_join_by_vertices (cmesh, ntrees, all_eclasses, all_verts, NULL, 0);
 
   /* Commit the mesh */
+  t8_cmesh_commit (cmesh, comm);
+  return cmesh;
+}
+
+static void
+t8_line_shift_vertices_along_face (double *vertices, const int face)
+{
+  const int v_0 = face;
+  const int v_1 = 1 - face;
+  double vec[3];
+  t8_vec_axpyz (vertices + 3 * v_0, vertices + 3 * v_1, vec, -1.0);
+  t8_vec_axpy (vec, vertices, 1.0);
+  t8_vec_axpy (vec, vertices + 3, 1.0);
+}
+
+static void
+t8_tri_shift_vertices_along_face (double *vertices, const int face)
+{
+  const int v_0 = t8_face_vertex_to_tree_vertex[T8_ECLASS_TET][face][0];
+  const int v_1 = t8_face_vertex_to_tree_vertex[T8_ECLASS_TET][face][1];
+  const int v_2 = face;
+  double ortho[3];
+  t8_vec_orthogonal_through_point (vertices + 3 * v_0, vertices + 3 * v_1, vertices + 3 * v_2, ortho);
+  double tmp[3];
+  memcpy (tmp, vertices + 3 * v_2, 3 * sizeof (double));
+  memcpy (vertices + 3 * v_2, vertices + 3 * v_1, 3 * sizeof (double));
+  memcpy (vertices + 3 * v_1, vertices + 3 * v_0, 3 * sizeof (double));
+
+  t8_vec_axpyz (ortho, tmp, vertices + 3 * v_0, 2.0);
+}
+
+static void
+t8_quad_shift_vertices_along_face (double *vertices, const int face)
+{
+  /* v_0 and v_1 define mirror face*/
+  const int v_0 = t8_face_vertex_to_tree_vertex[T8_ECLASS_QUAD][face][0];
+  const int v_1 = t8_face_vertex_to_tree_vertex[T8_ECLASS_QUAD][face][1];
+  /* v_2 and v_3 will be set to the other vertices. */
+  int v_2 = -1;
+  int v_3 = -1;
+  /* Compute the vertex number of the two vertices not on the face. */
+  for (int check_vertex = 0; check_vertex < 4; check_vertex++) {
+    if (check_vertex != v_0 && check_vertex != v_1) {
+      if (v_2 == -1) {
+        v_2 = check_vertex;
+      }
+      else {
+        v_3 = check_vertex;
+      }
+    }
+  }
+  /* Check that v_2 and v_3 have been set*/
+  T8_ASSERT (v_2 != -1);
+  T8_ASSERT (v_3 != -1);
+#if T8_ENABLE_DEBUG
+  /* Check that every vertex is used exactly once. */
+  int every_vertex_set[4] = { 0 };
+  every_vertex_set[v_0] += 1;
+  every_vertex_set[v_1] += 1;
+  every_vertex_set[v_2] += 1;
+  every_vertex_set[v_3] += 1;
+  for (int i = 0; i < 4; i++) {
+    T8_ASSERT (every_vertex_set[i] == 1);
+  }
+#endif
+  /* Compute the orthogonals from v_2 and v_3 to the face. */
+  double ortho_0[3];
+  t8_vec_orthogonal_through_point (vertices + 3 * v_0, vertices + 3 * v_1, vertices + 3 * v_2, ortho_0);
+
+  double ortho_1[3];
+  t8_vec_orthogonal_through_point (vertices + 3 * v_0, vertices + 3 * v_1, vertices + 3 * v_3, ortho_1);
+
+  /* Shift along ortho 0 */
+  t8_vec_axpy (ortho_0, vertices + 3 * v_0, 1.0);
+  t8_vec_axpy (ortho_0, vertices + 3 * v_2, 1.0);
+  /* Shift along ortho 1 */
+  t8_vec_axpy (ortho_1, vertices + 3 * v_1, 1.0);
+  t8_vec_axpy (ortho_1, vertices + 3 * v_3, 1.0);
+}
+
+static void
+t8_tet_shift_vertices_along_face (double *vertices, const int face)
+{
+  /* v_0, v_1 and v_2 define mirror face*/
+  const int v_0 = t8_face_vertex_to_tree_vertex[T8_ECLASS_TET][face][0];
+  const int v_1 = t8_face_vertex_to_tree_vertex[T8_ECLASS_TET][face][1];
+  const int v_2 = t8_face_vertex_to_tree_vertex[T8_ECLASS_TET][face][2];
+  const int v_3 = face;
+
+  double span_vec_0[3];
+  double span_vec_1[3];
+
+  t8_vec_axpyz (vertices + 3 * v_1, vertices + 3 * v_0, span_vec_0, -1.0);
+  t8_vec_axpyz (vertices + 3 * v_2, vertices + 3 * v_0, span_vec_1, -1.0);
+
+  double normal[3];
+  t8_vec_cross (span_vec_0, span_vec_1, normal);
+  t8_vec_cross (span_vec_0, span_vec_1, normal);
+  const double norm = t8_vec_norm (normal);
+  T8_ASSERT (norm > 1e-14);
+  double tmp[3];
+  t8_vec_axpyz (vertices + 3 * v_3, vertices + 3 * v_0, tmp, -1.0);
+  double n_p = t8_vec_dot (tmp, normal);
+
+  /* we want the normal facing from v_3 to the face */
+  t8_vec_ax (normal, n_p > 0 ? 1. / norm : -1. / norm);
+
+  const double dist = fabs (n_p) / norm;
+  t8_vec_axpyz (vertices + 3 * v_3, normal, tmp, 2 * dist);
+
+  /* TODO: maybe reorder vertices to avoid negative volume */
+  memcpy (vertices + 3 * v_3, tmp, 3 * sizeof (double));
+}
+
+static void
+t8_hex_shift_vertices_along_face (double *vertices, const int face)
+{
+  /* v_0-v_3 define mirror face*/
+  const int v_0 = t8_face_vertex_to_tree_vertex[T8_ECLASS_HEX][face][0];
+  const int v_1 = t8_face_vertex_to_tree_vertex[T8_ECLASS_HEX][face][1];
+  const int v_2 = t8_face_vertex_to_tree_vertex[T8_ECLASS_HEX][face][2];
+  const int v_3 = t8_face_vertex_to_tree_vertex[T8_ECLASS_HEX][face][3];
+  /* v_4-v_7 will be set to the other vertices. */
+  int v_4 = -1;
+  int v_5 = -1;
+  int v_6 = -1;
+  int v_7 = -1;
+
+  /* Compute the vertex number of the two vertices not on the face. */
+  for (int check_vertex = 0; check_vertex < 8; check_vertex++) {
+    if (check_vertex != v_0 && check_vertex != v_1 && check_vertex != v_2 && check_vertex != v_3) {
+      if (v_4 == -1) {
+        v_4 = check_vertex;
+      }
+      else if (v_5 == -1) {
+        v_5 = check_vertex;
+      }
+      else if (v_6 == -1) {
+        v_6 = check_vertex;
+      }
+      else {
+        v_7 = check_vertex;
+      }
+    }
+  }
+  /* Check that v_2 and v_3 have been set*/
+  T8_ASSERT (v_4 != -1);
+  T8_ASSERT (v_5 != -1);
+  T8_ASSERT (v_6 != -1);
+  T8_ASSERT (v_7 != -1);
+
+#if T8_ENABLE_DEBUG
+  /* Check that every vertex is used exactly once. */
+  int every_vertex_set[8] = { 0 };
+  every_vertex_set[v_0] += 1;
+  every_vertex_set[v_1] += 1;
+  every_vertex_set[v_2] += 1;
+  every_vertex_set[v_3] += 1;
+  every_vertex_set[v_4] += 1;
+  every_vertex_set[v_5] += 1;
+  every_vertex_set[v_6] += 1;
+  every_vertex_set[v_7] += 1;
+  for (int i = 0; i < 8; i++) {
+    T8_ASSERT (every_vertex_set[i] == 1);
+  }
+#endif
+  double span_vec_0[3];
+  double span_vec_1[3];
+
+  t8_vec_axpyz (vertices + 3 * v_1, vertices + 3 * v_0, span_vec_0, -1.0);
+  t8_vec_axpyz (vertices + 3 * v_2, vertices + 3 * v_0, span_vec_1, -1.0);
+  /*We approximate the normal be the normal of the tri v_0 v_1 v_2*/
+
+  double normal[3];
+  t8_vec_cross (span_vec_0, span_vec_1, normal);
+  t8_vec_cross (span_vec_0, span_vec_1, normal);
+  const double norm = t8_vec_norm (normal);
+  T8_ASSERT (norm > 1e-14);
+  double tmp[3];
+  t8_vec_axpyz (vertices + 3 * v_4, vertices + 3 * v_0, tmp, -1.0);
+  double n_p = t8_vec_dot (tmp, normal);
+
+  /* we want the normal facing from v_4 to the face */
+  t8_vec_ax (normal, n_p > 0 ? 1. / norm : -1. / norm);
+  const double dist_0 = fabs (n_p) / norm;
+
+  t8_vec_axpyz (vertices + 3 * v_5, vertices + 3 * v_0, tmp, -1.0);
+  n_p = t8_vec_dot (tmp, normal);
+  const double dist_1 = fabs (n_p) / norm;
+  t8_vec_axpyz (vertices + 3 * v_6, vertices + 3 * v_0, tmp, -1.0);
+  n_p = t8_vec_dot (tmp, normal);
+  const double dist_2 = fabs (n_p) / norm;
+  t8_vec_axpyz (vertices + 3 * v_7, vertices + 3 * v_0, tmp, -1.0);
+  n_p = t8_vec_dot (tmp, normal);
+  const double dist_3 = fabs (n_p) / norm;
+
+  memcpy (vertices + 3 * v_4, vertices + 3 * v_0, 3 * sizeof (double));
+  t8_vec_axpy (normal, vertices + 3 * v_0, dist_0);
+
+  memcpy (vertices + 3 * v_5, vertices + 3 * v_1, 3 * sizeof (double));
+  t8_vec_axpy (normal, vertices + 3 * v_1, dist_1);
+
+  memcpy (vertices + 3 * v_6, vertices + 3 * v_2, 3 * sizeof (double));
+  t8_vec_axpy (normal, vertices + 3 * v_2, dist_2);
+
+  memcpy (vertices + 3 * v_7, vertices + 3 * v_3, 3 * sizeof (double));
+  t8_vec_axpy (normal, vertices + 3 * v_3, dist_3);
+}
+
+static void
+t8_pyra_shift_vertices_along_face (double *vertices, const int face)
+{
+  /* v_0-v_3 define mirror face*/
+  const int v_0 = t8_face_vertex_to_tree_vertex[T8_ECLASS_PYRAMID][face][0];
+  const int v_1 = t8_face_vertex_to_tree_vertex[T8_ECLASS_PYRAMID][face][1];
+  const int v_2 = t8_face_vertex_to_tree_vertex[T8_ECLASS_PYRAMID][face][2];
+  int v_3 = -1;
+  int v_4 = -1;
+  if (face != 4) {
+    v_3 = t8_face_vertex_to_tree_vertex[T8_ECLASS_PYRAMID][face + 1][0];
+    v_4 = t8_face_vertex_to_tree_vertex[T8_ECLASS_PYRAMID][face + 1][1];
+  }
+
+  if (face == 4) {
+    v_3 = t8_face_vertex_to_tree_vertex[T8_ECLASS_QUAD][face][3];
+    v_4 = 5;
+  }
+  double span_vec_0[3];
+  double span_vec_1[3];
+
+  t8_vec_axpyz (vertices + 3 * v_1, vertices + 3 * v_0, span_vec_0, -1.0);
+  t8_vec_axpyz (vertices + 3 * v_2, vertices + 3 * v_0, span_vec_1, -1.0);
+
+  double normal[3];
+  t8_vec_cross (span_vec_0, span_vec_1, normal);
+  t8_vec_cross (span_vec_0, span_vec_1, normal);
+  const double norm = t8_vec_norm (normal);
+  T8_ASSERT (norm > 1e-14);
+  double tmp[3];
+  if (face != 4) {
+    t8_vec_axpyz (vertices + 3 * v_3, vertices + 3 * v_0, tmp, -1.0);
+  }
+  else {
+    t8_vec_axpyz (vertices + 3 * v_4, vertices + 3 * v_0, tmp, -1.0);
+  }
+
+  double n_p = t8_vec_dot (tmp, normal);
+
+  /* we want the normal facing from v_3 to the face */
+  t8_vec_ax (normal, n_p > 0 ? 1. / norm : -1. / norm);
+  const double dist_0 = fabs (n_p) / norm;
+
+  t8_vec_axpyz (vertices + 3 * v_4, vertices + 3 * v_0, tmp, -1.0);
+  n_p = t8_vec_dot (tmp, normal);
+  const double dist_1 = (face == 4) ? 0 : fabs (n_p) / norm;
+
+  if (face != 4) {
+    memcpy (vertices + 3 * v_3, vertices + 3 * v_0, 3 * sizeof (double));
+    t8_vec_axpy (normal, vertices + 3 * v_0, dist_0);
+
+    memcpy (vertices + 3 * v_4, vertices + 3 * v_1, 3 * sizeof (double));
+    t8_vec_axpy (normal, vertices + 3 * v_1, dist_1);
+  }
+  else {
+    /*Todo: shuffle v_0 - v_3 to avoid negative volume */
+    t8_vec_axpy (normal, vertices + 3 * v_4, 2 + dist_1);
+  }
+}
+
+static void
+t8_cmesh_mirror_tree_along_face (double *vertices, const t8_eclass_t eclass, const int face)
+{
+  switch (eclass) {
+  case T8_ECLASS_VERTEX:
+    return;
+  case T8_ECLASS_LINE:
+    t8_line_shift_vertices_along_face (vertices, face);
+    return;
+  case T8_ECLASS_TRIANGLE:
+    t8_tri_shift_vertices_along_face (vertices, face);
+    return;
+  case T8_ECLASS_QUAD:
+    t8_quad_shift_vertices_along_face (vertices, face);
+    return;
+  case T8_ECLASS_TET:
+    t8_tet_shift_vertices_along_face (vertices, face);
+    return;
+  case T8_ECLASS_HEX:
+    t8_hex_shift_vertices_along_face (vertices, face);
+    return;
+  case T8_ECLASS_PYRAMID:
+    t8_pyra_shift_vertices_along_face (vertices, face);
+    return;
+  case T8_ECLASS_PRISM:
+
+  default:
+    SC_ABORT ("Not yet implemented.");
+    return;
+  }
+}
+
+t8_cmesh_t
+t8_cmesh_new_two_trees_face_orientation (const t8_eclass_t eclass, const int face_num, const int orientation,
+                                         sc_MPI_Comm comm)
+{
+  t8_cmesh_t cmesh;
+  const int num_vertices = t8_eclass_num_vertices[eclass];
+  /* Get the vertices of the tree*/
+  double *vertices = T8_ALLOC (double, num_vertices * 3);
+  vertices_single_tree (eclass, vertices);
+  /* Dimension of the class */
+  const int dim = t8_eclass_to_dimension[eclass];
+  t8_geometry_c *linear_geom = t8_geometry_linear_new (dim);
+  /* Construct cmesh */
+  t8_cmesh_init (&cmesh);
+  t8_cmesh_register_geometry (cmesh, linear_geom);
+  /* Two trees of the same class */
+  t8_cmesh_set_tree_class (cmesh, 0, eclass);
+  t8_cmesh_set_tree_class (cmesh, 1, eclass);
+  t8_cmesh_set_tree_vertices (cmesh, 0, vertices, num_vertices);
+  /* Shift vertices along a face given by the normal of the face*/
+  t8_cmesh_mirror_tree_along_face (vertices, eclass, face_num);
+  t8_cmesh_set_tree_vertices (cmesh, 1, vertices, num_vertices);
   t8_cmesh_commit (cmesh, comm);
   return cmesh;
 }

--- a/src/t8_cmesh/t8_cmesh_examples.h
+++ b/src/t8_cmesh/t8_cmesh_examples.h
@@ -322,6 +322,9 @@ t8_cmesh_new_row_of_cubes (t8_locidx_t num_trees, const int set_attributes, cons
 t8_cmesh_t
 t8_cmesh_new_squared_disk (const double radius, sc_MPI_Comm comm);
 
+t8_cmesh_t
+t8_cmesh_new_two_trees_face_orientation (const t8_eclass_t eclass, const int face_num, const int orientation,
+                                         sc_MPI_Comm comm);
 T8_EXTERN_C_END ();
 
 #endif /* !T8_CMESH_EXAMPLES */

--- a/src/t8_vec.h
+++ b/src/t8_vec.h
@@ -188,26 +188,19 @@ t8_vec_orthogonal_through_point (const double v_0[3], const double v_1[3], const
   double line[3];
   /* Compute the direction of the line */
   t8_vec_axpyz (v_0, v_1, line, -1.0);
-  int i;
-  /* Find a non-zero axis*/
-  for (i = 0; i < 3; i++) {
-    if (line[i] != 0) {
-      break;
-    }
-  }
-  /* Solve the equation (v_0 + lambda * dir - p)\dot dir = 0 */
-  const double lambda = (p[i] * line[i] - v_0[i] * line[i]) / (line[i] * line[i]);
 
-#if T8_ENABLE_DEBUG
+  /* Solve the equation (v_0 + lambda * dir - p)\dot dir = 0 */
+  double numerator = 0.0;
+  double denominator = t8_vec_dot (line, line);
   for (int i = 0; i < 3; i++) {
-    if (line[i] != 0 && p[i] != v_0[i]) {
-      const double lambda_debug = (p[i] * line[i] - v_0[i] * line[i]) / (line[i] * line[i]);
-      T8_ASSERT (fabs (lambda - lambda_debug) < T8_PRECISION_EPS);
-    }
+    numerator += p[i] * line[i] - v_0[i] * line[i];
   }
-#endif
-  t8_vec_axpyz (line, v_0, orthogonal, lambda);
-  t8_vec_axpy (p, orthogonal, -1.0);
+
+  const double lambda = numerator / denominator;
+
+  double tmp[3];
+  t8_vec_axpyz (line, v_0, tmp, lambda);
+  t8_vec_axpyz (tmp, p, orthogonal, -1.0);
 }
 
 T8_EXTERN_C_END ();

--- a/src/t8_vec.h
+++ b/src/t8_vec.h
@@ -200,9 +200,9 @@ t8_vec_orthogonal_through_point (const double v_0[3], const double v_1[3], const
 
 #if T8_ENABLE_DEBUG
   for (int i = 0; i < 3; i++) {
-    if (line[i] != 0) {
+    if (line[i] != 0 && p[i] != v_0[i]) {
       const double lambda_debug = (p[i] * line[i] - v_0[i] * line[i]) / (line[i] * line[i]);
-      T8_ASSERT (lambda == lambda_debug);
+      T8_ASSERT (fabs (lambda - lambda_debug) < T8_PRECISION_EPS);
     }
   }
 #endif

--- a/src/t8_vec.h
+++ b/src/t8_vec.h
@@ -173,6 +173,43 @@ t8_vec_diff (const double vec_x[3], const double vec_y[3], double diff[3])
   }
 }
 
+/**
+ * Compute the orthogonal to a vector running through a point. 
+ * A line is given by l(t) = a + \lambda *dir, with dir as the vector from \a v_0 to \a v_1
+ * The orthogonal faces from the point to the line. 
+ * \param[in] v_0 refers to "a" in the line definition and is the starting point of the line
+ * \param[in] v_1 second point to define the line
+ * \param[in] p   point to check
+ * \param[in, out] orthogonal On input a 3D vec on output the orthogonal pointing from \a p to the vec. 
+ */
+static inline void
+t8_vec_orthogonal_through_point (const double v_0[3], const double v_1[3], const double p[3], double orthogonal[3])
+{
+  double line[3];
+  /* Compute the direction of the line */
+  t8_vec_axpyz (v_0, v_1, line, -1.0);
+  int i;
+  /* Find a non-zero axis*/
+  for (i = 0; i < 3; i++) {
+    if (line[i] != 0) {
+      break;
+    }
+  }
+  /* Solve the equation (v_0 + lambda * dir - p)\dot dir = 0 */
+  const double lambda = (p[i] * line[i] - v_0[i] * line[i]) / (line[i] * line[i]);
+
+#if T8_ENABLE_DEBUG
+  for (int i = 0; i < 3; i++) {
+    if (line[i] != 0) {
+      const double lambda_debug = (p[i] * line[i] - v_0[i] * line[i]) / (line[i] * line[i]);
+      T8_ASSERT (lambda == lambda_debug);
+    }
+  }
+#endif
+  t8_vec_axpyz (line, v_0, orthogonal, lambda);
+  t8_vec_axpy (p, orthogonal, -1.0);
+}
+
 T8_EXTERN_C_END ();
 
 #endif /* !T8_VEC_H! */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -47,7 +47,8 @@ t8code_googletest_programs = \
   test/t8_forest_incomplete/t8_gtest_recursive \
   test/t8_forest_incomplete/t8_gtest_iterate_replace \
   test/t8_forest_incomplete/t8_gtest_empty_local_tree \
-  test/t8_forest_incomplete/t8_gtest_empty_global_tree
+  test/t8_forest_incomplete/t8_gtest_empty_global_tree \
+  test/t8_forest/t8_gtest_tree_face_neigh
 
 test_t8_IO_t8_gtest_vtk_reader_SOURCES = \
   test/t8_gtest_main.cxx \
@@ -228,6 +229,10 @@ test_t8_forest_incomplete_t8_gtest_empty_local_tree_SOURCES = \
 test_t8_forest_incomplete_t8_gtest_empty_global_tree_SOURCES = \
   test/t8_gtest_main.cxx \
   test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
+
+test_t8_forest_t8_gtest_tree_face_neigh_SOURCES = \
+  test/t8_gtest_main.cxx \
+  test/t8_forest/t8_gtest_tree_face_neigh.cxx
 
 #define ld and cpp flags for all targets
 t8_gtest_target_ld_add = $(LDADD) test/libgtest.la
@@ -418,6 +423,10 @@ test_t8_forest_incomplete_t8_gtest_empty_global_tree_LDADD = $(t8_gtest_target_l
 test_t8_forest_incomplete_t8_gtest_empty_global_tree_LDFLAGS = $(t8_gtest_target_ld_flags)
 test_t8_forest_incomplete_t8_gtest_empty_global_tree_CPPFLAGS = $(t8_gtest_target_cpp_flags)
 
+test_t8_forest_t8_gtest_tree_face_neigh_LDADD = $(t8_gtest_target_ld_add)
+test_t8_forest_t8_gtest_tree_face_neigh_LDFLAGS = $(t8_gtest_target_ld_flags)
+test_t8_forest_t8_gtest_tree_face_neigh_CPPFLAGS = $(t8_gtest_target_cpp_flags)
+
 # If we did not configure t8code with MPI we need to build Googletest
 # without MPI support.
 if !T8_ENABLE_MPI
@@ -466,6 +475,8 @@ test_t8_forest_incomplete_t8_gtest_recursive_CPPFLAGS += $(t8_gtest_target_mpi_c
 test_t8_forest_incomplete_t8_gtest_iterate_replace_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_forest_incomplete_t8_gtest_empty_local_tree_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_forest_incomplete_t8_gtest_empty_global_tree_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
+test_t8_forest_t8_gtest_tree_face_neigh_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
+
 endif
 
 # Build Googletest library

--- a/test/t8_forest/t8_gtest_tree_face_neigh.cxx
+++ b/test/t8_forest/t8_gtest_tree_face_neigh.cxx
@@ -1,0 +1,71 @@
+/*
+This file is part of t8code.
+t8code is a C library to manage a collection (a forest) of multiple
+connected adaptive space-trees of general element classes in parallel.
+
+Copyright (C) 2023 the developers
+
+t8code is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+t8code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with t8code; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/**
+ * This test program tests if the face connectivity between two trees of the same
+ * eclass is correct w.r.t. orientation. We compute the faceneighbor and the coordinates
+ * of the corners of the touching faces. If they match for children of a the face the
+ * test is passed. 
+ */
+
+#include <gtest/gtest.h>
+#include <t8_cmesh.h>
+#include <t8_cmesh_vtk_writer.h>
+#include <t8_eclass.h>
+#include <t8_schemes/t8_default/t8_default_cxx.hxx>
+#include <t8_cmesh/t8_cmesh_examples.h>
+
+class tree_face_neigh: public testing::TestWithParam<t8_eclass_t> {
+ protected:
+  void
+  SetUp () override
+  {
+    eclass = GetParam ();
+    if (eclass == T8_ECLASS_PRISM) {
+      GTEST_SKIP ();
+    }
+    scheme = t8_scheme_new_default_cxx ();
+  }
+  void
+  TearDown () override
+  {
+    if (eclass != T8_ECLASS_PRISM) {
+      t8_scheme_cxx_unref (&scheme);
+    }
+  }
+  t8_eclass_t eclass;
+  t8_scheme_cxx_t *scheme;
+};
+
+TEST_P (tree_face_neigh, t8_forest_neigh_face_test)
+{
+  for (int face = 0; face < t8_eclass_num_faces[eclass]; face++) {
+    char fileprefix[BUFSIZ];
+    t8_cmesh_t cmesh = t8_cmesh_new_two_trees_face_orientation (eclass, face, 0, sc_MPI_COMM_WORLD);
+
+    snprintf (fileprefix, BUFSIZ, "%s_face_%i", t8_eclass_to_string[eclass], face);
+    t8_cmesh_vtk_write_file (cmesh, fileprefix, 1.0);
+    t8_cmesh_destroy (&cmesh);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P (t8_gtest_tree_face_neigh, tree_face_neigh, testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));

--- a/test/t8_forest/t8_gtest_tree_face_neigh.cxx
+++ b/test/t8_forest/t8_gtest_tree_face_neigh.cxx
@@ -58,23 +58,20 @@ class tree_face_neigh: public testing::TestWithParam<t8_eclass_t> {
 
 TEST_P (tree_face_neigh, t8_forest_neigh_face_test)
 {
+  /*Iterate over all faces of the tree */
   for (int face = 0; face < t8_eclass_num_faces[eclass]; face++) {
     const int face_type = t8_eclass_face_types[eclass][face];
     const int num_vertices = t8_eclass_num_vertices[face_type];
+    /* Check all possible orientations */
     for (int orientation = 0; orientation < num_vertices; orientation++) {
       t8_debugf ("[D] ------------------Test: %s face %i orientation %i -----------------\n",
                  t8_eclass_to_string[eclass], face, orientation);
       char fileprefix[BUFSIZ];
       t8_cmesh_t cmesh = t8_cmesh_new_two_trees_face_orientation (eclass, face, orientation, sc_MPI_COMM_WORLD);
-      t8_forest_t forest;
       scheme = t8_scheme_new_default_cxx ();
-      t8_forest_init (&forest);
-      t8_forest_set_level (forest, 0);
-      t8_forest_set_cmesh (forest, cmesh, comm);
-      t8_forest_set_scheme (forest, scheme);
-      t8_forest_commit (forest);
+      t8_forest_t forest = t8_forest_new_uniform (cmesh, scheme, 0, 0, comm);
       t8_element_t *elem = t8_forest_get_element_in_tree (forest, 0, 0);
-
+      /**/
       const int face_class = t8_eclass_face_types[eclass][face];
       t8_eclass_scheme_c *ts = scheme->eclass_schemes[eclass];
       t8_eclass_scheme_c *face_scheme = scheme->eclass_schemes[face_class];
@@ -91,9 +88,12 @@ TEST_P (tree_face_neigh, t8_forest_neigh_face_test)
       const int num_face_vertices = t8_eclass_num_vertices[face_class];
 
       for (int ichild = 0; ichild < num_face_children; ichild++) {
-        t8_debugf ("[D] nfc: %i, ichild %i\n", num_face_children, ichild);
+        /*Get the child at the face. */
         const int child_face = ts->t8_element_face_child_face (elem, face, ichild);
+        /*Construct the face of the child touching the boundary*/
         ts->t8_element_boundary_face (children[ichild], child_face, t0_face, face_scheme);
+
+        /* Transfer the face onto tree 1*/
         t8_locidx_t *face_neighbor;
         int8_t *ttf;
         (void) t8_cmesh_trees_get_tree_ext (cmesh->trees, 0, &face_neighbor, &ttf);
@@ -111,16 +111,19 @@ TEST_P (tree_face_neigh, t8_forest_neigh_face_test)
         const int is_smaller = face <= tree_neigh_face;
         const int sign
           = t8_eclass_face_orientation[eclass][face] == t8_eclass_face_orientation[eclass][tree_neigh_face];
-
+        /* Actual face transfer */
         face_scheme->t8_element_transform_face (t0_face, t1_face, ttf[face] / F, sign, is_smaller);
+        /* Extrude face onto tree 1*/
         const int neigh_face = ts->t8_element_extrude_face (t1_face, face_scheme, face_elem, tree_neigh_face);
         for (int ivertex = 0; ivertex < num_face_vertices; ivertex++) {
+          /* Compute the coordinates of all vertices touching the face of both elements*/
           int t0_face_vertex = t8_face_vertex_to_tree_vertex[eclass][child_face][ivertex];
           int t1_face_vertex = t8_face_vertex_to_tree_vertex[eclass][neigh_face][ivertex];
           double t0_face_vertex_coords[3];
           double t1_face_vertex_coords[3];
           t8_forest_element_coordinate (forest, 0, children[ichild], t0_face_vertex, t0_face_vertex_coords);
           t8_forest_element_coordinate (forest, 1, face_elem, t1_face_vertex, t1_face_vertex_coords);
+          /* If everything is set correct the coordinates should be equal. */
           for (int icoord = 0; icoord < 3; icoord++) {
             EXPECT_NEAR (t0_face_vertex_coords[icoord], t1_face_vertex_coords[icoord], T8_PRECISION_EPS);
           }

--- a/test/t8_forest/t8_gtest_tree_face_neigh.cxx
+++ b/test/t8_forest/t8_gtest_tree_face_neigh.cxx
@@ -29,10 +29,13 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 
 #include <gtest/gtest.h>
 #include <t8_cmesh.h>
+#include <t8_cmesh/t8_cmesh_trees.h>
 #include <t8_cmesh_vtk_writer.h>
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
 #include <t8_cmesh/t8_cmesh_examples.h>
+#include <t8_forest/t8_forest_general.h>
+#include <t8_forest/t8_forest_geometrical.h>
 
 class tree_face_neigh: public testing::TestWithParam<t8_eclass_t> {
  protected:
@@ -54,19 +57,77 @@ class tree_face_neigh: public testing::TestWithParam<t8_eclass_t> {
   }
   t8_eclass_t eclass;
   t8_scheme_cxx_t *scheme;
+  sc_MPI_Comm comm = sc_MPI_COMM_WORLD;
 };
 
 TEST_P (tree_face_neigh, t8_forest_neigh_face_test)
 {
+  t8_eclass_scheme_c *ts = scheme->eclass_schemes[eclass];
   for (int face = 0; face < t8_eclass_num_faces[eclass]; face++) {
     const int face_type = t8_eclass_face_types[eclass][face];
     const int num_vertices = t8_eclass_num_vertices[face_type];
     for (int orientation = 0; orientation < num_vertices; orientation++) {
       char fileprefix[BUFSIZ];
       t8_cmesh_t cmesh = t8_cmesh_new_two_trees_face_orientation (eclass, face, orientation, sc_MPI_COMM_WORLD);
+      t8_forest_t forest = t8_forest_new_uniform (cmesh, scheme, 0, 0, comm);
+      t8_element_t *elem = t8_forest_get_element_in_tree (forest, 0, 0);
 
-      snprintf (fileprefix, BUFSIZ, "%s_face_%i_%i", t8_eclass_to_string[eclass], face, orientation);
-      t8_cmesh_vtk_write_file (cmesh, fileprefix, 1.0);
+      const int face_class = t8_eclass_face_types[eclass][face];
+      t8_eclass_scheme_c *face_scheme = scheme->eclass_schemes[face_class];
+      t8_element_t *t0_face;
+      t8_element_t *t1_face;
+      const int num_face_children = ts->t8_element_num_face_children (elem, face);
+      face_scheme->t8_element_new (1, &t0_face);
+      face_scheme->t8_element_new (1, &t1_face);
+      t8_element_t **children;
+      t8_element_t *face_elem;
+      ts->t8_element_new (num_face_children, children);
+      ts->t8_element_new (1, &face_elem);
+
+      ts->t8_element_children_at_face (elem, face, children, num_face_children, NULL);
+      const int num_face_vertices = t8_eclass_num_vertices[face_class];
+      for (int ichild = 0; ichild < num_face_children; ichild++) {
+        ts->t8_element_boundary_face (children[ichild], face, t0_face, face_scheme);
+        t8_locidx_t *face_neighbor;
+        int8_t *ttf;
+        (void) t8_cmesh_trees_get_tree_ext (cmesh->trees, 0, &face_neighbor, &ttf);
+        /* Compute the local id of the face neighbor tree. */
+        const t8_locidx_t lcneigh_id = face_neighbor[face];
+        EXPECT_EQ (lcneigh_id, 1);
+        /* F is needed to compute the neighbor face number and the orientation.
+        * tree_neigh_face = ttf % F
+        * or = ttf / F
+        */
+        const int F = t8_eclass_max_num_faces[cmesh->dimension];
+        /* compute the neighbor face */
+        const int tree_neigh_face = ttf[face] % F;
+        /* eclasses of the trees are the same, so it is sufficient to compare the face-numbers */
+        const int is_smaller = face <= tree_neigh_face;
+        const int sign
+          = t8_eclass_face_orientation[eclass][face] == t8_eclass_face_orientation[eclass][tree_neigh_face];
+
+        face_scheme->t8_element_transform_face (t0_face, t1_face, ttf[face] / F, sign, is_smaller);
+        const int neigh_face = ts->t8_element_extrude_face (t1_face, face_scheme, face_elem, tree_neigh_face);
+        for (int ivertex = 0; ivertex < num_face_vertices; ivertex++) {
+          int t0_face_vertex = t8_face_vertex_to_tree_vertex[eclass][face][ivertex];
+          int t1_face_vertex = t8_face_vertex_to_tree_vertex[eclass][neigh_face][ivertex];
+          double t0_face_vertex_coords[3];
+          double t1_face_vertex_coords[3];
+          t8_forest_element_coordinate (forest, 0, children[ichild], t0_face_vertex, t0_face_vertex_coords);
+          t8_forest_element_coordinate (forest, 1, face_elem, t1_face_vertex, t1_face_vertex_coords);
+          for (int icoord = 0; icoord < 3; icoord++) {
+            EXPECT_NEAR (t0_face_vertex_coords[icoord], t1_face_vertex_coords[icoord], T8_PRECISION_EPS);
+          }
+        }
+      }
+      face_scheme->t8_element_destroy (1, &t0_face);
+      face_scheme->t8_element_destroy (1, &t1_face);
+      ts->t8_element_destroy (num_face_children, children);
+      ts->t8_element_destroy (1, &face_elem);
+
+      //snprintf (fileprefix, BUFSIZ, "%s_face_%i_%i", t8_eclass_to_string[eclass], face, orientation);
+      //t8_cmesh_vtk_write_file (cmesh, fileprefix, 1.0);
+      t8_forest_unref (&forest);
       t8_cmesh_destroy (&cmesh);
     }
   }

--- a/test/t8_forest/t8_gtest_tree_face_neigh.cxx
+++ b/test/t8_forest/t8_gtest_tree_face_neigh.cxx
@@ -118,7 +118,8 @@ TEST_P (tree_face_neigh, t8_forest_neigh_face_test)
         for (int ivertex = 0; ivertex < num_face_vertices; ivertex++) {
           /* Compute the coordinates of all vertices touching the face of both elements*/
           int t0_face_vertex = t8_face_vertex_to_tree_vertex[eclass][child_face][ivertex];
-          int t1_face_vertex = t8_face_vertex_to_tree_vertex[eclass][neigh_face][ivertex];
+          int t1_face_vertex
+            = t8_face_vertex_to_tree_vertex[eclass][neigh_face][(ivertex + orientation) % num_face_vertices];
           double t0_face_vertex_coords[3];
           double t1_face_vertex_coords[3];
           t8_forest_element_coordinate (forest, 0, children[ichild], t0_face_vertex, t0_face_vertex_coords);

--- a/test/t8_forest/t8_gtest_tree_face_neigh.cxx
+++ b/test/t8_forest/t8_gtest_tree_face_neigh.cxx
@@ -59,12 +59,16 @@ class tree_face_neigh: public testing::TestWithParam<t8_eclass_t> {
 TEST_P (tree_face_neigh, t8_forest_neigh_face_test)
 {
   for (int face = 0; face < t8_eclass_num_faces[eclass]; face++) {
-    char fileprefix[BUFSIZ];
-    t8_cmesh_t cmesh = t8_cmesh_new_two_trees_face_orientation (eclass, face, 0, sc_MPI_COMM_WORLD);
+    const int face_type = t8_eclass_face_types[eclass][face];
+    const int num_vertices = t8_eclass_num_vertices[face_type];
+    for (int orientation = 0; orientation < num_vertices; orientation++) {
+      char fileprefix[BUFSIZ];
+      t8_cmesh_t cmesh = t8_cmesh_new_two_trees_face_orientation (eclass, face, orientation, sc_MPI_COMM_WORLD);
 
-    snprintf (fileprefix, BUFSIZ, "%s_face_%i", t8_eclass_to_string[eclass], face);
-    t8_cmesh_vtk_write_file (cmesh, fileprefix, 1.0);
-    t8_cmesh_destroy (&cmesh);
+      snprintf (fileprefix, BUFSIZ, "%s_face_%i_%i", t8_eclass_to_string[eclass], face, orientation);
+      t8_cmesh_vtk_write_file (cmesh, fileprefix, 1.0);
+      t8_cmesh_destroy (&cmesh);
+    }
   }
 }
 

--- a/test/t8_gtest_vec.cxx
+++ b/test/t8_gtest_vec.cxx
@@ -253,3 +253,28 @@ TEST (t8_gtest_vec, cross)
     EXPECT_NEAR (cross[i], e1[i], epsilon);
   }
 }
+
+TEST (t8_gtest_vec, orthogonal_through_point)
+{
+  /* clang-format off */
+  const double coords[6][3] = 
+    {
+      {1, 0, 0},
+      {-1, 0, 0},
+      {0, 1, 0},
+      {0, -1, 0},
+      {0, 0, 1},
+      {0, 0, -1},
+    };
+  /* clang-format on */
+  const double v_0[3] = { 0, 0, 0 };
+  for (int i = 0; i < 6; i++) {
+    double point[3];
+    memcpy (point, coords[(i + 2) % 6], 3 * sizeof (double));
+    double ortho[3];
+    t8_vec_orthogonal_through_point (v_0, coords[i], point, ortho);
+    for (int j = 0; j < 3; j++) {
+      EXPECT_NEAR (ortho[j], -point[j], epsilon);
+    }
+  }
+}

--- a/test/t8_gtest_vec.cxx
+++ b/test/t8_gtest_vec.cxx
@@ -274,7 +274,7 @@ TEST (t8_gtest_vec, orthogonal_through_point)
     double ortho[3];
     t8_vec_orthogonal_through_point (v_0, coords[i], point, ortho);
     for (int j = 0; j < 3; j++) {
-      EXPECT_NEAR (ortho[j], -point[j], epsilon);
+      EXPECT_NEAR (ortho[j], point[j], epsilon);
     }
   }
 }


### PR DESCRIPTION
Used to analyse the bug in #778 

Idea: For every class construct a cmesh of two trees. 
Tree B created by shifting Tree A along the normal of a given face. 
Then Tree A and B share a common face. 

The function to construct the cmesh gives the possibility to to connect the trees via every face and for every possible orientation. 

To check the correctness of the face-neighbor along a tree boundary:
1. Construct all children at the tree boundary. 
2. Compute the face 'cf' of each child at the boundary. 
3. Extrude the face on the neighbouring tree. 
4. Check if the face touching the tree boundary has the same coordinates as the face 'cf'

Currently done:
Construction of a cmesh with shifted tree along faces
- [x] Bugs in Tet-version
- [x] pyra-version for face 1
- [x] pyra-version for face 4
- [x] triangle_normal for face 1
- [ ] Prisms not implemented
- [x] No orientation implemented
- [ ] Test itself not implemented

Pleas mark the above boxes as done if implemented.

Hopefully this will find the bug in #778 and a follow-up PR might solve it. 





**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
