### PR TITLE
Add abort message to Ghost algorithm when using deleted elements

### DIFF
--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -1399,6 +1399,13 @@ t8_forest_ghost_create_ext (t8_forest_t forest, int unbalanced_version)
 
   t8_global_productionf ("Into t8_forest_ghost with %i local elements.\n", t8_forest_get_local_num_elements (forest));
 
+  /* Check forest for deleted elements. The Ghost algorithm currently
+  * does not work on forests with deleted elements.
+  * See also the test case: TODO Add a test case that currently fails. */
+  SC_CHECK_ABORT (
+    forest->incomplete_trees,
+    "ERROR: Cannot compute Ghost layer for forest with deleted elements (incomplete trees/holes in the mesh).\n");
+
   if (forest->profile != NULL) {
     /* If profiling is enabled, we measure the runtime of ghost_create */
     forest->profile->ghost_runtime = -sc_MPI_Wtime ();

--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -1401,6 +1401,7 @@ t8_forest_ghost_create_ext (t8_forest_t forest, int unbalanced_version)
 
   /* In parallel, check forest for deleted elements. The ghost algorithm currently
   * does not work on forests with deleted elements.
+  * See also: https://github.com/DLR-AMR/t8code/issues/825
   * See also the test case: TODO Add a test case that currently fails. */
   SC_CHECK_ABORT (
     !forest->incomplete_trees || forest->mpisize == 1,

--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -1399,11 +1399,11 @@ t8_forest_ghost_create_ext (t8_forest_t forest, int unbalanced_version)
 
   t8_global_productionf ("Into t8_forest_ghost with %i local elements.\n", t8_forest_get_local_num_elements (forest));
 
-  /* Check forest for deleted elements. The Ghost algorithm currently
+  /* In parallel, check forest for deleted elements. The Ghost algorithm currently
   * does not work on forests with deleted elements.
   * See also the test case: TODO Add a test case that currently fails. */
   SC_CHECK_ABORT (
-    forest->incomplete_trees,
+    !forest->incomplete_trees || forest->mpisize == 1,
     "ERROR: Cannot compute Ghost layer for forest with deleted elements (incomplete trees/holes in the mesh).\n");
 
   if (forest->profile != NULL) {

--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -1399,7 +1399,7 @@ t8_forest_ghost_create_ext (t8_forest_t forest, int unbalanced_version)
 
   t8_global_productionf ("Into t8_forest_ghost with %i local elements.\n", t8_forest_get_local_num_elements (forest));
 
-  /* In parallel, check forest for deleted elements. The Ghost algorithm currently
+  /* In parallel, check forest for deleted elements. The ghost algorithm currently
   * does not work on forests with deleted elements.
   * See also the test case: TODO Add a test case that currently fails. */
   SC_CHECK_ABORT (

--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -1404,7 +1404,7 @@ t8_forest_ghost_create_ext (t8_forest_t forest, int unbalanced_version)
   * See also the test case: TODO Add a test case that currently fails. */
   SC_CHECK_ABORT (
     !forest->incomplete_trees || forest->mpisize == 1,
-    "ERROR: Cannot compute Ghost layer for forest with deleted elements (incomplete trees/holes in the mesh).\n");
+    "ERROR: Cannot compute ghost layer for forest with deleted elements (incomplete trees/holes in the mesh).\n");
 
   if (forest->profile != NULL) {
     /* If profiling is enabled, we measure the runtime of ghost_create */


### PR DESCRIPTION
**_Describe your changes here:_**

Abort the execution if Ghost is executed on a forest with incomplete trees.

This is necessary since the Ghost computation may fail on meshes with holes. See #825.
This behaviour can be reverted when #825 is fixed. 

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
