### PR TITLE
Delete element root len

### DIFF
--- a/example/forest/t8_face_neighbor.cxx
+++ b/example/forest/t8_face_neighbor.cxx
@@ -39,7 +39,7 @@ t8_ghost_neighbor_test (t8_eclass_t eclass, sc_MPI_Comm comm, int hybrid)
   t8_forest_t forest;
   t8_element_t *elem, *neigh;
   t8_scheme_cxx_t *scheme;
-  t8_eclass_scheme_c *elem_scheme, *neigh_scheme;
+  t8_eclass_scheme_c *neigh_scheme;
   t8_default_scheme_common_c *common_scheme;
   int level = 1;
   t8_locidx_t element_id = 0, treeid;
@@ -75,7 +75,6 @@ t8_ghost_neighbor_test (t8_eclass_t eclass, sc_MPI_Comm comm, int hybrid)
   elem = t8_forest_get_element (forest, element_id, &treeid);
   /* Get the scheme corresponding to the element. */
   elem_eclass = t8_forest_get_tree_class (forest, treeid);
-  elem_scheme = t8_forest_get_eclass_scheme (forest, elem_eclass);
   T8_ASSERT (elem != NULL);
 
   /* Iterate over all faces and create the face neighbor */

--- a/example/forest/t8_face_neighbor.cxx
+++ b/example/forest/t8_face_neighbor.cxx
@@ -80,7 +80,6 @@ t8_ghost_neighbor_test (t8_eclass_t eclass, sc_MPI_Comm comm, int hybrid)
 
   /* Iterate over all faces and create the face neighbor */
 
