### PR TITLE
More const params

### DIFF
--- a/src/t8.c
+++ b/src/t8.c
@@ -159,7 +159,7 @@ t8_init (int log_threshold)
 }
 
 void *
-t8_sc_array_index_locidx (sc_array_t *array, t8_locidx_t it)
+t8_sc_array_index_locidx (const sc_array_t *array, const t8_locidx_t it)
 {
   T8_ASSERT (it >= 0 && (size_t) it < array->elem_count);
 

--- a/src/t8.h
+++ b/src/t8.h
@@ -264,7 +264,7 @@ t8_init (int log_threshold);
  * \return           A void * pointing to entry \a it in \a array.
  */
 void *
-t8_sc_array_index_locidx (sc_array_t *array, t8_locidx_t it);
+t8_sc_array_index_locidx (const sc_array_t *array, const t8_locidx_t it);
 
 /* call this at the end of a header file to match T8_EXTERN_C_BEGIN (). */
 T8_EXTERN_C_END ();

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -798,7 +798,7 @@ t8_forest_get_num_ghost_trees (t8_forest_t forest)
 }
 
 t8_locidx_t
-t8_forest_get_num_local_trees (t8_forest_t forest)
+t8_forest_get_num_local_trees (const t8_forest_t forest)
 {
   t8_locidx_t num_trees;
 

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -695,7 +695,7 @@ t8_forest_commit (t8_forest_t forest)
 }
 
 t8_locidx_t
-t8_forest_get_local_num_elements (t8_forest_t forest)
+t8_forest_get_local_num_elements (const t8_forest_t forest)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
 
@@ -703,7 +703,7 @@ t8_forest_get_local_num_elements (t8_forest_t forest)
 }
 
 t8_gloidx_t
-t8_forest_get_global_num_elements (t8_forest_t forest)
+t8_forest_get_global_num_elements (const t8_forest_t forest)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
 
@@ -711,7 +711,7 @@ t8_forest_get_global_num_elements (t8_forest_t forest)
 }
 
 t8_locidx_t
-t8_forest_get_num_ghosts (t8_forest_t forest)
+t8_forest_get_num_ghosts (const t8_forest_t forest)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
 
@@ -772,7 +772,7 @@ t8_forest_partition_cmesh (t8_forest_t forest, sc_MPI_Comm comm, int set_profili
 }
 
 sc_MPI_Comm
-t8_forest_get_mpicomm (t8_forest_t forest)
+t8_forest_get_mpicomm (const t8_forest_t forest)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
   return forest->mpicomm;
@@ -787,7 +787,7 @@ t8_forest_get_first_local_tree_id (const t8_forest_t forest)
 }
 
 t8_locidx_t
-t8_forest_get_num_ghost_trees (t8_forest_t forest)
+t8_forest_get_num_ghost_trees (const t8_forest_t forest)
 {
   if (forest->ghosts != NULL) {
     return t8_forest_ghost_num_trees (forest);
@@ -813,7 +813,7 @@ t8_forest_get_num_local_trees (const t8_forest_t forest)
 }
 
 t8_gloidx_t
-t8_forest_get_num_global_trees (t8_forest_t forest)
+t8_forest_get_num_global_trees (const t8_forest_t forest)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
 
@@ -821,7 +821,7 @@ t8_forest_get_num_global_trees (t8_forest_t forest)
 }
 
 t8_gloidx_t
-t8_forest_global_tree_id (t8_forest_t forest, t8_locidx_t ltreeid)
+t8_forest_global_tree_id (const t8_forest_t forest, const t8_locidx_t ltreeid)
 {
   t8_locidx_t num_local_trees;
   T8_ASSERT (t8_forest_is_committed (forest));
@@ -857,7 +857,7 @@ t8_forest_get_tree_vertices (t8_forest_t forest, t8_locidx_t ltreeid)
 }
 
 t8_element_array_t *
