### PR TITLE
Enhance eclass scheme is default

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_cxx.cxx
@@ -74,9 +74,10 @@ t8_eclass_scheme_is_default (t8_eclass_scheme_c *ts)
     return T8_COMMON_IS_TYPE (ts, t8_default_scheme_tet_c *);
   case T8_ECLASS_PRISM:
     return T8_COMMON_IS_TYPE (ts, t8_default_scheme_prism_c *);
+  case T8_ECLASS_PYRAMID:
+    return T8_COMMON_IS_TYPE (ts, t8_default_scheme_pyramid_c *);
   default:
     SC_ABORT_NOT_REACHED ();
-    /* TODO: Add pyramid as soon as pyramid scheme is implemented */
     /* TODO: Add a test for this function */
   }
   return 0; /* Default return value false */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -48,7 +48,8 @@ t8code_googletest_programs = \
   test/t8_forest_incomplete/t8_gtest_recursive \
   test/t8_forest_incomplete/t8_gtest_iterate_replace \
   test/t8_forest_incomplete/t8_gtest_empty_local_tree \
-  test/t8_forest_incomplete/t8_gtest_empty_global_tree
+  test/t8_forest_incomplete/t8_gtest_empty_global_tree \
+  test/t8_schemes/t8_gtest_default
 
 test_t8_IO_t8_gtest_vtk_reader_SOURCES = \
   test/t8_gtest_main.cxx \
@@ -233,6 +234,10 @@ test_t8_forest_incomplete_t8_gtest_empty_local_tree_SOURCES = \
 test_t8_forest_incomplete_t8_gtest_empty_global_tree_SOURCES = \
   test/t8_gtest_main.cxx \
   test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
+
+test_t8_schemes_t8_gtest_default_SOURCES = \
+  test/t8_gtest_main.cxx \
+  test/t8_schemes/t8_gtest_default.cxx  
 
 #define ld and cpp flags for all targets
 t8_gtest_target_ld_add = $(LDADD) test/libgtest.la
@@ -427,6 +432,11 @@ test_t8_forest_incomplete_t8_gtest_empty_global_tree_LDADD = $(t8_gtest_target_l
 test_t8_forest_incomplete_t8_gtest_empty_global_tree_LDFLAGS = $(t8_gtest_target_ld_flags)
 test_t8_forest_incomplete_t8_gtest_empty_global_tree_CPPFLAGS = $(t8_gtest_target_cpp_flags)
 
+test_t8_schemes_t8_gtest_default_LDADD = $(t8_gtest_target_ld_add)
+test_t8_schemes_t8_gtest_default_LDFLAGS = $(t8_gtest_target_ld_flags)
+test_t8_schemes_t8_gtest_default_CPPFLAGS = $(t8_gtest_target_cpp_flags)
+
+
 # If we did not configure t8code with MPI we need to build Googletest
 # without MPI support.
 if !T8_ENABLE_MPI
@@ -476,6 +486,7 @@ test_t8_forest_incomplete_t8_gtest_recursive_CPPFLAGS += $(t8_gtest_target_mpi_c
 test_t8_forest_incomplete_t8_gtest_iterate_replace_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_forest_incomplete_t8_gtest_empty_local_tree_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_forest_incomplete_t8_gtest_empty_global_tree_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
+test_t8_schemes_t8_gtest_default_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 endif
 
 # Build Googletest library

--- a/test/t8_schemes/t8_gtest_default.cxx
+++ b/test/t8_schemes/t8_gtest_default.cxx
@@ -1,0 +1,89 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element types in parallel.
+
+  Copyright (C) 2023 The University of Texas System
+  Written by Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_gtest_default.cxx
+* Provide tests to check the functionality of the default-scheme. 
+*/
+
+#include <gtest/gtest.h>
+#include <t8_schemes/t8_default/t8_default_cxx.hxx>
+
+#include <t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx>
+#include <t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx>
+#include <t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx>
+#include <t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx>
+#include <t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx>
+#include <t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx>
+#include <t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx>
+#include <t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx>
+
+class gtest_default_scheme: public testing::TestWithParam<t8_eclass_t> {
+ protected:
+  void
+  SetUp () override
+  {
+    const t8_eclass_t eclass = GetParam ();
+    switch (eclass) {
+    case T8_ECLASS_VERTEX:
+      eclass_scheme = new t8_default_scheme_vertex_c ();
+      break;
+    case T8_ECLASS_LINE:
+      eclass_scheme = new t8_default_scheme_line_c ();
+      break;
+    case T8_ECLASS_QUAD:
+      eclass_scheme = new t8_default_scheme_quad_c ();
+      break;
+    case T8_ECLASS_TRIANGLE:
+      eclass_scheme = new t8_default_scheme_tri_c ();
+      break;
+    case T8_ECLASS_HEX:
+      eclass_scheme = new t8_default_scheme_hex_c ();
+      break;
+    case T8_ECLASS_TET:
+      eclass_scheme = new t8_default_scheme_tet_c ();
+      break;
+    case T8_ECLASS_PRISM:
+      eclass_scheme = new t8_default_scheme_prism_c ();
+      break;
+    case T8_ECLASS_PYRAMID:
+      eclass_scheme = new t8_default_scheme_pyramid_c ();
+      break;
+    default:
+      SC_ABORT_NOT_REACHED ();
+    }
+  }
+  void
+  TearDown () override
+  {
+    delete (eclass_scheme);
+  }
+  t8_eclass_scheme_c *eclass_scheme;
+};
+
+TEST_P (gtest_default_scheme, is_default)
+{
+  EXPECT_TRUE (t8_eclass_scheme_is_default (eclass_scheme));
+}
+
+INSTANTIATE_TEST_SUITE_P (t8_gtest_default_scheme, gtest_default_scheme,
+                          testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));

--- a/test/t8_schemes/t8_gtest_default.cxx
+++ b/test/t8_schemes/t8_gtest_default.cxx
@@ -42,6 +42,7 @@ class gtest_default_scheme: public testing::TestWithParam<t8_eclass_t> {
   void
   SetUp () override
   {
+    /* Construct every eclass scheme explixitly */
     const t8_eclass_t eclass = GetParam ();
     switch (eclass) {
     case T8_ECLASS_VERTEX:
@@ -82,6 +83,7 @@ class gtest_default_scheme: public testing::TestWithParam<t8_eclass_t> {
 
 TEST_P (gtest_default_scheme, is_default)
 {
+  /* TODO: Implement an EXPECT_FALSE check for non-default schemes */
   EXPECT_TRUE (t8_eclass_scheme_is_default (eclass_scheme));
 }
 


### PR DESCRIPTION
Implements a basic check if a scheme is a default scheme. 
With further schemes we should add an EXPECT_FALSE check, too. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