-  t8_debugf ("root len = %i\n", elem_scheme->t8_element_root_len (elem));
   for (i = 0; i < t8_eclass_num_faces[elem_eclass]; i++) {
     /* Get the eclass of the face neighbor's tree */
     neighbor_class = t8_forest_element_neighbor_eclass (forest, treeid, elem, i);

--- a/src/t8_element_c_interface.cxx
+++ b/src/t8_element_c_interface.cxx
@@ -365,14 +365,6 @@ t8_element_successor (const t8_eclass_scheme_c *ts, const t8_element_t *elem1, t
   ts->t8_element_successor (elem1, elem2, level);
 }
 
-int
-t8_element_root_len (const t8_eclass_scheme_c *ts, const t8_element_t *elem)
-{
-  T8_ASSERT (ts != NULL);
-
-  return ts->t8_element_root_len (elem);
-}
-
 void
 t8_element_vertex_reference_coords (const t8_eclass_scheme_c *ts, const t8_element_t *t, const int vertex,
                                     double coords[])

--- a/src/t8_element_c_interface.h
+++ b/src/t8_element_c_interface.h
@@ -558,15 +558,6 @@ t8_element_last_descendant (const t8_eclass_scheme_c *ts, const t8_element_t *el
 void
 t8_element_successor (const t8_eclass_scheme_c *ts, const t8_element_t *elem1, t8_element_t *elem2, int level);
 
-/** Compute the root length of a given element, that is the length of
- * its level 0 ancestor.
- * \param [in] ts       Implementation of a class scheme.
- * \param [in] elem     The element whose root length should be computed.
- * \return              The root length of \a elem
- */
-int
-t8_element_root_len (const t8_eclass_scheme_c *ts, const t8_element_t *elem);
-
 /** Compute the coordinates of a given element vertex inside a reference tree
  *  that is embedded into [0,1]^d (d = dimension).
  * \param [in] ts       Implementation of a class scheme.

--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -596,16 +596,6 @@ struct t8_eclass_scheme
   t8_element_successor (const t8_element_t *t, t8_element_t *s, int level) const
     = 0;
 
-  /* TODO: This function should be removed, since root length is not a general concept that exists for all possible elements. */
-  /** Compute the root length of a given element, that is the length of
-   * its level 0 ancestor.
-   * \param [in] elem     The element whose root length should be computed.
-   * \return              The root length of \a elem
-   */
-  virtual int
-  t8_element_root_len (const t8_element_t *elem) const
-    = 0;
-
   /** Compute the coordinates of a given element vertex inside a reference tree
    *  that is embedded into [0,1]^d (d = dimension).
    *   \param [in] t      The element to be considered.

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -542,13 +542,6 @@ t8_default_scheme_hex_c::t8_element_anchor (const t8_element_t *elem, int coord[
   coord[2] = q->z;
 }
 
-int
-t8_default_scheme_hex_c::t8_element_root_len (const t8_element_t *elem) const
-{
-  T8_ASSERT (t8_element_is_valid (elem));
-  return P8EST_ROOT_LEN;
-}
-
 void
 t8_default_scheme_hex_c::t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
 {

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -516,14 +516,6 @@ struct t8_default_scheme_hex_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
-  /** Compute the root length of a given element, that is the length of
-   * its level 0 ancestor.
-   * \param [in] elem     The element whose root length should be computed.
-   * \return              The root length of \a elem
-   */
-  virtual int
-  t8_element_root_len (const t8_element_t *elem) const;
-
   /** Compute the integer coordinates of a given element vertex.
    * The default scheme implements the Morton type SFCs. In these SFCs the
    * elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and 

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
@@ -304,13 +304,6 @@ t8_default_scheme_line_c::t8_element_reference_coords (const t8_element_t *elem,
   t8_dline_compute_reference_coords ((const t8_dline_t *) elem, ref_coords, num_coords, 0, out_coords);
 }
 
-int
-t8_default_scheme_line_c::t8_element_root_len (const t8_element_t *elem) const
-{
-  T8_ASSERT (t8_element_is_valid (elem));
-  return T8_DLINE_ROOT_LEN;
-}
-
 t8_linearidx_t
 t8_default_scheme_line_c::t8_element_get_linear_id (const t8_element_t *elem, int level) const
 {

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
@@ -534,13 +534,6 @@ struct t8_default_scheme_line_c: public t8_default_scheme_common_c
     SC_ABORT ("This function is not implemented yet.\n");
     return; /* suppresses compiler warning */
   }
-  /** Compute the root length of a given element, that is the length of
-   * its level 0 ancestor.
-   * \param [in] elem     The element whose root length should be computed.
-   * \return              The root length of \a elem
-   */
-  virtual int
-  t8_element_root_len (const t8_element_t *elem) const;
 
   /** Compute the integer coordinates of a given element vertex.
    * The default scheme implements the Morton type SFCs. In these SFCs the

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -381,13 +381,6 @@ t8_default_scheme_prism_c::t8_element_anchor (const t8_element_t *elem, int anch
   anchor[2] = prism->line.x / T8_DLINE_ROOT_LEN * T8_DPRISM_ROOT_LEN;
 }
 
-int
-t8_default_scheme_prism_c::t8_element_root_len (const t8_element_t *elem) const
-{
-  T8_ASSERT (t8_element_is_valid (elem));
-  return T8_DPRISM_ROOT_LEN;
-}
-
 void
 t8_default_scheme_prism_c::t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
 {

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
@@ -506,13 +506,6 @@ struct t8_default_scheme_prism_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
-  /** Compute the root length of a given element, that is the length of its level 0 ancestor.
-   * \param [in] elem     The element whose root length should be computed.
-   * \return              The root length of \a elem
-   */
-  virtual int
-  t8_element_root_len (const t8_element_t *elem) const;
-
   /** Compute the integer coordinates of a given element vertex. The default scheme implements the Morton type SFCs. 
    * In these SFCs the elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and L the maximum 
    * refinement level. All element vertices have integer coordinates in this cube.

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -231,13 +231,6 @@ t8_default_scheme_pyramid_c::t8_element_level (const t8_element_t *elem) const
   return t8_dpyramid_get_level ((const t8_dpyramid_t *) elem);
 }
 
-int
-t8_default_scheme_pyramid_c::t8_element_root_len (const t8_element_t *elem) const
-{
-  T8_ASSERT (t8_element_is_valid (elem));
-  return T8_DPYRAMID_ROOT_LEN;
-}
-
 void
 t8_default_scheme_pyramid_c::t8_element_set_linear_id (t8_element_t *elem, int level, t8_linearidx_t id) const
 {

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
@@ -498,13 +498,6 @@ struct t8_default_scheme_pyramid_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
-  /** Compute the root length of a given element, that is the length of its level 0 ancestor.
-   * \param [in] elem     The element whose root length should be computed.
-   * \return              The root length of \a elem
-   */
-  virtual int
-  t8_element_root_len (const t8_element_t *elem) const;
-
   /** Compute the integer coordinates of a given element vertex. The default scheme implements the Morton type SFCs. 
    * In these SFCs the elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and  L the maximum 
    * refinement level. All element vertices have integer coordinates in this cube.

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -674,12 +674,6 @@ t8_default_scheme_quad_c::t8_element_anchor (const t8_element_t *elem, int coord
   T8_QUAD_SET_TDIM (q, 2);
 }
 
-int
-t8_default_scheme_quad_c::t8_element_root_len (const t8_element_t *elem) const
-{
-  return P4EST_ROOT_LEN;
-}
-
 void
 t8_default_scheme_quad_c::t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
 {

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -551,14 +551,6 @@ struct t8_default_scheme_quad_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
-  /** Compute the root length of a given element, that is the length of
-   * its level 0 ancestor.
-   * \param [in] elem     The element whose root length should be computed.
-   * \return              The root length of \a elem
-   */
-  virtual int
-  t8_element_root_len (const t8_element_t *elem) const;
-
   /** Compute the integer coordinates of a given element vertex.
    * The default scheme implements the Morton type SFCs. In these SFCs the
    * elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and 

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
@@ -455,13 +455,6 @@ t8_default_scheme_tet_c::t8_element_anchor (const t8_element_t *elem, int anchor
   anchor[2] = tet->z;
 }
 
-int
-t8_default_scheme_tet_c::t8_element_root_len (const t8_element_t *elem) const
-{
-  T8_ASSERT (t8_element_is_valid (elem));
-  return T8_DTET_ROOT_LEN;
-}
-
 void
 t8_default_scheme_tet_c::t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
 {

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
@@ -465,13 +465,6 @@ struct t8_default_scheme_tet_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
-  /** Compute the root length of a given element, that is the length ofits level 0 ancestor.
-   * \param [in] elem     The element whose root length should be computed.
-   * \return              The root length of \a elem
-   */
-  virtual int
-  t8_element_root_len (const t8_element_t *elem) const;
-
   /** Compute the integer coordinates of a given element vertex. The default scheme implements the Morton type SFCs. 
    * In these SFCs the elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and L the maximum 
    * refinement level. All element vertices have integer coordinates in this cube.

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
@@ -469,13 +469,6 @@ t8_default_scheme_tri_c::t8_element_anchor (const t8_element_t *elem, int anchor
   anchor[2] = 0;
 }
 
-int
-t8_default_scheme_tri_c::t8_element_root_len (const t8_element_t *elem) const
-{
-  T8_ASSERT (t8_element_is_valid (elem));
-  return T8_DTRI_ROOT_LEN;
-}
-
 void
 t8_default_scheme_tri_c::t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
 {

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
@@ -459,13 +459,6 @@ struct t8_default_scheme_tri_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
-  /** Compute the root length of a given element, that is the length of its level 0 ancestor.
-   * \param [in] elem     The element whose root length should be computed.
-   * \return              The root length of \a elem
-   */
-  virtual int
-  t8_element_root_len (const t8_element_t *elem) const;
-
   /** Compute the integer coordinates of a given element vertex. The default scheme implements the Morton type SFCs. 
    * In these SFCs the elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and L the maximum 
    * refinement level. All element vertices have integer coordinates in this cube.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
@@ -242,13 +242,6 @@ t8_default_scheme_vertex_c::t8_element_anchor (const t8_element_t *elem, int anc
   anchor[2] = 0;
 }
 
-int
-t8_default_scheme_vertex_c::t8_element_root_len (const t8_element_t *elem) const
-{
-  T8_ASSERT (t8_element_is_valid (elem));
-  return T8_DVERTEX_ROOT_LEN;
-}
-
 void
 t8_default_scheme_vertex_c::t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
 {

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
@@ -561,14 +561,6 @@ struct t8_default_scheme_vertex_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
-  /** Compute the root length of a given element, that is the length of
-   * its level 0 ancestor.
-   * \param [in] elem     The element whose root length should be computed.
-   * \return              The root length of \a elem
-   */
-  virtual int
-  t8_element_root_len (const t8_element_t *elem) const;
-
   /** Compute the integer coordinates of a given element vertex.
    * The default scheme implements the Morton type SFCs. In these SFCs the
    * elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and 


### PR DESCRIPTION
Element root len was only used for debug-output. 
Deleted the debugging output and the function



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
