### PR TITLE
Fixed TODO for code duplication in t8_cmesh_examples.c

### DIFF
--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -40,8 +40,8 @@
  * \param [in] comm The MPi communicator to use for the partition
  */
 static void
-t8_cmesh_examples_compute_and_set_partition_range (t8_cmesh_t cmesh, const int num_trees, const int set_face_knowledge,
-                                                   sc_MPI_Comm comm)
+t8_cmesh_examples_compute_and_set_partition_range (t8_cmesh_t cmesh, const t8_gloidx_t num_trees,
+                                                   const int set_face_knowledge, sc_MPI_Comm comm)
 {
   int mpirank, mpisize, mpiret;
 
@@ -155,7 +155,7 @@ t8_cmesh_new_from_p4est_ext (void *conn, int dim, sc_MPI_Comm comm, int set_part
       SC_CHECK_MPI (mpiret);
 
       /* First_tree and last_tree are the first and last trees of conn plus the offset */
-      const t8_gloidx_t num_local_trees = _T8_CMESH_P48_CONN (num_trees);
+      t8_gloidx_t num_local_trees = _T8_CMESH_P48_CONN (num_trees);
 
       /* First process-local tree-id */
       const t8_gloidx_t first_tree = offset;
@@ -169,7 +169,9 @@ t8_cmesh_new_from_p4est_ext (void *conn, int dim, sc_MPI_Comm comm, int set_part
 #ifdef T8_ENABLE_DEBUG
       t8_gloidx_t num_global_trees;
       /* The global number of trees is the sum over all numbers of trees in conn on each process */
-      sc_MPI_Allreduce (&num_local_trees, &num_global_trees, 1, T8_MPI_GLOIDX, sc_MPI_SUM, comm);
+      mpiret = sc_MPI_Allreduce (&num_local_trees, &num_global_trees, 1, T8_MPI_GLOIDX, sc_MPI_SUM, comm);
+      SC_CHECK_MPI (mpiret);
+
       t8_debugf ("Generating partitioned cmesh from connectivity\n"
                  "Has %li global and %li local trees.\n",
                  num_global_trees, num_local_trees);

--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -30,6 +30,39 @@
 #include <t8_mat.h>
 #include <t8_eclass.h>
 
+/**
+ * \brief This function calculates an 'equal' partition for the cmesh based on the \var number of trees supplied
+ *  and stores the computed partition range within the \var cmesh.
+ * 
+ * \param [in,out] cmesh The cmesh for which the partition will be calculated
+ * \param [in] num_trees The number of trees the cmesh consists of
+ * \param [in] set_face_knowledge Set how much information is required on face connections (\see t8_cmesh_set_partition_range)
+ * \param [in] comm The MPi communicator to use for the partition
+ */
+static void
+t8_cmesh_examples_compute_and_set_partition_range (t8_cmesh_t cmesh, const int num_trees, const int set_face_knowledge,
+                                                   sc_MPI_Comm comm)
+{
+  int mpirank, mpisize, mpiret;
+
+  /* Obtain the rank of this process */
+  mpiret = sc_MPI_Comm_rank (comm, &mpirank);
+  SC_CHECK_MPI (mpiret);
+
+  /* Obtain the size of the communicator */
+  mpiret = sc_MPI_Comm_size (comm, &mpisize);
+  SC_CHECK_MPI (mpiret);
+
+  /* Calculate the first process-local tree-id of an equal partition */
+  const t8_gloidx_t first_tree = (mpirank * num_trees) / mpisize;
+
+  /* Calculate the last process-local tree-id of an equal partition */
+  const t8_gloidx_t last_tree = ((mpirank + 1) * num_trees) / mpisize - 1;
+
+  /* Set the calculated partition */
+  t8_cmesh_set_partition_range (cmesh, set_face_knowledge, first_tree, last_tree);
+}
+
 /* TODO: In p4est a tree edge is joined with itself to denote a domain boundary.
  *       Will we do it the same in t8code? This is not yet decided, however the
  *       function below stores these neighbourhood information in the cmesh. */
@@ -103,37 +136,50 @@ t8_cmesh_new_from_p4est_ext (void *conn, int dim, sc_MPI_Comm comm, int set_part
       }
     }
   }
-  if (set_partition) {
-    /* TODO: a copy of this code exists below, make it a function */
-    int mpirank, mpisize, mpiret;
-    t8_gloidx_t first_tree, last_tree, num_trees, num_local_trees;
 
-    mpiret = sc_MPI_Comm_rank (comm, &mpirank);
-    SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Comm_size (comm, &mpisize);
-    SC_CHECK_MPI (mpiret);
+  /* Check whether the cmesh will be partitioned */
+  if (set_partition) {
     if (use_offset == 0) {
-      /* The total number of trees is the number of trees in conn */
-      num_trees = _T8_CMESH_P48_CONN (num_trees);
-      /* First tree and last tree according to uniform level 0 partitioning */
-      first_tree = (mpirank * num_trees) / mpisize;
-      last_tree = ((mpirank + 1) * num_trees) / mpisize - 1;
+      /* Set the partition (without offsets) */
+      t8_cmesh_examples_compute_and_set_partition_range (cmesh, _T8_CMESH_P48_CONN (num_trees), 3, comm);
     }
     else {
-      /* First_tree and last_tree are the first and last trees of conn plu the offset */
-      num_local_trees = _T8_CMESH_P48_CONN (num_trees);
-      first_tree = offset;
-      last_tree = offset + num_local_trees - 1;
-      /* The global number of trees is the sum over all numbers of trees
-       * in conn on each process */
-      sc_MPI_Allreduce (&num_local_trees, &num_trees, 1, T8_MPI_GLOIDX, sc_MPI_SUM, comm);
+      int mpirank, mpisize, mpiret;
+
+      /* Get the rank */
+      mpiret = sc_MPI_Comm_rank (comm, &mpirank);
+      SC_CHECK_MPI (mpiret);
+
+      /* Get the size of the communicator in which the cmesh will be partitioned */
+      mpiret = sc_MPI_Comm_size (comm, &mpisize);
+      SC_CHECK_MPI (mpiret);
+
+      /* First_tree and last_tree are the first and last trees of conn plus the offset */
+      const t8_gloidx_t num_local_trees = _T8_CMESH_P48_CONN (num_trees);
+
+      /* First process-local tree-id */
+      const t8_gloidx_t first_tree = offset;
+
+      /* Last process-local tree-id */
+      const t8_gloidx_t last_tree = offset + num_local_trees - 1;
+
+      /* Set the partition (with offsets) */
+      t8_cmesh_set_partition_range (cmesh, 3, first_tree, last_tree);
+
+#ifdef T8_ENABLE_DEBUG
+      t8_gloidx_t num_global_trees;
+      /* The global number of trees is the sum over all numbers of trees in conn on each process */
+      sc_MPI_Allreduce (&num_local_trees, &num_global_trees, 1, T8_MPI_GLOIDX, sc_MPI_SUM, comm);
       t8_debugf ("Generating partitioned cmesh from connectivity\n"
                  "Has %li global and %li local trees.\n",
-                 num_trees, num_local_trees);
+                 num_global_trees, num_local_trees);
+#endif
     }
-    t8_cmesh_set_partition_range (cmesh, 3, first_tree, last_tree);
   }
+
+  /* Commit the constructed cmesh */
   t8_cmesh_commit (cmesh, comm);
+
   return cmesh;
 #undef _T8_CMESH_P48_CONN
 }
