### PR TITLE
Feature issue28 get element return const

### DIFF
--- a/example/advect/t8_advection.cxx
+++ b/example/advect/t8_advection.cxx
@@ -563,10 +563,13 @@ t8_advect_replace (t8_forest_t forest_old, t8_forest_t forest_new, t8_locidx_t w
     /* The element is not changed, copy phi and vol */
     memcpy (elem_data_in, elem_data_out, sizeof (t8_advect_element_data_t));
     t8_advect_element_set_phi_adapt (problem, first_incoming_data, phi_old);
+#if T8_ENABLE_DEBUG
     /* Get a pointer to the new element */
     const t8_element_t *element = t8_forest_get_element_in_tree (problem->forest_adapt, which_tree, first_incoming);
-    /* Set the neighbor entries to uninitialized */
+    /* Debug check number of faces */
     T8_ASSERT (elem_data_in->num_faces == ts->t8_element_num_faces (element));
+#endif
+    /* Set the neighbor entries to uninitialized */
     for (iface = 0; iface < elem_data_in->num_faces; iface++) {
       elem_data_in->num_neighbors[iface] = 0;
       elem_data_in->flux_valid[iface] = -1;

--- a/example/advect/t8_advection.cxx
+++ b/example/advect/t8_advection.cxx
@@ -411,7 +411,7 @@ t8_advect_flux_upwind (const t8_advect_problem_t *problem, double el_plus_phi, d
 int a = 0;
 static double
 t8_advect_flux_upwind_hanging (const t8_advect_problem_t *problem, t8_locidx_t iel_hang, t8_locidx_t ltreeid,
-                               t8_element_t *element_hang, int face, int adapted_or_partitioned)
+                               const t8_element_t *element_hang, int face, int adapted_or_partitioned)
 {
   int i, num_face_children, child_face;
   t8_eclass_scheme_c *ts;
@@ -516,7 +516,7 @@ t8_advect_advance_element (t8_advect_problem_t *problem, t8_locidx_t lelement)
 /* Compute element midpoint and vol and store at element_data field. */
 static void
 t8_advect_compute_element_data (t8_advect_problem_t *problem, t8_advect_element_data_t *elem_data,
-                                t8_element_t *element, t8_locidx_t ltreeid, t8_eclass_scheme_c *ts)
+                                const t8_element_t *element, t8_locidx_t ltreeid, t8_eclass_scheme_c *ts)
 {
   /* Compute the midpoint coordinates of element */
   t8_forest_element_centroid (problem->forest, ltreeid, element, elem_data->midpoint);
@@ -541,7 +541,6 @@ t8_advect_replace (t8_forest_t forest_old, t8_forest_t forest_new, t8_locidx_t w
   t8_advect_problem_t *problem;
   t8_advect_element_data_t *elem_data_in, *elem_data_out;
   t8_locidx_t first_incoming_data, first_outgoing_data;
-  t8_element_t *element;
   int i, iface;
   double phi_old;
 
@@ -565,7 +564,7 @@ t8_advect_replace (t8_forest_t forest_old, t8_forest_t forest_new, t8_locidx_t w
     memcpy (elem_data_in, elem_data_out, sizeof (t8_advect_element_data_t));
     t8_advect_element_set_phi_adapt (problem, first_incoming_data, phi_old);
     /* Get a pointer to the new element */
-    element = t8_forest_get_element_in_tree (problem->forest_adapt, which_tree, first_incoming);
+    const t8_element_t *element = t8_forest_get_element_in_tree (problem->forest_adapt, which_tree, first_incoming);
     /* Set the neighbor entries to uninitialized */
     T8_ASSERT (elem_data_in->num_faces == ts->t8_element_num_faces (element));
     for (iface = 0; iface < elem_data_in->num_faces; iface++) {
@@ -581,16 +580,15 @@ t8_advect_replace (t8_forest_t forest_old, t8_forest_t forest_new, t8_locidx_t w
 #if T8_ENABLE_DEBUG
     /* Ensure that the number of incoming elements matches the
      * number of children of the outgoing element. */
-    const t8_element_t *element_outgoing =
-      t8_forest_get_element_in_tree (forest_old, which_tree, first_outgoing);
-    const int           num_children =
-      ts->t8_element_num_children (element_outgoing);
+    const t8_element_t *element_outgoing = t8_forest_get_element_in_tree (forest_old, which_tree, first_outgoing);
+    const int num_children = ts->t8_element_num_children (element_outgoing);
     T8_ASSERT (num_incoming == num_children);
 #endif
     /* The old element is refined, we copy the phi values and compute the new midpoints */
     for (i = 0; i < num_incoming; i++) {
       /* Get a pointer to the new element */
-      element = t8_forest_get_element_in_tree (problem->forest_adapt, which_tree, first_incoming + i);
+      const t8_element_t *element
+        = t8_forest_get_element_in_tree (problem->forest_adapt, which_tree, first_incoming + i);
       /* Compute midpoint and vol of the new element */
       t8_advect_compute_element_data (problem, elem_data_in + i, element, which_tree, ts);
       t8_advect_element_set_phi_adapt (problem, first_incoming_data + i, phi_old);
@@ -615,16 +613,14 @@ t8_advect_replace (t8_forest_t forest_old, t8_forest_t forest_new, t8_locidx_t w
 #if T8_ENABLE_DEBUG
     /* Ensure that the number of outgoing elements matches the
      * number of siblings of the first outgoing element. */
-    const t8_element_t *element_outgoing =
-      t8_forest_get_element_in_tree (forest_old, which_tree, first_outgoing);
-    const int           num_siblings =
-      ts->t8_element_num_siblings (element_outgoing);
+    const t8_element_t *element_outgoing = t8_forest_get_element_in_tree (forest_old, which_tree, first_outgoing);
+    const int num_siblings = ts->t8_element_num_siblings (element_outgoing);
     T8_ASSERT (num_outgoing == num_siblings);
 #endif
     /* The old elements form a family which is coarsened. We compute the average
      * phi value and set it as the new phi value */
     /* Get a pointer to the new element */
-    element = t8_forest_get_element_in_tree (problem->forest_adapt, which_tree, first_incoming);
+    const t8_element_t *element = t8_forest_get_element_in_tree (problem->forest_adapt, which_tree, first_incoming);
     /* Compute midpoint and vol of the new element */
     t8_advect_compute_element_data (problem, elem_data_in, element, which_tree, ts);
 
@@ -985,7 +981,7 @@ t8_advect_problem_init_elements (t8_advect_problem_t *problem)
 {
   t8_locidx_t itree, ielement, idata;
   t8_locidx_t num_trees, num_elems_in_tree;
-  t8_element_t *element, **neighbors;
+  t8_element_t **neighbors;
   int iface, ineigh;
   t8_advect_element_data_t *elem_data;
   t8_eclass_scheme_c *ts, *neigh_scheme;
@@ -1001,7 +997,7 @@ t8_advect_problem_init_elements (t8_advect_problem_t *problem)
     ts = t8_forest_get_eclass_scheme (problem->forest, t8_forest_get_tree_class (problem->forest, itree));
     num_elems_in_tree = t8_forest_get_tree_num_elements (problem->forest, itree);
     for (ielement = 0; ielement < num_elems_in_tree; ielement++, idata++) {
-      element = t8_forest_get_element_in_tree (problem->forest, itree, ielement);
+      const t8_element_t *element = t8_forest_get_element_in_tree (problem->forest, itree, ielement);
       elem_data = (t8_advect_element_data_t *) t8_sc_array_index_locidx (problem->element_data, idata);
       /* Initialize the element's midpoint and volume */
       t8_advect_compute_element_data (problem, elem_data, element, itree, ts);
@@ -1196,7 +1192,7 @@ t8_advect_solve (t8_cmesh_t cmesh, t8_flow_function_3d_fn u, t8_example_level_se
   int done = 0;
   int adapted_or_partitioned = 0;
   int dual_face;
-  t8_element_t *elem, **neighs;
+  t8_element_t **neighs;
   t8_eclass_scheme_c *neigh_scheme;
   double total_time, solve_time = 0;
   double ghost_exchange_time, ghost_waittime, neighbor_time, flux_time;
@@ -1269,7 +1265,7 @@ t8_advect_solve (t8_cmesh_t cmesh, t8_flow_function_3d_fn u, t8_example_level_se
         /* element loop */
         /* Get a pointer to the element data */
         elem_data = (t8_advect_element_data_t *) t8_sc_array_index_locidx (problem->element_data, lelement);
-        elem = t8_forest_get_element_in_tree (problem->forest, itree, ielement);
+        const t8_element_t *elem = t8_forest_get_element_in_tree (problem->forest, itree, ielement);
         num_faces = elem_data->num_faces;
         /* Compute left and right flux */
         for (iface = 0; iface < num_faces; iface++) {

--- a/example/forest/t8_test_face_iterate.cxx
+++ b/example/forest/t8_test_face_iterate.cxx
@@ -78,7 +78,7 @@ t8_test_fiterate (t8_forest_t forest)
   t8_locidx_t itree, num_trees;
   t8_eclass_t eclass;
   t8_eclass_scheme_c *ts;
-  t8_element_t *first_el, *last_el, *nca;
+  t8_element_t *nca;
   t8_element_array_t *leaf_elements;
   t8_test_fiterate_udata_t udata;
   int iface;
@@ -87,8 +87,9 @@ t8_test_fiterate (t8_forest_t forest)
   for (itree = 0; itree < num_trees; itree++) {
     eclass = t8_forest_get_tree_class (forest, itree);
     ts = t8_forest_get_eclass_scheme (forest, eclass);
-    first_el = t8_forest_get_element_in_tree (forest, itree, 0);
-    last_el = t8_forest_get_element_in_tree (forest, itree, t8_forest_get_tree_num_elements (forest, itree) - 1);
+    const t8_element_t *first_el = t8_forest_get_element_in_tree (forest, itree, 0);
+    const t8_element_t *last_el
+      = t8_forest_get_element_in_tree (forest, itree, t8_forest_get_tree_num_elements (forest, itree) - 1);
     ts->t8_element_new (1, &nca);
     ts->t8_element_nca (first_el, last_el, nca);
     leaf_elements = t8_forest_tree_get_leafs (forest, itree);

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -957,7 +957,7 @@ t8_forest_get_element (t8_forest_t forest, t8_locidx_t lelement_id, t8_locidx_t 
   return NULL;
 }
 
-t8_element_t *
+const t8_element_t *
 t8_forest_get_element_in_tree (t8_forest_t forest, t8_locidx_t ltreeid, t8_locidx_t leid_in_tree)
 {
   t8_tree_t tree;

--- a/src/t8_forest/t8_forest_balance.cxx
+++ b/src/t8_forest/t8_forest_balance.cxx
@@ -48,7 +48,8 @@ t8_forest_balance_adapt (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_
   t8_gloidx_t neighbor_tree;
   t8_eclass_t neigh_class;
   t8_eclass_scheme_c *neigh_scheme;
-  t8_element_t *element = elements[0], **half_neighbors;
+  const t8_element_t *element = elements[0];
+  t8_element_t **half_neighbors;
 
   /* We only need to check an element, if its level is smaller then the maximum
    * level in the forest minus 2.
@@ -103,7 +104,6 @@ t8_forest_compute_max_element_level (t8_forest_t forest)
 {
   t8_locidx_t ielement, elem_in_tree;
   t8_locidx_t itree, num_trees;
-  t8_element_t *elem;
   t8_eclass_scheme_c *scheme;
   int local_max_level = 0, elem_level;
 
@@ -114,7 +114,7 @@ t8_forest_compute_max_element_level (t8_forest_t forest)
     scheme = t8_forest_get_eclass_scheme (forest, t8_forest_get_tree_class (forest, itree));
     for (ielement = 0; ielement < elem_in_tree; ielement++) {
       /* Get the element and compute its level */
-      elem = t8_forest_get_element_in_tree (forest, itree, ielement);
+      const t8_element_t *elem = t8_forest_get_element_in_tree (forest, itree, ielement);
       elem_level = scheme->t8_element_level (elem);
       local_max_level = SC_MAX (local_max_level, elem_level);
     }
@@ -316,7 +316,6 @@ t8_forest_is_balanced (t8_forest_t forest)
   t8_forest_t forest_from;
   t8_locidx_t num_trees, num_elements;
   t8_locidx_t itree, ielem;
-  t8_element_t *element;
   t8_eclass_scheme_c *ts;
   void *data_temp;
   int dummy_int;
@@ -339,10 +338,10 @@ t8_forest_is_balanced (t8_forest_t forest)
     ts = t8_forest_get_eclass_scheme (forest, t8_forest_get_tree_class (forest, itree));
     /* Iterate over all elements of this tree */
     for (ielem = 0; ielem < num_elements; ielem++) {
-      element = t8_forest_get_element_in_tree (forest, itree, ielem);
+      const t8_element_t *element = t8_forest_get_element_in_tree (forest, itree, ielem);
       /* Test if this element would need to be refined in the balance step.
        * If so, the forest is not balanced locally. */
-      if (t8_forest_balance_adapt (forest, forest, itree, ielem, ts, 0, 1, &element)) {
+      if (t8_forest_balance_adapt (forest, forest, itree, ielem, ts, 0, 1, (t8_element_t **) (&element))) {
         forest->set_from = forest_from;
         forest->t8code_data = data_temp;
         return 0;

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -2174,8 +2174,7 @@ t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid, const t8
         /* We check whether the element is really the element at this local id */
         {
           t8_locidx_t check_ltreeid;
-          t8_element_t *check_element;
-          check_element = t8_forest_get_element (forest, element_indices[ineigh], &check_ltreeid);
+          const t8_element_t *check_element = t8_forest_get_element (forest, element_indices[ineigh], &check_ltreeid);
           T8_ASSERT (check_ltreeid == lneigh_treeid);
           T8_ASSERT (!neigh_scheme->t8_element_compare (check_element, neighbor_leafs[ineigh]));
         }
@@ -2213,7 +2212,7 @@ void
 t8_forest_print_all_leaf_neighbors (t8_forest_t forest)
 {
   t8_locidx_t ltree, ielem;
-  t8_element_t *leaf, **neighbor_leafs;
+  t8_element_t **neighbor_leafs;
   int iface, num_neighbors, ineigh;
   t8_eclass_t eclass;
   t8_eclass_scheme_c *ts, *neigh_scheme;
@@ -2237,7 +2236,7 @@ t8_forest_print_all_leaf_neighbors (t8_forest_t forest)
   }
   for (ielem = 0; ielem < t8_forest_get_local_num_elements (forest); ielem++) {
     /* Get a pointer to the ielem-th element, its eclass, treeid and scheme */
-    leaf = t8_forest_get_element (forest, ielem, &ltree);
+    const t8_element_t *leaf = t8_forest_get_element (forest, ielem, &ltree);
     eclass = t8_forest_get_tree_class (forest, ltree);
     ts = t8_forest_get_eclass_scheme (forest, eclass);
     /* Iterate over all faces */

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -320,7 +320,6 @@ t8_forest_is_equal (t8_forest_t forest_a, t8_forest_t forest_b)
   t8_locidx_t elems_in_tree_a, elems_in_tree_b;
   t8_locidx_t ielem;
   t8_locidx_t itree;
-  t8_element_t *elem_a, *elem_b;
   t8_eclass_scheme_c *ts_a, *ts_b;
 
   T8_ASSERT (t8_forest_is_committed (forest_a));
@@ -349,8 +348,8 @@ t8_forest_is_equal (t8_forest_t forest_a, t8_forest_t forest_b)
     }
     for (ielem = 0; ielem < elems_in_tree_a; ielem++) {
       /* Get pointers to both elements */
-      elem_a = t8_forest_get_element_in_tree (forest_a, itree, ielem);
-      elem_b = t8_forest_get_element_in_tree (forest_b, itree, ielem);
+      const t8_element_t *elem_a = t8_forest_get_element_in_tree (forest_a, itree, ielem);
+      const t8_element_t *elem_b = t8_forest_get_element_in_tree (forest_b, itree, ielem);
       /* check for equality */
       if (ts_a->t8_element_compare (elem_a, elem_b)) {
         /* The elements are not equal */

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -639,7 +639,7 @@ t8_forest_get_element (t8_forest_t forest, t8_locidx_t lelement_id, t8_locidx_t 
  * \note If the tree id is know, this function should be preferred over \ref t8_forest_get_element.
  * \a forest must be committed before calling this function.
  */
-t8_element_t *
+const t8_element_t *
 t8_forest_get_element_in_tree (t8_forest_t forest, t8_locidx_t ltreeid, t8_locidx_t leid_in_tree);
 
 /** Return the number of elements of a tree.

--- a/src/t8_forest/t8_forest_iterate.cxx
+++ b/src/t8_forest/t8_forest_iterate.cxx
@@ -402,9 +402,8 @@ t8_forest_iterate_replace (t8_forest_t forest_new, t8_forest_t forest_old, t8_fo
 #if T8_DEBUG
             /* Check if family of new refined elements is complete */
             T8_ASSERT (ielem_new + family_size <= elems_per_tree_new);
-            t8_element_t *elem_new_debug;
             for (t8_locidx_t ielem = 1; ielem < family_size; ielem++) {
-              elem_new_debug = t8_forest_get_element_in_tree (forest_new, itree, ielem_new + ielem);
+              const t8_element_t *elem_new_debug = t8_forest_get_element_in_tree (forest_new, itree, ielem_new + ielem);
               ts->t8_element_parent (elem_new_debug, elem_parent);
               SC_CHECK_ABORT (!ts->t8_element_compare (elem_old, elem_parent), "Family is not complete.");
             }
@@ -443,10 +442,9 @@ t8_forest_iterate_replace (t8_forest_t forest_new, t8_forest_t forest_old, t8_fo
             T8_ASSERT (family_size <= ts->t8_element_num_children (elem_new));
 #if T8_DEBUG
             /* Check whether elem_old is the first element of the family */
-            t8_element_t *elem_old_debug;
             for (t8_locidx_t ielem = 1; ielem < ts->t8_element_num_children (elem_old) && ielem_old - ielem >= 0;
                  ielem++) {
-              elem_old_debug = t8_forest_get_element_in_tree (forest_old, itree, ielem_old - ielem);
+              const t8_element_t *elem_old_debug = t8_forest_get_element_in_tree (forest_old, itree, ielem_old - ielem);
               ts->t8_element_parent (elem_old_debug, elem_parent);
               SC_CHECK_ABORT (0 != ts->t8_element_compare (elem_new, elem_parent),
                               "elem_old is not the first of the family.");

--- a/src/t8_forest/t8_forest_netcdf.cxx
+++ b/src/t8_forest/t8_forest_netcdf.cxx
@@ -379,7 +379,6 @@ t8_forest_write_netcdf_data (t8_forest_t forest, t8_forest_netcdf_context_t *con
   t8_locidx_t local_elem_id;
   t8_locidx_t num_local_tree_elem;
   t8_element_shape_t element_shape;
-  t8_element_t *element;
   t8_locidx_t local_tree_offset;
   t8_gloidx_t first_local_elem_id;
   t8_gloidx_t num_local_nodes;
@@ -419,7 +418,7 @@ t8_forest_write_netcdf_data (t8_forest_t forest, t8_forest_netcdf_context_t *con
       /* Get the eclass scheme */
       t8_eclass_scheme_c *scheme = t8_forest_get_eclass_scheme (forest, tree_class);
       /* Get the local element in the local tree */
-      element = t8_forest_get_element_in_tree (forest, ltree_id, local_elem_id);
+      const t8_element_t *element = t8_forest_get_element_in_tree (forest, ltree_id, local_elem_id);
       /* Determine the element shape */
       element_shape = scheme->t8_element_shape (element);
       /* Store the type of the element in its global index position */
@@ -675,7 +674,6 @@ t8_forest_write_netcdf_coordinate_data (t8_forest_t forest, t8_forest_netcdf_con
   t8_locidx_t num_local_tree_elem;
   t8_locidx_t local_elem_id;
   t8_locidx_t local_tree_offset;
-  t8_element_t *element;
   t8_element_shape_t element_shape;
   t8_gloidx_t first_local_elem_id;
   size_t num_elements;
@@ -745,7 +743,7 @@ t8_forest_write_netcdf_coordinate_data (t8_forest_t forest, t8_forest_netcdf_con
       /* Get the eclass scheme */
       t8_eclass_scheme_c *scheme = t8_forest_get_eclass_scheme (forest, tree_class);
       /* Get the local element in the local tree */
-      element = t8_forest_get_element_in_tree (forest, ltree_id, local_elem_id);
+      const t8_element_t *element = t8_forest_get_element_in_tree (forest, ltree_id, local_elem_id);
       /* Determine the element shape */
       element_shape = scheme->t8_element_shape (element);
       /* Get the number of nodes for this elements shape */

--- a/src/t8_forest/t8_forest_partition.cxx
+++ b/src/t8_forest/t8_forest_partition.cxx
@@ -253,7 +253,6 @@ t8_forest_partition_create_first_desc (t8_forest_t forest)
 {
   sc_MPI_Comm comm;
   t8_linearidx_t local_first_desc;
-  t8_element_t *first_element = NULL;
   t8_element_t *first_desc = NULL;
   t8_eclass_scheme_c *ts;
 
@@ -280,6 +279,7 @@ t8_forest_partition_create_first_desc (t8_forest_t forest)
     local_first_desc = 0;
   }
   else {
+    const t8_element_t *first_element = NULL;
     /* Get a pointer to the first local element. */
     if (forest->incomplete_trees) {
       for (t8_locidx_t itree = 0; itree < t8_forest_get_num_local_trees (forest); itree++) {

--- a/test/t8_forest/t8_gtest_ghost_exchange.cxx
+++ b/test/t8_forest/t8_gtest_ghost_exchange.cxx
@@ -87,7 +87,6 @@ static void
 t8_test_ghost_exchange_data_id (t8_forest_t forest)
 {
   t8_eclass_scheme_c *ts;
-  t8_element_t *elem;
   size_t array_pos = 0;
   sc_array_t element_data;
 
@@ -102,7 +101,7 @@ t8_test_ghost_exchange_data_id (t8_forest_t forest)
     ts = t8_forest_get_eclass_scheme (forest, t8_forest_get_tree_class (forest, itree));
     for (t8_locidx_t ielem = 0; ielem < t8_forest_get_tree_num_elements (forest, itree); ielem++) {
       /* Get a pointer to this element */
-      elem = t8_forest_get_element_in_tree (forest, itree, ielem);
+      const t8_element_t *elem = t8_forest_get_element_in_tree (forest, itree, ielem);
       /* Compute the linear id of this element */
       t8_linearidx_t elem_id = ts->t8_element_get_linear_id (elem, ts->t8_element_level (elem));
       /* Store this id at the element's index in the array */
@@ -121,7 +120,7 @@ t8_test_ghost_exchange_data_id (t8_forest_t forest)
     ts = t8_forest_get_eclass_scheme (forest, t8_forest_ghost_get_tree_class (forest, itree));
     for (t8_locidx_t ielem = 0; ielem < t8_forest_ghost_tree_num_elements (forest, itree); ielem++) {
       /* Get a pointer to this ghost */
-      elem = t8_forest_ghost_get_element (forest, itree, ielem);
+      const t8_element_t *elem = t8_forest_ghost_get_element (forest, itree, ielem);
       /* Compute its ghost_id */
       t8_linearidx_t ghost_id = ts->t8_element_get_linear_id (elem, ts->t8_element_level (elem));
       /* Compare this id with the entry in the element_data array */

--- a/test/t8_forest/t8_gtest_half_neighbors.cxx
+++ b/test/t8_forest/t8_gtest_half_neighbors.cxx
@@ -91,7 +91,7 @@ TEST_P (forest_half_neighbors, test_half_neighbors)
   /* iterate over all elements */
   for (t8_locidx_t itree = 0; itree < t8_forest_get_num_local_trees (forest); itree++) {
     for (t8_locidx_t ielement = 0; ielement < t8_forest_get_tree_num_elements (forest, itree); ielement++) {
-      t8_element_t *element = t8_forest_get_element_in_tree (forest, itree, ielement);
+      const t8_element_t *element = t8_forest_get_element_in_tree (forest, itree, ielement);
       /* iterate over the faces */
       for (int face = 0; face < ts->t8_element_num_faces (element); face++) {
         /* Get the eclass of the face neighbor and get the scheme */

--- a/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
@@ -95,15 +95,14 @@ t8_forest_replace (t8_forest_t forest_old, t8_forest_t forest_new, t8_locidx_t w
     ASSERT_EQ (num_incoming, 1);
 
     /* Begin check family */
-    t8_element_t *parent = t8_forest_get_element_in_tree (forest_new, which_tree, first_incoming);
-    t8_element_t *child;
+    const t8_element_t *parent = t8_forest_get_element_in_tree (forest_new, which_tree, first_incoming);
     t8_element_t *parent_compare;
     ts->t8_element_new (1, &parent_compare);
     int family_size = 1;
     t8_locidx_t tree_num_elements_old = t8_forest_get_tree_num_elements (forest_old, which_tree);
     for (t8_locidx_t elidx = 1;
          elidx < ts->t8_element_num_children (parent) && elidx + first_outgoing < tree_num_elements_old; elidx++) {
-      child = t8_forest_get_element_in_tree (forest_old, which_tree, first_outgoing + elidx);
+      const t8_element_t *child = t8_forest_get_element_in_tree (forest_old, which_tree, first_outgoing + elidx);
       ts->t8_element_parent (child, parent_compare);
       if (!ts->t8_element_compare (parent, parent_compare)) {
         family_size++;
@@ -128,7 +127,7 @@ t8_forest_replace (t8_forest_t forest_old, t8_forest_t forest_new, t8_locidx_t w
   /* Element got refined. */
   if (refine == 1) {
     ASSERT_EQ (num_outgoing, 1);
-    t8_element_t *element = t8_forest_get_element_in_tree (forest_old, which_tree, first_outgoing);
+    const t8_element_t *element = t8_forest_get_element_in_tree (forest_old, which_tree, first_outgoing);
     const t8_locidx_t family_size = ts->t8_element_num_children (element);
     ASSERT_EQ (num_incoming, family_size);
   }

--- a/test/t8_schemes/t8_gtest_element_ref_coords.cxx
+++ b/test/t8_schemes/t8_gtest_element_ref_coords.cxx
@@ -252,7 +252,7 @@ TEST_P (class_ref_coords, t8_check_elem_ref_coords)
     const t8_eclass_t tree_class = t8_forest_get_tree_class (forest, itree);
     const t8_eclass_scheme_c *ts = t8_forest_get_eclass_scheme (forest, tree_class);
     for (ielement = 0; ielement < t8_forest_get_tree_num_elements (forest, itree); ielement++) {
-      t8_element_t *element = t8_forest_get_element_in_tree (forest, itree, ielement);
+      const t8_element_t *element = t8_forest_get_element_in_tree (forest, itree, ielement);
       t8_test_coords (forest, itree, element, ts);
     }
   }

--- a/tutorials/general/t8_step6_stencil.cxx
+++ b/tutorials/general/t8_step6_stencil.cxx
@@ -136,7 +136,7 @@ t8_step6_create_element_data (t8_forest_t forest)
 
     /* Loop over all local elements in the tree. */
     for (t8_locidx_t ielement = 0; ielement < num_elements_in_tree; ++ielement, ++current_index) {
-      t8_element_t *element = t8_forest_get_element_in_tree (forest, itree, ielement);
+      const t8_element_t *element = t8_forest_get_element_in_tree (forest, itree, ielement);
 
       /* Pointer to our current element data struct. */
       struct data_per_element *edat = &element_data[current_index];
@@ -194,7 +194,7 @@ t8_step6_compute_stencil (t8_forest_t forest, struct data_per_element *element_d
 
     /* Loop over all local elements in the tree. */
     for (t8_locidx_t ielement = 0; ielement < num_elements_in_tree; ++ielement, ++current_index) {
-      t8_element_t *element = t8_forest_get_element_in_tree (forest, itree, ielement);
+      const t8_element_t *element = t8_forest_get_element_in_tree (forest, itree, ielement);
 
       /* Gather center point of the 3x3 stencil. */
       stencil[1][1] = element_data[current_index].height;


### PR DESCRIPTION
**_Describe your changes here:_**

This PR fixes #28.
- `t8_forest_get_element` now returns a `const t8_element_t*`
- `t8_forest_get_element_in_tree` now returns a `const t8_element_t*`

We do these changes since both getter functions are part of the public interface and users should not be able to modify elements of the forest.

Before merging please double check that this integrates easily into user codes. Especially Trixi @jmark 

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