-t8_forest_tree_get_leafs (t8_forest_t forest, t8_locidx_t ltree_id)
+t8_forest_tree_get_leafs (const t8_forest_t forest, const t8_locidx_t ltree_id)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
   T8_ASSERT (0 <= ltree_id && ltree_id < t8_forest_get_num_local_trees (forest));
@@ -866,7 +866,7 @@ t8_forest_tree_get_leafs (t8_forest_t forest, t8_locidx_t ltree_id)
 }
 
 t8_cmesh_t
-t8_forest_get_cmesh (t8_forest_t forest)
+t8_forest_get_cmesh (const t8_forest_t forest)
 {
   return forest->cmesh;
 }
@@ -969,7 +969,7 @@ t8_forest_get_element_in_tree (t8_forest_t forest, t8_locidx_t ltreeid, t8_locid
 }
 
 t8_locidx_t
-t8_forest_get_tree_element_offset (t8_forest_t forest, t8_locidx_t ltreeid)
+t8_forest_get_tree_element_offset (const t8_forest_t forest, const t8_locidx_t ltreeid)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
 
@@ -998,7 +998,7 @@ t8_forest_get_tree_num_elements (t8_forest_t forest, t8_locidx_t ltreeid)
 }
 
 t8_eclass_t
-t8_forest_get_tree_class (t8_forest_t forest, t8_locidx_t ltreeid)
+t8_forest_get_tree_class (const t8_forest_t forest, const t8_locidx_t ltreeid)
 {
   t8_locidx_t num_local_trees = t8_forest_get_num_local_trees (forest);
 
@@ -1026,7 +1026,7 @@ t8_forest_get_first_local_element_id (t8_forest_t forest)
 }
 
 t8_scheme_cxx_t *
-t8_forest_get_scheme (t8_forest_t forest)
+t8_forest_get_scheme (const t8_forest_t forest)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
   T8_ASSERT (forest->scheme_cxx != NULL);
@@ -1035,7 +1035,7 @@ t8_forest_get_scheme (t8_forest_t forest)
 }
 
 t8_eclass_scheme_c *
-t8_forest_get_eclass_scheme (t8_forest_t forest, t8_eclass_t eclass)
+t8_forest_get_eclass_scheme (const t8_forest_t forest, const t8_eclass_t eclass)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
   T8_ASSERT (forest->scheme_cxx != NULL);
@@ -1055,14 +1055,14 @@ t8_forest_get_eclass_scheme_before_commit (t8_forest_t forest, t8_eclass_t eclas
 }
 
 t8_eclass_t
-t8_forest_get_eclass (t8_forest_t forest, t8_locidx_t ltreeid)
+t8_forest_get_eclass (const t8_forest_t forest, const t8_locidx_t ltreeid)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
   return t8_forest_get_tree (forest, ltreeid)->eclass;
 }
 
 t8_locidx_t
-t8_forest_get_local_id (t8_forest_t forest, t8_gloidx_t gtreeid)
+t8_forest_get_local_id (const t8_forest_t forest, const t8_gloidx_t gtreeid)
 {
   t8_gloidx_t ltreeid;
   T8_ASSERT (t8_forest_is_committed (forest));

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -80,7 +80,7 @@ t8_forest_is_initialized (t8_forest_t forest)
 }
 
 int
-t8_forest_is_committed (t8_forest_t forest)
+t8_forest_is_committed (const t8_forest_t forest)
 {
   if (!(forest != NULL && t8_refcount_is_active (&forest->rc) && forest->committed)) {
     return 0;
@@ -306,7 +306,7 @@ t8_forest_set_user_data (t8_forest_t forest, void *data)
 }
 
 void *
-t8_forest_get_user_data (t8_forest_t forest)
+t8_forest_get_user_data (const t8_forest_t forest)
 {
   return forest->user_data;
 }
@@ -779,7 +779,7 @@ t8_forest_get_mpicomm (t8_forest_t forest)
 }
 
 t8_gloidx_t
