### PR TITLE
Added a test for the face-orientation

### DIFF
--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -23,6 +23,9 @@
 
 #include <gtest/gtest.h>
 #include <t8_eclass.h>
+#include <t8_cmesh.h>
+#include <t8_cmesh/t8_cmesh_examples.h>
+#include <t8_vec.h>
 
 class gtest_eclass: public testing::TestWithParam<int> {
  protected:
@@ -74,6 +77,49 @@ TEST_P (gtest_eclass, t8_to_vtk_corner_numbers)
     const int vtk_corner_number = t8_eclass_t8_to_vtk_corner_number[ieclass][ivertex];
     const int t8_corner_number = t8_eclass_vtk_to_t8_corner_number[ieclass][vtk_corner_number];
     EXPECT_EQ (ivertex, t8_corner_number);
+  }
+}
+
+TEST_P (gtest_eclass, eclass_face_orientation)
+{
+  const int num_faces = t8_eclass_num_faces[ieclass];
+  /* For dim <= 2 all faces are 0 oriented. */
+  if (t8_eclass_to_dimension[ieclass] <= 2) {
+    for (int iface = 0; iface < num_faces; iface++) {
+      EXPECT_EQ (0, t8_eclass_face_orientation[ieclass][iface]);
+    }
+  }
+  else {
+    /* Compute the normal of each face and the signed distance between the normal and the centroid
+     * (corrected wrt to vertex 0. If the sign is positive the face is 0 oriented, 
+     * ow it is 1 oriented. */
+    t8_cmesh_t cmesh = t8_cmesh_new_from_class ((t8_eclass_t) ieclass, sc_MPI_COMM_WORLD);
+    const double *vertices = t8_cmesh_get_tree_vertices (cmesh, 0);
+    for (int iface = 0; iface < num_faces; iface++) {
+      /* clang-format off */
+      const int v[3] = {  t8_face_vertex_to_tree_vertex[ieclass][iface][0], 
+                          t8_face_vertex_to_tree_vertex[ieclass][iface][1],
+                          t8_face_vertex_to_tree_vertex[ieclass][iface][2] };
+      /* clang-format on */
+      double vec_0[3];
+      double vec_1[3];
+      t8_vec_axpyz (vertices + 3 * v[1], vertices + 3 * v[0], vec_0, -1.0);
+      t8_vec_axpyz (vertices + 3 * v[2], vertices + 3 * v[0], vec_1, -1.0);
+      double normal[3];
+      t8_vec_cross (vec_0, vec_1, normal);
+      double centroid[3] = { 0.0 };
+      for (int ivertex = 0; ivertex < t8_eclass_num_vertices[ieclass]; ivertex++) {
+        centroid[0] += vertices[3 * ivertex];
+        centroid[1] += vertices[3 * ivertex + 1];
+        centroid[2] += vertices[3 * ivertex + 2];
+      }
+      t8_vec_ax (centroid, 1.0 / t8_eclass_num_vertices[ieclass]);
+      t8_vec_axpy (vertices + 3 * v[0], centroid, -1.0);
+      const double c_n = t8_vec_dot (centroid, normal);
+      const int orientation = c_n > 0 ? 0 : 1;
+      EXPECT_EQ (orientation, t8_eclass_face_orientation[ieclass][iface]);
+    }
+    t8_cmesh_destroy (&cmesh);
   }
 }
 

--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -90,8 +90,8 @@ TEST_P (gtest_eclass, eclass_face_orientation)
     }
   }
   else {
-    /* Compute the normal of each face and the signed distance between the normal and the centroid
-     * (corrected wrt to vertex 0. If the sign is positive the face is 0 oriented, 
+    /* Compute the normal of each face and the signed distance between the normal and the vector
+     * from vertex 0 to the centroid. If the sign is positive the face is 0 oriented, 
      * ow it is 1 oriented. */
     t8_cmesh_t cmesh = t8_cmesh_new_from_class ((t8_eclass_t) ieclass, sc_MPI_COMM_WORLD);
     const double *vertices = t8_cmesh_get_tree_vertices (cmesh, 0);


### PR DESCRIPTION
To prevent bugs like in #778 

Creates a cmesh with a single tree of a class, and computes the normal of each face, based on the vertex order described in the look-up table. Computing the signed distance from the normal to the center (w.r.t to vertex 0) tells if the normal points inwards or outwards.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
