### PR TITLE
Test ghost for forests with holes

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -42,6 +42,7 @@ t8code_googletest_programs = \
   test/t8_forest/t8_gtest_user_data \
   test/t8_forest/t8_gtest_transform \
   test/t8_forest/t8_gtest_ghost_exchange \
+  test/t8_forest/t8_gtest_ghost_delete \
   test/t8_forest/t8_gtest_ghost_and_owner \
   test/t8_IO/t8_gtest_vtk_reader \
   test/t8_forest_incomplete/t8_gtest_permute_hole \
@@ -209,6 +210,10 @@ test_t8_forest_t8_gtest_transform_SOURCES = \
 test_t8_forest_t8_gtest_ghost_exchange_SOURCES = \
   test/t8_gtest_main.cxx \
   test/t8_forest/t8_gtest_ghost_exchange.cxx
+
+test_t8_forest_t8_gtest_ghost_delete_SOURCES = \
+  test/t8_gtest_main.cxx \
+  test/t8_forest/t8_gtest_ghost_delete.cxx
 
 test_t8_forest_t8_gtest_ghost_and_owner_SOURCES = \
   test/t8_gtest_main.cxx \
@@ -399,6 +404,10 @@ test_t8_forest_t8_gtest_ghost_exchange_LDADD = $(t8_gtest_target_ld_add)
 test_t8_forest_t8_gtest_ghost_exchange_LDFLAGS = $(t8_gtest_target_ld_flags)
 test_t8_forest_t8_gtest_ghost_exchange_CPPFLAGS = $(t8_gtest_target_cpp_flags)
 
+test_t8_forest_t8_gtest_ghost_delete_LDADD = $(t8_gtest_target_ld_add)
+test_t8_forest_t8_gtest_ghost_delete_LDFLAGS = $(t8_gtest_target_ld_flags)
+test_t8_forest_t8_gtest_ghost_delete_CPPFLAGS = $(t8_gtest_target_cpp_flags)
+
 test_t8_forest_t8_gtest_ghost_and_owner_LDADD = $(t8_gtest_target_ld_add)
 test_t8_forest_t8_gtest_ghost_and_owner_LDFLAGS = $(t8_gtest_target_ld_flags)
 test_t8_forest_t8_gtest_ghost_and_owner_CPPFLAGS = $(t8_gtest_target_cpp_flags)
@@ -469,6 +478,7 @@ test_t8_geometry_t8_gtest_point_inside_CPPFLAGS += $(t8_gtest_target_mpi_cpp_fla
 test_t8_forest_t8_gtest_user_data_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_forest_t8_gtest_transform_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_forest_t8_gtest_ghost_exchange_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
+test_t8_forest_t8_gtest_ghost_delete_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_forest_t8_gtest_ghost_and_owner_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_IO_t8_gtest_vtk_reader_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_forest_incomplete_t8_gtest_permute_hole_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)

--- a/test/t8_forest/t8_gtest_ghost_delete.cxx
+++ b/test/t8_forest/t8_gtest_ghost_delete.cxx
@@ -68,19 +68,24 @@ class forest_ghost_exchange_holes: public testing::Test {
 
     sc_MPI_Comm_split(sc_MPI_COMM_WORLD, color, key, &comm);
 
-    sc_MPI_Comm_size(comm, &size);
-    t8_debugf("New size is: %i", size);
+    if(comm != sc_MPI_COMM_NULL){
+        sc_MPI_Comm_size(comm, &size);
+        t8_debugf("\nNew size is: %i\n\n", size);
+        scheme = t8_scheme_new_default_cxx ();
+        /* Construct a cmesh */
+        cmesh = t8_cmesh_new_hypercube (T8_ECLASS_QUAD, comm, 0, 0, 0);
+    }else{
+        t8_debugf("\nThis proc has comm NULL \n\n");
+    }
 
-
-    scheme = t8_scheme_new_default_cxx ();
-    /* Construct a cmesh */
-    cmesh = t8_cmesh_new_hypercube (T8_ECLASS_QUAD, comm, 0, 0, 0);
   }
   void
   TearDown () override
   {
     //cmesh and scheme are freed taken and freed by forest
-    sc_MPI_Comm_free(&comm);
+    if(comm != sc_MPI_COMM_NULL){
+      sc_MPI_Comm_free(&comm);
+    }
   }
   sc_MPI_Comm comm;
   t8_scheme_cxx_t *scheme;