@@ -802,19 +848,13 @@ t8_cmesh_new_hypercube (t8_eclass_t eclass, sc_MPI_Comm comm, int do_bcast, int 
    * cannot bcast the geometries. */
   t8_cmesh_register_geometry (cmesh, linear_geom);
 
+  /* Check whether the cmesh will be partitioned */
   if (do_partition) {
-    int mpirank, mpisize, mpiret;
-    int first_tree, last_tree, num_trees;
-    mpiret = sc_MPI_Comm_rank (comm, &mpirank);
-    SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Comm_size (comm, &mpisize);
-    SC_CHECK_MPI (mpiret);
-    num_trees = num_trees_for_hypercube[eclass];
-    first_tree = (mpirank * num_trees) / mpisize;
-    last_tree = ((mpirank + 1) * num_trees) / mpisize - 1;
-    t8_cmesh_set_partition_range (cmesh, 3, first_tree, last_tree);
+    /* Compute and set the partition for the cmesh */
+    t8_cmesh_examples_compute_and_set_partition_range (cmesh, num_trees_for_hypercube[eclass], 3, comm);
   }
 
+  /* Commit the constructed cmesh */
   t8_cmesh_commit (cmesh, comm);
   return cmesh;
 }
@@ -2643,19 +2683,15 @@ t8_cmesh_new_row_of_cubes (t8_locidx_t num_trees, const int set_attributes, cons
     t8_cmesh_set_join (cmesh, tree_id, tree_id + 1, 0, 1, 0);
   }
 
+  /* Check whether the cmesh will be partitioed */
   if (do_partition) {
-    int mpirank, mpisize, mpiret;
-    int first_tree, last_tree;
-    mpiret = sc_MPI_Comm_rank (comm, &mpirank);
-    SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Comm_size (comm, &mpisize);
-    SC_CHECK_MPI (mpiret);
-    first_tree = (mpirank * num_trees) / mpisize;
-    last_tree = ((mpirank + 1) * num_trees) / mpisize - 1;
-    t8_cmesh_set_partition_range (cmesh, 3, first_tree, last_tree);
+    /* Set a uniform partition of the cmesh */
+    t8_cmesh_examples_compute_and_set_partition_range (cmesh, (int) num_trees, 3, comm);
   }
 
+  /* Commit the constructed cmesh */
   t8_cmesh_commit (cmesh, comm);
+
   return cmesh;
 }
 


### PR DESCRIPTION
**_Describe your changes here:_**
Implemented a function for redundant computations and function calls in t8_cmesh_examples.c


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