-t8_forest_get_first_local_tree_id (t8_forest_t forest)
+t8_forest_get_first_local_tree_id (const t8_forest_t forest)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
 

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -843,7 +843,7 @@ t8_forest_global_tree_id (t8_forest_t forest, t8_locidx_t ltreeid)
  * forest is only partially committed. Thus, we cannot check whether the
  * forest is committed here. */
 t8_tree_t
-t8_forest_get_tree (t8_forest_t forest, t8_locidx_t ltree_id)
+t8_forest_get_tree (const t8_forest_t forest, const t8_locidx_t ltree_id)
 {
   T8_ASSERT (forest->trees != NULL);
   T8_ASSERT (0 <= ltree_id && ltree_id < t8_forest_get_num_local_trees (forest));

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -197,7 +197,7 @@ t8_forest_compute_maxlevel (t8_forest_t forest)
 
 /* Return the maximum level of a forest */
 int
-t8_forest_get_maxlevel (t8_forest_t forest)
+t8_forest_get_maxlevel (const t8_forest_t forest)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
   T8_ASSERT (forest->maxlevel >= 0);

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -407,7 +407,7 @@ t8_forest_get_maxlevel (const t8_forest_t forest);
  * \a forest must be committed before calling this function.
  */
 t8_locidx_t
-t8_forest_get_local_num_elements (t8_forest_t forest);
+t8_forest_get_local_num_elements (const t8_forest_t forest);
 
 /** Return the number of global elements in the forest.
  * \param [in]  forest    A forest.
@@ -415,7 +415,7 @@ t8_forest_get_local_num_elements (t8_forest_t forest);
  * \a forest must be committed before calling this function.
  */
 t8_gloidx_t
-t8_forest_get_global_num_elements (t8_forest_t forest);
+t8_forest_get_global_num_elements (const t8_forest_t forest);
 
 /** Return the number of ghost elements of a forest.
  * \param [in]      forest      The forest.
@@ -425,7 +425,7 @@ t8_forest_get_global_num_elements (t8_forest_t forest);
  * \a forest must be committed before calling this function.
  */
 t8_locidx_t
-t8_forest_get_num_ghosts (t8_forest_t forest);
+t8_forest_get_num_ghosts (const t8_forest_t forest);
 
 /** Return the element class of a forest local tree.
  * \param [in] forest    The forest.
@@ -434,7 +434,7 @@ t8_forest_get_num_ghosts (t8_forest_t forest);
  * \a forest must be committed before calling this function.
  */
 t8_eclass_t
-t8_forest_get_eclass (t8_forest_t forest, t8_locidx_t ltreeid);
+t8_forest_get_eclass (const t8_forest_t forest, const t8_locidx_t ltreeid);
 
 /** Given a global tree id compute the forest local id of this tree.
  * If the tree is a local tree, then the local id is between 0 and the number
@@ -446,7 +446,7 @@ t8_forest_get_eclass (t8_forest_t forest, t8_locidx_t ltreeid);
  * \see https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
  */
 t8_locidx_t
-t8_forest_get_local_id (t8_forest_t forest, t8_gloidx_t gtreeid);
+t8_forest_get_local_id (const t8_forest_t forest, const t8_gloidx_t gtreeid);
 
 /** Given the local id of a tree in a forest, compute the tree's local id in the associated cmesh.
  * \param [in] forest    The forest.
@@ -544,7 +544,7 @@ t8_forest_partition_cmesh (t8_forest_t forest, sc_MPI_Comm comm, int set_profili
  * \a forest must be committed before calling this function.
  */
 sc_MPI_Comm
-t8_forest_get_mpicomm (t8_forest_t forest);
+t8_forest_get_mpicomm (const t8_forest_t forest);
 
 /** Return the global id of the first local tree of a forest.
  * \param [in]      forest      The forest.
@@ -572,7 +572,7 @@ t8_forest_get_num_ghost_trees (const t8_forest_t forest);
  * \return          The number of global trees of that forest.
  */
 t8_gloidx_t
-t8_forest_get_num_global_trees (t8_forest_t forest);
+t8_forest_get_num_global_trees (const t8_forest_t forest);
 
 /** Return the global id of a local tree or a ghost tree.
  * \param [in]      forest      The forest.
@@ -583,7 +583,7 @@ t8_forest_get_num_global_trees (t8_forest_t forest);
  * \see https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
  */
 t8_gloidx_t
-t8_forest_global_tree_id (t8_forest_t forest, t8_locidx_t ltreeid);
+t8_forest_global_tree_id (const t8_forest_t forest, const t8_locidx_t ltreeid);
 
 /** Return a pointer to a tree in a forest.
  * \param [in]      forest      The forest.
@@ -610,7 +610,7 @@ t8_forest_get_tree_vertices (t8_forest_t forest, t8_locidx_t ltreeid);
  *                              of this tree.
  */
 t8_element_array_t *
-t8_forest_tree_get_leafs (t8_forest_t forest, t8_locidx_t ltree_id);
+t8_forest_tree_get_leafs (const t8_forest_t forest, const t8_locidx_t ltree_id);
 
 /** Return a cmesh associated to a forest.
  * \param [in]      forest      The forest.
@@ -659,7 +659,7 @@ t8_forest_get_tree_num_elements (t8_forest_t forest, t8_locidx_t ltreeid);
  * \note \a forest must be committed before calling this function.
  */
 t8_locidx_t
-t8_forest_get_tree_element_offset (t8_forest_t forest, t8_locidx_t ltreeid);
+t8_forest_get_tree_element_offset (const t8_forest_t forest, const t8_locidx_t ltreeid);
 
 /** Return the number of elements of a tree.
  * \param [in]      tree       A tree in a forest.
@@ -674,7 +674,7 @@ t8_forest_get_tree_element_count (t8_tree_t tree);
  * \return                    The element class of the tree with local id \a ltreeid.
  */
 t8_eclass_t
-t8_forest_get_tree_class (t8_forest_t forest, t8_locidx_t ltreeid);
+t8_forest_get_tree_class (const t8_forest_t forest, const t8_locidx_t ltreeid);
 
 /** Compute the global index of the first local element of a forest.
  * This function is collective.
@@ -692,7 +692,7 @@ t8_forest_get_first_local_element_id (t8_forest_t forest);
  * \see t8_forest_set_scheme
  */
 t8_scheme_cxx_t *
-t8_forest_get_scheme (t8_forest_t forest);
+t8_forest_get_scheme (const t8_forest_t forest);
 
 /** Return the eclass scheme of a given element class associated to a forest.
  * \param [in]      forest.     A committed forest.

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -558,7 +558,7 @@ t8_forest_get_first_local_tree_id (t8_forest_t forest);
  * \return          The number of local trees of that forest.
  */
 t8_locidx_t
-t8_forest_get_num_local_trees (t8_forest_t forest);
+t8_forest_get_num_local_trees (const t8_forest_t forest);
 
 /** Return the number of ghost trees of a given forest.
  * \param [in]      forest      The forest.

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -592,7 +592,7 @@ t8_forest_global_tree_id (t8_forest_t forest, t8_locidx_t ltreeid);
  * \a forest must be committed before calling this function.
  */
 t8_tree_t
-t8_forest_get_tree (t8_forest_t forest, t8_locidx_t ltree_id);
+t8_forest_get_tree (const t8_forest_t forest, const t8_locidx_t ltree_id);
 
 /** Return a pointer to the vertex coordinates of a tree.
  * \param [in]    forest        The forest.

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -272,7 +272,7 @@ t8_forest_set_user_data (t8_forest_t forest, void *data);
  * \see t8_forest_set_user_data
  */
 void *
-t8_forest_get_user_data (t8_forest_t forest);
+t8_forest_get_user_data (const t8_forest_t forest);
 
 /** Set the user function pointer of a forest. This can i.e. be used to pass user defined
  * functions to the adapt routine.
@@ -285,7 +285,7 @@ t8_forest_get_user_data (t8_forest_t forest);
  * \see t8_forest_get_user_function
  */
 void
-t8_forest_set_user_function (t8_forest_t forest, t8_generic_function_pointer functrion);
+t8_forest_set_user_function (t8_forest_t forest, t8_generic_function_pointer function);
 
 /** Return the user function pointer associated with a forest.
  * \param [in]     forest   The forest.
@@ -294,7 +294,7 @@ t8_forest_set_user_function (t8_forest_t forest, t8_generic_function_pointer fun
  * \see t8_forest_set_user_function
  */
 t8_generic_function_pointer
-t8_forest_get_user_function (t8_forest_t forest);
+t8_forest_get_user_function (const t8_forest_t forest);
 
 /** Set a source forest to be partitioned during commit.
  * The partitioning is done according to the SFC and each rank is assigned
@@ -399,7 +399,7 @@ t8_forest_commit (t8_forest_t forest);
  * the minimum of all maxlevels of the element classes in this forest.
  */
 int
-t8_forest_get_maxlevel (t8_forest_t forest);
+t8_forest_get_maxlevel (const t8_forest_t forest);
 
 /** Return the number of process local elements in the forest.
  * \param [in]  forest    A forest.
@@ -551,7 +551,7 @@ t8_forest_get_mpicomm (t8_forest_t forest);
  * \return                      The global id of the first local tree in \a forest.
  */
 t8_gloidx_t
-t8_forest_get_first_local_tree_id (t8_forest_t forest);
+t8_forest_get_first_local_tree_id (const t8_forest_t forest);
 
 /** Return the number of local trees of a given forest.
  * \param [in]      forest      The forest.
@@ -565,7 +565,7 @@ t8_forest_get_num_local_trees (const t8_forest_t forest);
  * \return          The number of ghost trees of that forest.
  */
 t8_locidx_t
-t8_forest_get_num_ghost_trees (t8_forest_t forest);
+t8_forest_get_num_ghost_trees (const t8_forest_t forest);
 
 /** Return the number of global trees of a given forest.
  * \param [in]      forest      The forest.

--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -249,7 +249,7 @@ t8_forest_ghost_get_proc_info (t8_forest_t forest, int remote)
 
 /* return the number of trees in a ghost */
 t8_locidx_t
-t8_forest_ghost_num_trees (t8_forest_t forest)
+t8_forest_ghost_num_trees (const t8_forest_t forest)
 {
   if (forest->ghosts == NULL) {
     return 0;
@@ -265,7 +265,7 @@ t8_forest_ghost_num_trees (t8_forest_t forest)
 
 /* Given an index into the ghost_trees array return the ghost tree */
 static t8_ghost_tree_t *
-t8_forest_ghost_get_tree (t8_forest_t forest, t8_locidx_t lghost_tree)
+t8_forest_ghost_get_tree (const t8_forest_t forest, const t8_locidx_t lghost_tree)
 {
   t8_ghost_tree_t *ghost_tree;
   t8_forest_ghost_t ghost;
@@ -281,7 +281,7 @@ t8_forest_ghost_get_tree (t8_forest_t forest, t8_locidx_t lghost_tree)
 }
 
 t8_locidx_t
-t8_forest_ghost_get_tree_element_offset (t8_forest_t forest, t8_locidx_t lghost_tree)
+t8_forest_ghost_get_tree_element_offset (const t8_forest_t forest, const t8_locidx_t lghost_tree)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
   return t8_forest_ghost_get_tree (forest, lghost_tree)->element_offset;
@@ -300,7 +300,7 @@ t8_forest_ghost_tree_num_elements (t8_forest_t forest, t8_locidx_t lghost_tree)
 }
 
 t8_element_array_t *
-t8_forest_ghost_get_tree_elements (t8_forest_t forest, t8_locidx_t lghost_tree)
+t8_forest_ghost_get_tree_elements (const t8_forest_t forest, const t8_locidx_t lghost_tree)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
   T8_ASSERT (forest->ghosts != NULL);
@@ -330,7 +330,7 @@ t8_forest_ghost_get_ghost_treeid (t8_forest_t forest, t8_gloidx_t gtreeid)
 
 /* Given an index in the ghost_tree array, return this tree's element class */
 t8_eclass_t
-t8_forest_ghost_get_tree_class (t8_forest_t forest, t8_locidx_t lghost_tree)
+t8_forest_ghost_get_tree_class (const t8_forest_t forest, const t8_locidx_t lghost_tree)
 {
   t8_ghost_tree_t *ghost_tree;
   T8_ASSERT (t8_forest_is_committed (forest));
@@ -341,7 +341,7 @@ t8_forest_ghost_get_tree_class (t8_forest_t forest, t8_locidx_t lghost_tree)
 
 /* Given an index in the ghost_tree array, return this tree's global id */
 t8_gloidx_t
-t8_forest_ghost_get_global_treeid (t8_forest_t forest, t8_locidx_t lghost_tree)
+t8_forest_ghost_get_global_treeid (const t8_forest_t forest, const t8_locidx_t lghost_tree)
 {
   t8_ghost_tree_t *ghost_tree;
   T8_ASSERT (t8_forest_is_committed (forest));

--- a/src/t8_forest/t8_forest_ghost.h
+++ b/src/t8_forest/t8_forest_ghost.h
@@ -54,7 +54,7 @@ t8_forest_ghost_init (t8_forest_ghost_t *pghost, t8_ghost_type_t ghost_type);
 /* TODO: document */
 /* returns 0 if ghost structure doesnt exist */
 t8_locidx_t
-t8_forest_ghost_num_trees (t8_forest_t forest);
+t8_forest_ghost_num_trees (const t8_forest_t forest);
 
 /** Return the element offset of a ghost tree.
  * \param [in]      forest      The forest with constructed ghost layer.
@@ -76,7 +76,7 @@ t8_forest_ghost_tree_num_elements (t8_forest_t forest, t8_locidx_t lghost_tree);
  * \a forest must be committed before calling this function.
  */
 t8_element_array_t *
-t8_forest_ghost_get_tree_elements (t8_forest_t forest, t8_locidx_t lghost_tree);
+t8_forest_ghost_get_tree_elements (const t8_forest_t forest, const t8_locidx_t lghost_tree);
 
 /** Given a global tree compute the ghost local tree id of it.
  * \param [in]  forest    The forest. Ghost layer must exist.
@@ -92,7 +92,7 @@ t8_forest_ghost_get_ghost_treeid (t8_forest_t forest, t8_gloidx_t gtreeid);
 
 /* TODO: document */
 t8_eclass_t
-t8_forest_ghost_get_tree_class (t8_forest_t forest, t8_locidx_t lghost_tree);
+t8_forest_ghost_get_tree_class (const t8_forest_t forest, const t8_locidx_t lghost_tree);
 
 /** Given a local ghost tree compute the global tree id of it.
  * \param [in]  forest    The forest. Ghost layer must exist.
@@ -102,7 +102,7 @@ t8_forest_ghost_get_tree_class (t8_forest_t forest, t8_locidx_t lghost_tree);
  * \see https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
  */
 t8_gloidx_t
-t8_forest_ghost_get_global_treeid (t8_forest_t forest, t8_locidx_t lghost_tree);
+t8_forest_ghost_get_global_treeid (const t8_forest_t forest, const t8_locidx_t lghost_tree);
 
 /* TODO: document */
 t8_element_t *


### PR DESCRIPTION
In many cases we want to get something from the forest, but the params of these getter functions weren't const. 
It anoyed me and on this branch I introduced const params for the most easy getter functions, where I did not have to introduce bigger changes. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