@@ -89,9 +94,11 @@ class forest_ghost_exchange_holes: public testing::Test {
 
 TEST_F (forest_ghost_exchange_holes, errorTest)
 {
-  int level = 1;
-  t8_forest_t forest = t8_forest_new_uniform (cmesh, scheme, level, 1, comm);
-  forest = t8_forest_new_adapt (forest, test_adapt_holes, 0, 1, NULL);
-  forest = t8_forest_new_adapt (forest, test_adapt_holes, 0, 1, NULL);
-  t8_forest_unref(&forest);
+  if(comm != sc_MPI_COMM_NULL){
+    int level = 1;
+    t8_forest_t forest = t8_forest_new_uniform (cmesh, scheme, level, 1, comm);
+    forest = t8_forest_new_adapt (forest, test_adapt_holes, 0, 1, NULL);
+    forest = t8_forest_new_adapt (forest, test_adapt_holes, 0, 1, NULL);
+    t8_forest_unref(&forest);
+  }
 }

--- a/test/t8_forest/t8_gtest_ghost_delete.cxx
+++ b/test/t8_forest/t8_gtest_ghost_delete.cxx
@@ -33,15 +33,18 @@
 /* This test
  */
 
-static int test_adapt_holes (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree, t8_locidx_t lelement_id,
-                       t8_eclass_scheme_c *ts, const int is_family, const int num_elements, t8_element_t *elements[])
+static int
+test_adapt_holes (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree, t8_locidx_t lelement_id,
+                  t8_eclass_scheme_c *ts, const int is_family, const int num_elements, t8_element_t *elements[])
 {
-    double coordinates[3];
-    double eps = 0.0001;
-    t8_forest_element_coordinate (forest_from, which_tree, elements[0], 0, coordinates);
-    if (fabs(coordinates[1]) < eps) return 1; // refine the lowest row 
-    if (fabs(coordinates[1] - 0.25) < eps) return -2; // refine the lowest row 
-    return 0;
+  double coordinates[3];
+  double eps = 0.0001;
+  t8_forest_element_coordinate (forest_from, which_tree, elements[0], 0, coordinates);
+  if (fabs (coordinates[1]) < eps)
+    return 1;  // refine the lowest row
+  if (fabs (coordinates[1] - 0.25) < eps)
+    return -2;  // refine the lowest row
+  return 0;
 }
 
 class forest_ghost_exchange_holes: public testing::Test {
@@ -52,41 +55,42 @@ class forest_ghost_exchange_holes: public testing::Test {
     /* adjust communicator size */
     int size, rank, color, key;
 
-    sc_MPI_Comm_size(sc_MPI_COMM_WORLD, &size);
-    sc_MPI_Comm_rank(sc_MPI_COMM_WORLD, &rank);
-    t8_debugf("size is %i\n", size);
+    sc_MPI_Comm_size (sc_MPI_COMM_WORLD, &size);
+    sc_MPI_Comm_rank (sc_MPI_COMM_WORLD, &rank);
+    t8_debugf ("size is %i\n", size);
 
-    if (rank < 2){
-        color = 0;
-        key = rank;
-    }else{
-        color = sc_MPI_UNDEFINED;
-        key = -1;
+    if (rank < 2) {
+      color = 0;
+      key = rank;
+    }
+    else {
+      color = sc_MPI_UNDEFINED;
+      key = -1;
     }
 
-    t8_debugf("Color: %i, Key: %i\n", color, key);
+    t8_debugf ("Color: %i, Key: %i\n", color, key);
 
-    sc_MPI_Comm_split(sc_MPI_COMM_WORLD, color, key, &comm);
+    sc_MPI_Comm_split (sc_MPI_COMM_WORLD, color, key, &comm);
 
-    if(comm != sc_MPI_COMM_NULL){
-        sc_MPI_Comm_size(comm, &size);
-        t8_debugf("\nNew size is: %i\n\n", size);
-        scheme = t8_scheme_new_default_cxx ();
-        /* Construct a cmesh */
-        cmesh = t8_cmesh_new_hypercube (T8_ECLASS_QUAD, comm, 0, 0, 0);
-    }else{
-        t8_debugf("\nThis proc has comm NULL \n\n");
+    if (comm != sc_MPI_COMM_NULL) {
+      sc_MPI_Comm_size (comm, &size);
+      t8_debugf ("\nNew size is: %i\n\n", size);
+      scheme = t8_scheme_new_default_cxx ();
+      /* Construct a cmesh */
+      cmesh = t8_cmesh_new_hypercube (T8_ECLASS_QUAD, comm, 0, 0, 0);
     }
-
+    else {
+      t8_debugf ("\nThis proc has comm NULL \n\n");
+    }
   }
   void
   TearDown () override
   {
     //cmesh and scheme are freed taken and freed by forest
-    if(comm != sc_MPI_COMM_NULL){
-      sc_MPI_Comm_free(&comm);
+    if (comm != sc_MPI_COMM_NULL) {
+      sc_MPI_Comm_free (&comm);
     }
-    sc_MPI_Barrier(sc_MPI_COMM_WORLD);
+    sc_MPI_Barrier (sc_MPI_COMM_WORLD);
   }
   sc_MPI_Comm comm;
   t8_scheme_cxx_t *scheme;
@@ -95,11 +99,11 @@ class forest_ghost_exchange_holes: public testing::Test {
 
 TEST_F (forest_ghost_exchange_holes, errorTest)
 {
-  if(comm != sc_MPI_COMM_NULL){
+  if (comm != sc_MPI_COMM_NULL) {
     int level = 1;
     t8_forest_t forest = t8_forest_new_uniform (cmesh, scheme, level, 1, comm);
     forest = t8_forest_new_adapt (forest, test_adapt_holes, 0, 1, NULL);
-    forest = t8_forest_new_adapt (forest, test_adapt_holes, 0, 1, NULL);
-    t8_forest_unref(&forest);
+    forest = t8_forest_new_adapt (forest, test_adapt_holes, 0, 0, NULL);
+    t8_forest_unref (&forest);
   }
 }

--- a/test/t8_forest/t8_gtest_ghost_delete.cxx
+++ b/test/t8_forest/t8_gtest_ghost_delete.cxx
@@ -30,15 +30,17 @@
 #include <t8_cmesh.h>
 #include <t8_cmesh/t8_cmesh_examples.h>
 
-/* This test is executed on a subcommunicator of exactly 2 procs, because it demonstrates a configuration that is currently not working
+/* This test is executed on a subcommunicator of exactly 2 procs, because it demonstrates a configuration that is currently not working. See https://github.com/DLR-AMR/t8code/issues/825.
  * A partitioned square of uniform refinement level 1 is adapted once, where only the lower half is refined.
  * Then the mesh is adapted again, where only the upper half of the lower elements is deleted.
- * Now, no element actually has a face connection to an existing element on the other proc, but they send a message anyway.
+ * Now, no element actually has a face connection to an existing element on the other proc, thus the Ghost structure should be empty.
+ * Within the bug discussed in https://github.com/DLR-AMR/t8code/issues/825 they send a message anyway.
+ * Once, https://github.com/DLR-AMR/t8code/issues/825 is resolved, no messages should be send and the test should pass.
  */
 
 
-/* refine elements, whose y coordinate is 0, so that the lowest row is refined
- * delete elements, whose y coordniate is 0.25, so that the second row is deleted
+/* refine elements, whose lower left y coordinate is 0, so that the lowest row is refined
+ * delete elements, whose lower left y coordniate is 0.25, so that the second row is deleted
  */
 static int
 test_adapt_holes (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree, t8_locidx_t lelement_id,

--- a/test/t8_forest/t8_gtest_ghost_delete.cxx
+++ b/test/t8_forest/t8_gtest_ghost_delete.cxx
@@ -43,7 +43,7 @@ test_adapt_holes (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which
   if (fabs (coordinates[1]) < eps)
     return 1;  // refine the lowest row
   if (fabs (coordinates[1] - 0.25) < eps)
-    return -2;  // refine the lowest row
+    return -2;  // delete the higher row in the lower quadrants
   return 0;
 }
 

--- a/test/t8_forest/t8_gtest_ghost_delete.cxx
+++ b/test/t8_forest/t8_gtest_ghost_delete.cxx
@@ -86,6 +86,7 @@ class forest_ghost_exchange_holes: public testing::Test {
     if(comm != sc_MPI_COMM_NULL){
       sc_MPI_Comm_free(&comm);
     }
+    sc_MPI_Barrier(sc_MPI_COMM_WORLD);
   }
   sc_MPI_Comm comm;
   t8_scheme_cxx_t *scheme;

--- a/test/t8_forest/t8_gtest_ghost_delete.cxx
+++ b/test/t8_forest/t8_gtest_ghost_delete.cxx
@@ -1,0 +1,97 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#include <gtest/gtest.h>
+#include <t8_eclass.h>
+#include <t8_schemes/t8_default/t8_default_cxx.hxx>
+#include <t8_forest/t8_forest_general.h>
+#include <t8_forest/t8_forest_geometrical.h>
+#include <t8_forest/t8_forest_ghost.h>
+#include <t8_forest/t8_forest_private.h>
+#include <t8_cmesh.h>
+#include <t8_cmesh/t8_cmesh_examples.h>
+
+/* This test
+ */
+
+static int test_adapt_holes (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree, t8_locidx_t lelement_id,
+                       t8_eclass_scheme_c *ts, const int is_family, const int num_elements, t8_element_t *elements[])
+{
+    double coordinates[3];
+    double eps = 0.0001;
+    t8_forest_element_coordinate (forest_from, which_tree, elements[0], 0, coordinates);
+    if (fabs(coordinates[1]) < eps) return 1; // refine the lowest row 
+    if (fabs(coordinates[1] - 0.25) < eps) return -2; // refine the lowest row 
+    return 0;
+}
+
+class forest_ghost_exchange_holes: public testing::Test {
+ protected:
+  void
+  SetUp () override
+  {
+    /* adjust communicator size */
+    int size, rank, color, key;
+
+    sc_MPI_Comm_size(sc_MPI_COMM_WORLD, &size);
+    sc_MPI_Comm_rank(sc_MPI_COMM_WORLD, &rank);
+    t8_debugf("size is %i\n", size);
+
+    if (rank < 2){
+        color = 0;
+        key = rank;
+    }else{
+        color = sc_MPI_UNDEFINED;
+        key = -1;
+    }
+
+    t8_debugf("Color: %i, Key: %i\n", color, key);
+
+    sc_MPI_Comm_split(sc_MPI_COMM_WORLD, color, key, &comm);
+
+    sc_MPI_Comm_size(comm, &size);
+    t8_debugf("New size is: %i", size);
+
+
+    scheme = t8_scheme_new_default_cxx ();
+    /* Construct a cmesh */
+    cmesh = t8_cmesh_new_hypercube (T8_ECLASS_QUAD, comm, 0, 0, 0);
+  }
+  void
+  TearDown () override
+  {
+    //cmesh and scheme are freed taken and freed by forest
+    sc_MPI_Comm_free(&comm);
+  }
+  sc_MPI_Comm comm;
+  t8_scheme_cxx_t *scheme;
+  t8_cmesh_t cmesh;
+};
+
+TEST_F (forest_ghost_exchange_holes, errorTest)
+{
+  int level = 1;
+  t8_forest_t forest = t8_forest_new_uniform (cmesh, scheme, level, 1, comm);
+  forest = t8_forest_new_adapt (forest, test_adapt_holes, 0, 1, NULL);
+  forest = t8_forest_new_adapt (forest, test_adapt_holes, 0, 1, NULL);
+  t8_forest_unref(&forest);
+}

--- a/test/t8_forest/t8_gtest_ghost_delete.cxx
+++ b/test/t8_forest/t8_gtest_ghost_delete.cxx
@@ -30,19 +30,25 @@
 #include <t8_cmesh.h>
 #include <t8_cmesh/t8_cmesh_examples.h>
 
-/* This test
+/* This test is executed on a subcommunicator of exactly 2 procs, because it demonstrates a configuration that is currently not working
+ * A partitioned square of uniform refinement level 1 is adapted once, where only the lower half is refined.
+ * Then the mesh is adapted again, where only the upper half of the lower elements is deleted.
+ * Now, no element actually has a face connection to an existing element on the other proc, but they send a message anyway.
  */
 
+
+/* refine elements, whose y coordinate is 0, so that the lowest row is refined
+ * delete elements, whose y coordniate is 0.25, so that the second row is deleted
+ */
 static int
 test_adapt_holes (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree, t8_locidx_t lelement_id,
                   t8_eclass_scheme_c *ts, const int is_family, const int num_elements, t8_element_t *elements[])
 {
   double coordinates[3];
-  double eps = 0.0001;
   t8_forest_element_coordinate (forest_from, which_tree, elements[0], 0, coordinates);
-  if (fabs (coordinates[1]) < eps)
+  if (fabs (coordinates[1]) < T8_PRECISION_EPS)
     return 1;  // refine the lowest row
-  if (fabs (coordinates[1] - 0.25) < eps)
+  if (fabs (coordinates[1] - 0.25) < T8_PRECISION_EPS)
     return -2;  // delete the higher row in the lower quadrants
   return 0;
 }
@@ -52,12 +58,11 @@ class forest_ghost_exchange_holes: public testing::Test {
   void
   SetUp () override
   {
-    /* adjust communicator size */
+    /* adjust communicator size, we split the comm here, because we know that the test fails on 2 procs*/
     int size, rank, color, key;
 
     sc_MPI_Comm_size (sc_MPI_COMM_WORLD, &size);
     sc_MPI_Comm_rank (sc_MPI_COMM_WORLD, &rank);
-    t8_debugf ("size is %i\n", size);
 
     if (rank < 2) {
       color = 0;
@@ -67,20 +72,17 @@ class forest_ghost_exchange_holes: public testing::Test {
       color = sc_MPI_UNDEFINED;
       key = -1;
     }
-
-    t8_debugf ("Color: %i, Key: %i\n", color, key);
-
     sc_MPI_Comm_split (sc_MPI_COMM_WORLD, color, key, &comm);
+    T8_ASSERT (rank < 2 || comm == sc_MPI_COMM_NULL);
 
     if (comm != sc_MPI_COMM_NULL) {
       sc_MPI_Comm_size (comm, &size);
-      t8_debugf ("\nNew size is: %i\n\n", size);
+      T8_ASSERT(size <= 2);
       scheme = t8_scheme_new_default_cxx ();
       /* Construct a cmesh */
       cmesh = t8_cmesh_new_hypercube (T8_ECLASS_QUAD, comm, 0, 0, 0);
-    }
-    else {
-      t8_debugf ("\nThis proc has comm NULL \n\n");
+    }else{
+      T8_ASSERT(rank >= 2);
     }
   }
   void
@@ -91,6 +93,8 @@ class forest_ghost_exchange_holes: public testing::Test {
       sc_MPI_Comm_free (&comm);
     }
     sc_MPI_Barrier (sc_MPI_COMM_WORLD);
+    t8_cmesh_unref (&cmesh);
+    t8_scheme_cxx_unref (&scheme);
   }
   sc_MPI_Comm comm;
   t8_scheme_cxx_t *scheme;
@@ -99,11 +103,18 @@ class forest_ghost_exchange_holes: public testing::Test {
 
 TEST_F (forest_ghost_exchange_holes, errorTest)
 {
+  /* This test tests the functionality described in Issue: https://github.com/DLR-AMR/t8code/issues/825
+  * Remove the GTEST_SKIP() macros when you start working on the issue.
+  */
+  GTEST_SKIP(); 
   if (comm != sc_MPI_COMM_NULL) {
-    int level = 1;
+    const int level = 1;
+    const int execute_ghost = 1;
+    t8_cmesh_ref(cmesh);
+    t8_scheme_cxx_ref(scheme);
     t8_forest_t forest = t8_forest_new_uniform (cmesh, scheme, level, 1, comm);
-    forest = t8_forest_new_adapt (forest, test_adapt_holes, 0, 1, NULL);
-    forest = t8_forest_new_adapt (forest, test_adapt_holes, 0, 0, NULL);
+    forest = t8_forest_new_adapt (forest, test_adapt_holes, 0, execute_ghost, NULL);
+    forest = t8_forest_new_adapt (forest, test_adapt_holes, 0, execute_ghost, NULL);
     t8_forest_unref (&forest);
   }
 }


### PR DESCRIPTION
**_Describe your changes here:_**
Ghost currently does not work on forests with deleted elements. This test is an example of a configuration that fails.
See #825.
It does not fail when the second adapt call is done without ghosts

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
