### PR TITLE
Add a comment on the usage of the incomplete trees flag of a forest

### DIFF
--- a/src/t8_forest/t8_forest_types.h
+++ b/src/t8_forest/t8_forest_types.h
@@ -83,7 +83,9 @@ typedef struct t8_forest
   int dimension;               /**< Dimension inferred from \b cmesh. */
   int incomplete_trees;        /**< Flag to check whether the forest has (potential) incomplete trees.
                                              A tree is incomplete if an element has been removed from it.
-                                             Once an element got removed, the flag sets to 1 (true) and stays. */
+                                             Once an element got removed, the flag sets to 1 (true) and stays. 
+                                             For a committed forest this flag is either true on all ranks or
+                                             false on all ranks. */
 
   t8_forest_t set_from;           /**< Temporarily store source forest. */
   t8_forest_from_t from_method;   /**< Method to derive from \b set_from. */


### PR DESCRIPTION
**_Describe your changes here:_**

Add a comment on the usage of the incomplete trees flag of a forest.

This flag is collective, so has the same value on each process.
The usage comment now reflects that.

Please note that i was not able to indent the code properly since my clang version is currently too old.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
