### PR TITLE
Update cmesh partition alternative sendrecv range

### DIFF
--- a/src/t8_cmesh/t8_cmesh_partition.c
+++ b/src/t8_cmesh/t8_cmesh_partition.c
@@ -246,16 +246,9 @@ t8_cmesh_gather_treecount_nocommit (t8_cmesh_t cmesh, sc_MPI_Comm comm)
   t8_cmesh_gather_treecount_ext (cmesh, comm, 0);
 }
 
-/* TODO: currently this function is unused.
- *        Also it better fits to cmesh_offset.c/h */
-
-/* TODO: deprecated, can be removed */
-
-/* TODO: deprecated. Can be removed */
-
 /* A much faster version to compute the sendrange */
 static t8_locidx_t
-t8_cmesh_partition_alternative_sendrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *send_first, int *send_last)
+t8_cmesh_partition_sendrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *send_first, int *send_last)
 {
   t8_gloidx_t first_tree = t8_cmesh_get_first_treeid (cmesh_from), last_tree;
   t8_gloidx_t ret;
@@ -995,7 +988,7 @@ t8_cmesh_partition_sendloop (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *num_r
 
   sc_array_init (&send_as_ghost, sizeof (t8_locidx_t));
 
-  range_end = t8_cmesh_partition_alternative_sendrange (cmesh, (t8_cmesh_t) cmesh_from, send_first, send_last);
+  range_end = t8_cmesh_partition_sendrange (cmesh, (t8_cmesh_t) cmesh_from, send_first, send_last);
 
   offset_to = t8_shmem_array_get_gloidx_array (cmesh->tree_offsets);
   if (cmesh_from->set_partition) {

--- a/src/t8_cmesh/t8_cmesh_partition.c
+++ b/src/t8_cmesh/t8_cmesh_partition.c
@@ -400,7 +400,7 @@ t8_cmesh_partition_sendrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *send
 
 /* A much faster version to compute the receive range */
 static void
-t8_cmesh_partition_alternative_recvrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *recv_first, int *recv_last)
+t8_cmesh_partition_recvrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *recv_first, int *recv_last)
 {
   t8_gloidx_t first_tree, last_tree;
   const t8_gloidx_t *offset_to;
@@ -1250,7 +1250,7 @@ t8_cmesh_partition_recvloop (t8_cmesh_t cmesh, const struct t8_cmesh *cmesh_from
   if (cmesh_from->set_partition) {
     T8_ASSERT (cmesh_from->tree_offsets != NULL);
     from_offsets = t8_shmem_array_get_gloidx_array (cmesh_from->tree_offsets);
-    t8_cmesh_partition_alternative_recvrange (cmesh, (t8_cmesh_t) cmesh_from, &recv_first, &recv_last);
+    t8_cmesh_partition_recvrange (cmesh, (t8_cmesh_t) cmesh_from, &recv_first, &recv_last);
 #if T8_ENABLE_DEBUG
     if (recv_first <= recv_last) {
       T8_ASSERT (fr == recv_first);

--- a/src/t8_cmesh/t8_cmesh_partition.c
+++ b/src/t8_cmesh/t8_cmesh_partition.c
@@ -400,10 +400,7 @@ t8_cmesh_partition_sendrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *send
 static void
 t8_cmesh_partition_recvrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *recv_first, int *recv_last)
 {
-  t8_gloidx_t first_tree, last_tree;
-  const t8_gloidx_t *offset_to;
-  const t8_gloidx_t *offset_from;
-  int alternative_recvfirst, alternative_recvlast;
+  int recvfirst, recvlast;
   int some_owner = -1; /* Passes as argument to first/last owner functions */
 
   if (cmesh->num_local_trees == 0) {
@@ -419,27 +416,27 @@ t8_cmesh_partition_recvrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *recv
     *recv_last = cmesh_from->mpirank;
     return;
   }
-  offset_to = t8_shmem_array_get_gloidx_array (cmesh->tree_offsets);
-  offset_from = t8_shmem_array_get_gloidx_array (cmesh_from->tree_offsets);
+  const t8_gloidx_t *offset_to = t8_shmem_array_get_gloidx_array (cmesh->tree_offsets);
+  const t8_gloidx_t *offset_from = t8_shmem_array_get_gloidx_array (cmesh_from->tree_offsets);
   /* Get the new first local tree */
-  first_tree = t8_cmesh_get_first_treeid (cmesh);
+  const t8_gloidx_t first_tree = t8_cmesh_get_first_treeid (cmesh);
   if (t8_offset_in_range (first_tree, cmesh->mpirank, offset_from)) {
     /* It it already was a local tree then we received it from ourselves
      * and are thus the first process we receive from */
-    alternative_recvfirst = cmesh->mpirank;
+    recvfirst = cmesh->mpirank;
   }
   else {
     /* Otherwise the first process we receive from is the smallest process that
      * had our new first tree as a local tree. */
     some_owner = -1;
-    alternative_recvfirst = t8_offset_first_owner_of_tree (cmesh->mpisize, first_tree, offset_from, &some_owner);
+    recvfirst = t8_offset_first_owner_of_tree (cmesh->mpisize, first_tree, offset_from, &some_owner);
   }
   /* Get the new last local tree */
-  last_tree = t8_offset_last (cmesh->mpirank, offset_to);
+  const t8_gloidx_t last_tree = t8_offset_last (cmesh->mpirank, offset_to);
   if (t8_offset_in_range (last_tree, cmesh->mpirank, offset_from)) {
     /* We had our last local tree as a local tree before and thus
      * we are the last process that we receive from */
-    alternative_recvlast = cmesh->mpirank;
+    recvlast = cmesh->mpirank;
   }
   else {
     /* We receive from the smallest process that had our new last local tree
@@ -449,10 +446,10 @@ t8_cmesh_partition_recvrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *recv
        * otherwise we have to reset it */
       some_owner = -1;
     }
-    alternative_recvlast = t8_offset_first_owner_of_tree (cmesh->mpisize, last_tree, offset_from, &some_owner);
+    recvlast = t8_offset_first_owner_of_tree (cmesh->mpisize, last_tree, offset_from, &some_owner);
   }
-  *recv_first = alternative_recvfirst;
-  *recv_last = alternative_recvlast;
+  *recv_first = recvfirst;
+  *recv_last = recvlast;
 }
 
 /* Compute the number of bytes that need to be allocated in the send buffer

--- a/src/t8_cmesh/t8_cmesh_partition.c
+++ b/src/t8_cmesh/t8_cmesh_partition.c
@@ -246,7 +246,7 @@ t8_cmesh_gather_treecount_nocommit (t8_cmesh_t cmesh, sc_MPI_Comm comm)
   t8_cmesh_gather_treecount_ext (cmesh, comm, 0);
 }
 
-/* A much faster version to compute the sendrange */
+/* A fast way to compute the sendrange */
 static t8_locidx_t
 t8_cmesh_partition_sendrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *send_first, int *send_last)
 {
@@ -395,7 +395,7 @@ t8_cmesh_partition_sendrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *send
   return (t8_locidx_t) ret;
 }
 
-/* A much faster version to compute the receive range */
+/* A fast way to compute the receive range */
 static void
 t8_cmesh_partition_recvrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *recv_first, int *recv_last)
 {


### PR DESCRIPTION
It is the only function that exits to send/recvrange, therefore it is not necessary to call it the alternative.
Updated the name and improved some minor parts of the code.



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
