### PR TITLE
Introduce interface function t8_element_equal

### DIFF
--- a/src/t8_element_c_interface.cxx
+++ b/src/t8_element_c_interface.cxx
@@ -86,6 +86,14 @@ t8_element_compare (const t8_eclass_scheme_c *ts, const t8_element_t *elem1, con
   return ts->t8_element_compare (elem1, elem2);
 }
 
+int
+t8_element_equal (const t8_eclass_scheme_c *ts, const t8_element_t *elem1, const t8_element_t *elem2)
+{
+  T8_ASSERT (ts != NULL);
+
+  return ts->t8_element_equal (elem1, elem2);
+}
+
 void
 t8_element_parent (const t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_element_t *parent)
 {

--- a/src/t8_element_c_interface.h
+++ b/src/t8_element_c_interface.h
@@ -83,7 +83,7 @@ t8_element_level (const t8_eclass_scheme_c *ts, const t8_element_t *elem);
 void
 t8_element_copy (const t8_eclass_scheme_c *ts, const t8_element_t *source, t8_element_t *dest);
 
-/** Compare two elements.
+/** Compare two elements with respect to the scheme.
  * \param [in] ts     Implementation of a class scheme.
  * \param [in] elem1  The first element.
  * \param [in] elem2  The second element.
@@ -93,6 +93,15 @@ t8_element_copy (const t8_eclass_scheme_c *ts, const t8_element_t *source, t8_el
  */
 int
 t8_element_compare (const t8_eclass_scheme_c *ts, const t8_element_t *elem1, const t8_element_t *elem2);
+
+/** Check if two elements are equal.
+ * \param [in] ts     Implementation of a class scheme.
+ * \param [in] elem1  The first element.
+ * \param [in] elem2  The second element.
+ * \return            1 if the elements are equal, 0 if they are not equal
+ */
+int
+t8_element_equal (const t8_eclass_scheme_c *ts, const t8_element_t *elem1, const t8_element_t *elem2);
 
 /** Compute the parent of a given element \b elem and store it in \b parent.
  *  \b parent needs to be an existing element. No memory is allocated by this function.

--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -127,6 +127,16 @@ struct t8_eclass_scheme
   t8_element_compare (const t8_element_t *elem1, const t8_element_t *elem2) const
     = 0;
 
+  /** Check if two elements are equal.
+  * \param [in] ts     Implementation of a class scheme.
+  * \param [in] elem1  The first element.
+  * \param [in] elem2  The second element.
+  * \return            1 if the elements are equal, 0 if they are not equal
+  */
+  virtual int
+  t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const
+    = 0;
+
   /** Compute the parent of a given element \b elem and store it in \b parent.
    *  \b parent needs to be an existing element. No memory is allocated by this function.
    *  \b elem and \b parent can point to the same element, then the entries of

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -63,7 +63,7 @@ t8_forest_is_family_callback (t8_eclass_scheme_c *ts, const int num_elements, t8
 
   for (int iter = 0; iter < num_elements; iter++) {
     ts->t8_element_parent (elements[iter], element_parent_compare);
-    if (ts->t8_element_compare (element_parent, element_parent_compare)) {
+    if (!ts->t8_element_equal (element_parent, element_parent_compare)) {
       ts->t8_element_destroy (1, &element_parent);
       ts->t8_element_destroy (1, &element_parent_compare);
       return 0;
@@ -73,7 +73,7 @@ t8_forest_is_family_callback (t8_eclass_scheme_c *ts, const int num_elements, t8
   if (num_elements < ts->t8_element_num_siblings (elements[0])) {
     for (int iter = num_elements; iter < num_elements; iter++) {
       ts->t8_element_parent (elements[iter], element_parent_compare);
-      if (!ts->t8_element_compare (element_parent, element_parent_compare)) {
+      if (ts->t8_element_equal (element_parent, element_parent_compare)) {
         ts->t8_element_destroy (1, &element_parent);
         ts->t8_element_destroy (1, &element_parent_compare);
         return 0;
@@ -155,7 +155,7 @@ t8_forest_pos (t8_forest_t forest, t8_eclass_scheme_c *ts, t8_element_array_t *t
       break;
     }
     ts->t8_element_parent (element_compare, element_parent_compare);
-    if (ts->t8_element_compare (element_parent, element_parent_compare)) {
+    if (!ts->t8_element_equal (element_parent, element_parent_compare)) {
       break;
     }
   }

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -114,7 +114,7 @@ t8_forest_is_incomplete_family (const t8_forest_t forest, const t8_locidx_t ltre
     }
     tscheme->t8_element_parent (elements[family_iter], element_compare);
     /* If the levels are equal, check if the parents are too. */
-    if (0 != tscheme->t8_element_compare (element_parent_current, element_compare)) {
+    if (!tscheme->t8_element_equal (element_parent_current, element_compare)) {
       family_size = family_iter;
       break;
     }
@@ -352,7 +352,7 @@ t8_forest_is_equal (t8_forest_t forest_a, t8_forest_t forest_b)
       elem_a = t8_forest_get_element_in_tree (forest_a, itree, ielem);
       elem_b = t8_forest_get_element_in_tree (forest_b, itree, ielem);
       /* check for equality */
-      if (ts_a->t8_element_compare (elem_a, elem_b)) {
+      if (!ts_a->t8_element_equal (elem_a, elem_b)) {
         /* The elements are not equal */
         return 0;
       }
@@ -1628,7 +1628,7 @@ t8_forest_tree_shared (t8_forest_t forest, int first_or_last)
     /* We can now check whether the first/last possible descendant matches the
      * first/last local descendant */
     tree_desc = first_or_last == 0 ? tree->first_desc : tree->last_desc;
-    ret = ts->t8_element_compare (desc, tree_desc);
+    ret = !ts->t8_element_equal (desc, tree_desc);
     /* clean-up */
     ts->t8_element_destroy (1, &element);
     ts->t8_element_destroy (1, &desc);
@@ -2177,7 +2177,7 @@ t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid, const t8
           t8_element_t *check_element;
           check_element = t8_forest_get_element (forest, element_indices[ineigh], &check_ltreeid);
           T8_ASSERT (check_ltreeid == lneigh_treeid);
-          T8_ASSERT (!neigh_scheme->t8_element_compare (check_element, neighbor_leafs[ineigh]));
+          T8_ASSERT (neigh_scheme->t8_element_equal (check_element, neighbor_leafs[ineigh]));
         }
 #endif
       }
@@ -2192,7 +2192,7 @@ t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid, const t8
         {
           t8_element_t *check_element;
           check_element = t8_forest_ghost_get_element (forest, lghost_treeid, element_indices[ineigh]);
-          T8_ASSERT (!neigh_scheme->t8_element_compare (check_element, neighbor_leafs[ineigh]));
+          T8_ASSERT (neigh_scheme->t8_element_equal (check_element, neighbor_leafs[ineigh]));
         }
 #endif
         /* Add the element offset of previous ghosts to this index */
@@ -2686,9 +2686,9 @@ t8_forest_element_owners_at_face_recursion (t8_forest_t forest, t8_gloidx_t gtre
 
     ts->t8_element_new (1, &test_desc);
     ts->t8_element_last_descendant_face (element, face, test_desc, forest->maxlevel);
-    T8_ASSERT (!ts->t8_element_compare (test_desc, last_face_desc));
+    T8_ASSERT (ts->t8_element_equal (test_desc, last_face_desc));
     ts->t8_element_first_descendant_face (element, face, test_desc, forest->maxlevel);
-    T8_ASSERT (!ts->t8_element_compare (test_desc, first_face_desc));
+    T8_ASSERT (ts->t8_element_equal (test_desc, first_face_desc));
     ts->t8_element_destroy (1, &test_desc);
   }
 #endif

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -166,7 +166,7 @@ t8_forest_no_overlap (t8_forest_t forest);
  * \param [in] forest_b The second forest.
  * \return              True if \a forest_a and \a forest_b do have the same
  *                      number of local trees and each local tree has the same
- *                      elements, that is \ref t8_element_compare returns false
+ *                      elements, that is \ref t8_element_equal returns true
  *                      for each pair of elements of \a forest_a and \a forest_b.
  * \note This function is not collective. It only returns the state on the current
  * rank.

--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -458,7 +458,7 @@ t8_ghost_add_remote (t8_forest_t forest, t8_forest_ghost_t ghost, int remote_ran
     int elem_count = t8_element_array_get_count (&remote_tree->elements);
     for (ielem = 0; ielem < elem_count - 1; ielem++) {
       test_el = t8_element_array_index_int (&remote_tree->elements, ielem);
-      SC_CHECK_ABORTF (ts->t8_element_compare (test_el, elem), "Local element %i already in remote ghosts at pos %i\n",
+      SC_CHECK_ABORTF (!ts->t8_element_equal (test_el, elem), "Local element %i already in remote ghosts at pos %i\n",
                        element_index, ielem);
     }
   }

--- a/src/t8_forest/t8_forest_iterate.cxx
+++ b/src/t8_forest/t8_forest_iterate.cxx
@@ -103,7 +103,7 @@ t8_forest_iterate_faces (t8_forest_t forest, t8_locidx_t ltreeid, const t8_eleme
     /* There is only one leaf left, we check whether it is the same as element
      * and if so call the callback function */
     leaf = t8_element_array_index_locidx (leaf_elements, 0);
-    if (!ts->t8_element_compare (element, leaf)) {
+    if (ts->t8_element_equal (element, leaf)) {
       /* The element is the leaf, we are at the last stage of the recursion
        * and can call the callback. */
       (void) callback (forest, ltreeid, leaf, face, user_data, tree_lindex_of_first_leaf);
@@ -213,7 +213,7 @@ t8_forest_search_recursion (t8_forest_t forest, t8_locidx_t ltreeid, t8_eclass_t
     SC_CHECK_ABORT (ts->t8_element_level (element) <= ts->t8_element_level (leaf),
                     "Search: element level greater than leaf level\n");
     if (ts->t8_element_level (element) == ts->t8_element_level (leaf)) {
-      T8_ASSERT (!ts->t8_element_compare (element, leaf));
+      T8_ASSERT (ts->t8_element_equal (element, leaf));
       /* The element is the leaf */
       is_leaf = 1;
     }
@@ -395,7 +395,7 @@ t8_forest_iterate_replace (t8_forest_t forest_new, t8_forest_t forest_old, t8_fo
           t8_element_t *elem_parent;
           ts->t8_element_new (1, &elem_parent);
           ts->t8_element_parent (elem_new, elem_parent);
-          if (!ts->t8_element_compare (elem_old, elem_parent)) {
+          if (ts->t8_element_equal (elem_old, elem_parent)) {
             /* elem_old got refined */
             T8_ASSERT (level_new == level_old + 1);
             const t8_locidx_t family_size = ts->t8_element_num_children (elem_old);
@@ -406,7 +406,7 @@ t8_forest_iterate_replace (t8_forest_t forest_new, t8_forest_t forest_old, t8_fo
             for (t8_locidx_t ielem = 1; ielem < family_size; ielem++) {
               elem_new_debug = t8_forest_get_element_in_tree (forest_new, itree, ielem_new + ielem);
               ts->t8_element_parent (elem_new_debug, elem_parent);
-              SC_CHECK_ABORT (!ts->t8_element_compare (elem_old, elem_parent), "Family is not complete.");
+              SC_CHECK_ABORT (ts->t8_element_equal (elem_old, elem_parent), "Family is not complete.");
             }
 #endif
             ts->t8_element_destroy (1, &elem_parent);
@@ -427,7 +427,7 @@ t8_forest_iterate_replace (t8_forest_t forest_new, t8_forest_t forest_old, t8_fo
           t8_element_t *elem_parent;
           ts->t8_element_new (1, &elem_parent);
           ts->t8_element_parent (elem_old, elem_parent);
-          if (!ts->t8_element_compare (elem_new, elem_parent)) {
+          if (ts->t8_element_equal (elem_new, elem_parent)) {
             /* elem_old got coarsened */
             T8_ASSERT (level_new == level_old - 1);
             /* Get size of family of old forest */
@@ -436,7 +436,7 @@ t8_forest_iterate_replace (t8_forest_t forest_new, t8_forest_t forest_old, t8_fo
                  ielem < ts->t8_element_num_children (elem_new) && ielem + ielem_old < elems_per_tree_old; ielem++) {
               elem_old = t8_forest_get_element_in_tree (forest_old, itree, ielem_old + ielem);
               ts->t8_element_parent (elem_old, elem_parent);
-              if (!ts->t8_element_compare (elem_new, elem_parent)) {
+              if (ts->t8_element_equal (elem_new, elem_parent)) {
                 family_size++;
               }
             }
@@ -448,7 +448,7 @@ t8_forest_iterate_replace (t8_forest_t forest_new, t8_forest_t forest_old, t8_fo
                  ielem++) {
               elem_old_debug = t8_forest_get_element_in_tree (forest_old, itree, ielem_old - ielem);
               ts->t8_element_parent (elem_old_debug, elem_parent);
-              SC_CHECK_ABORT (0 != ts->t8_element_compare (elem_new, elem_parent),
+              SC_CHECK_ABORT (!ts->t8_element_equal (elem_new, elem_parent),
                               "elem_old is not the first of the family.");
             }
 #endif
@@ -467,7 +467,7 @@ t8_forest_iterate_replace (t8_forest_t forest_new, t8_forest_t forest_old, t8_fo
         }
         else {
           /* elem_old was untouched or got removed */
-          if (!ts->t8_element_compare (elem_new, elem_old)) {
+          if (ts->t8_element_equal (elem_new, elem_old)) {
             /* elem_new = elem_old */
             const int refine = 0;
             replace_fn (forest_old, forest_new, itree, ts, refine, 1, ielem_old, 1, ielem_new);
@@ -518,7 +518,7 @@ t8_forest_iterate_replace (t8_forest_t forest_new, t8_forest_t forest_old, t8_fo
         }
         else {
           /* elem_new = elem_old */
-          T8_ASSERT (!ts->t8_element_compare (elem_new, elem_old));
+          T8_ASSERT (ts->t8_element_equal (elem_new, elem_old));
           const int refine = 0;
           replace_fn (forest_old, forest_new, itree, ts, refine, 1, ielem_old, 1, ielem_new);
           /* Advance to the next element */

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -71,6 +71,13 @@ t8_default_scheme_hex_c::t8_element_compare (const t8_element_t *elem1, const t8
   return p8est_quadrant_compare ((const p8est_quadrant_t *) elem1, (const p8est_quadrant_t *) elem2);
 }
 
+int
+t8_default_scheme_hex_c::t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const
+{
+  return p8est_quadrant_is_equal ((const p8est_quadrant_t *) elem1, (const p8est_quadrant_t *) elem2);
+}
+
+
 void
 t8_default_scheme_hex_c::t8_element_parent (const t8_element_t *elem, t8_element_t *parent) const
 {

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -121,6 +121,15 @@ struct t8_default_scheme_hex_c: public t8_default_scheme_common_c
   virtual int
   t8_element_compare (const t8_element_t *elem1, const t8_element_t *elem2) const;
 
+  /** Check if two elements are equal.
+  * \param [in] ts     Implementation of a class scheme.
+  * \param [in] elem1  The first element.
+  * \param [in] elem2  The second element.
+  * \return            1 if the elements are equal, 0 if they are not equal
+  */
+  virtual int
+  t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const;
+
   /** Compute the parent of a given element \b elem and store it in \b parent.
    *  \b parent needs to be an existing element. No memory is allocated by this function.
    *  \b elem and \b parent can point to the same element, then the entries of

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
@@ -59,6 +59,13 @@ t8_default_scheme_line_c::t8_element_compare (const t8_element_t *elem1, const t
   return t8_dline_compare ((const t8_dline_t *) elem1, (const t8_dline_t *) elem2);
 }
 
+int
+t8_default_scheme_line_c::t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const
+{
+  return t8_dline_equal ((const t8_dline_t *) elem1, (const t8_dline_t *) elem2);
+}
+
+
 void
 t8_default_scheme_line_c::t8_element_parent (const t8_element_t *elem, t8_element_t *parent) const
 {

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
@@ -120,6 +120,15 @@ struct t8_default_scheme_line_c: public t8_default_scheme_common_c
   virtual int
   t8_element_compare (const t8_element_t *elem1, const t8_element_t *elem2) const;
 
+  /** Check if two elements are equal.
+  * \param [in] ts     Implementation of a class scheme.
+  * \param [in] elem1  The first element.
+  * \param [in] elem2  The second element.
+  * \return            1 if the elements are equal, 0 if they are not equal
+  */
+  virtual int
+  t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const;
+
   /** Compute the parent of a given element \b elem and store it in \b parent.
    *  \b parent needs to be an existing element. No memory is allocated by this function.
    *  \b elem and \b parent can point to the same element, then the entries of

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
@@ -51,6 +51,12 @@ t8_dline_compare (const t8_dline_t *l1, const t8_dline_t *l2)
   return id1 < id2 ? -1 : id1 != id2;
 }
 
+int
+t8_dline_equal (const t8_dline_t *l1, const t8_dline_t *l2)
+{
+  return (l1->level == l2->level && l1->x == l2->x);
+}
+
 void
 t8_dline_parent (const t8_dline_t *l, t8_dline_t *parent)
 {

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
@@ -55,6 +55,14 @@ t8_dline_copy (const t8_dline_t *l, t8_dline_t *dest);
 int
 t8_dline_compare (const t8_dline_t *l1, const t8_dline_t *l2);
 
+/** Check if two elements are equal.
+* \param [in] elem1  The first element.
+* \param [in] elem2  The second element.
+* \return            1 if the elements are equal, 0 if they are not equal
+*/
+int
+t8_dline_equal (const t8_dline_t *elem1, const t8_dline_t *elem2);
+
 /** Compute the parent of a line.
  * \param [in]  l   The input line.
  * \param [in,out] parent Existing line whose data will be filled with the parent

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -100,6 +100,13 @@ t8_default_scheme_prism_c::t8_element_compare (const t8_element_t *elem1, const 
   return t8_dprism_compare ((const t8_dprism_t *) elem1, (const t8_dprism_t *) elem2);
 }
 
+int
+t8_default_scheme_prism_c::t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const
+{
+  return t8_dprism_equal ((const t8_dprism_t *) elem1, (const t8_dprism_t *) elem2);
+}
+
+
 void
 t8_default_scheme_prism_c::t8_element_parent (const t8_element_t *elem, t8_element_t *parent) const
 {

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
@@ -120,6 +120,15 @@ struct t8_default_scheme_prism_c: public t8_default_scheme_common_c
   virtual int
   t8_element_compare (const t8_element_t *elem1, const t8_element_t *elem2) const;
 
+  /** Check if two elements are equal.
+  * \param [in] ts     Implementation of a class scheme.
+  * \param [in] elem1  The first element.
+  * \param [in] elem2  The second element.
+  * \return            1 if the elements are equal, 0 if they are not equal
+  */
+  virtual int
+  t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const;
+
   /** Compute the parent of a given element \b elem and store it in \b parent.
    * \b parent needs to be an existing element. No memory is allocated by this function.
    * \b elem and \b parent can point to the same element, then the entries of

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -43,6 +43,12 @@ t8_dprism_copy (const t8_dprism_t *p, t8_dprism_t *dest)
   T8_ASSERT (dest->line.level == dest->tri.level);
 }
 
+int 
+t8_dprism_equal (const t8_dprism_t *elem1, const t8_dprism_t *elem2) 
+{
+  return t8_dline_equal(&elem1->line, &elem2->line) && t8_dtri_equal(&elem1->tri, &elem2->tri);
+}
+
 int
 t8_dprism_compare (const t8_dprism_t *p1, const t8_dprism_t *p2)
 {

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
@@ -57,6 +57,14 @@ t8_dprism_copy (const t8_dprism_t *p, t8_dprism_t *dest);
 int
 t8_dprism_compare (const t8_dprism_t *p1, const t8_dprism_t *p2);
 
+/** Check if two elements are equal.
+* \param [in] elem1  The first element.
+* \param [in] elem2  The second element.
+* \return            1 if the elements are equal, 0 if they are not equal
+*/
+int 
+t8_dprism_equal (const t8_dprism_t *elem1, const t8_dprism_t *elem2);
+
 /** Initialize a prism as the prism with a given global id in a uniform
  *  refinement of a given level. *
  * \param [in,out] p  Existing prism whose data will be filled.

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -121,6 +121,13 @@ t8_default_scheme_pyramid_c::t8_element_compare (const t8_element_t *elem1, cons
   return t8_dpyramid_compare ((const t8_dpyramid_t *) elem1, (const t8_dpyramid_t *) elem2);
 }
 
+int
+t8_default_scheme_pyramid_c::t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const
+{
+  return t8_dpyramid_equal ((const t8_dpyramid_t *) elem1, (const t8_dpyramid_t *) elem2);
+}
+
+
 void
 t8_default_scheme_pyramid_c::t8_element_copy (const t8_element_t *source, t8_element_t *dest) const
 {

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
@@ -113,6 +113,15 @@ struct t8_default_scheme_pyramid_c: public t8_default_scheme_common_c
   virtual int
   t8_element_compare (const t8_element_t *elem1, const t8_element_t *elem2) const;
 
+  /** Check if two elements are equal.
+  * \param [in] ts     Implementation of a class scheme.
+  * \param [in] elem1  The first element.
+  * \param [in] elem2  The second element.
+  * \return            1 if the elements are equal, 0 if they are not equal
+  */
+  virtual int
+  t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const;
+
   /** Compute the parent of a given element \b elem and store it in \b parent.
    * \b parent needs to be an existing element. No memory is allocated by this function.
    * \b elem and \b parent can point to the same element, then the entries of

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -383,6 +383,12 @@ t8_dpyramid_copy (const t8_dpyramid_t *source, t8_dpyramid_t *dest)
   memcpy (dest, source, sizeof (t8_dpyramid_t));
 }
 
+int 
+t8_dpyramid_equal (const t8_dpyramid_t *elem1, const t8_dpyramid_t *elem2) 
+{
+  return t8_dtet_equal(&elem1->pyramid, &elem2->pyramid) && elem1->switch_shape_at_level == elem2->switch_shape_at_level;
+}
+
 int
 t8_dpyramid_compare (const t8_dpyramid_t *p1, const t8_dpyramid_t *p2)
 {

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
@@ -144,6 +144,14 @@ t8_dpyramid_extrude_face (const t8_element_t *face, t8_dpyramid_t *p, const int 
 int
 t8_dpyramid_compare (const t8_dpyramid_t *p1, const t8_dpyramid_t *p2);
 
+/** Check if two elements are equal.
+* \param [in] elem1  The first element.
+* \param [in] elem2  The second element.
+* \return            1 if the elements are equal, 0 if they are not equal
+*/
+int
+t8_dpyramid_equal (const t8_dpyramid_t *elem1, const t8_dpyramid_t *elem2);
+
 /** Check whether a collection of 10 pyramids is a family in Morton order.
  * \param [in]  fam A collection of pyramids
  * \return      Nonzero if \a fam is a family of pyramids

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -94,6 +94,13 @@ t8_default_scheme_quad_c::t8_element_compare (const t8_element_t *elem1, const t
   return p4est_quadrant_compare ((const p4est_quadrant_t *) elem1, (const p4est_quadrant_t *) elem2);
 }
 
+int
+t8_default_scheme_quad_c::t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const
+{
+  return p4est_quadrant_is_equal ((const p4est_quadrant_t *) elem1, (const p4est_quadrant_t *) elem2);
+}
+
+
 void
 t8_default_scheme_quad_c::t8_element_parent (const t8_element_t *elem, t8_element_t *parent) const
 {

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -160,6 +160,15 @@ struct t8_default_scheme_quad_c: public t8_default_scheme_common_c
   virtual int
   t8_element_compare (const t8_element_t *elem1, const t8_element_t *elem2) const;
 
+  /** Check if two elements are equal.
+  * \param [in] ts     Implementation of a class scheme.
+  * \param [in] elem1  The first element.
+  * \param [in] elem2  The second element.
+  * \return            1 if the elements are equal, 0 if they are not equal
+  */
+  virtual int
+  t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const;
+
   /** Compute the parent of a given element \b elem and store it in \b parent.
    *  \b parent needs to be an existing element. No memory is allocated by this function.
    *  \b elem and \b parent can point to the same element, then the entries of

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
@@ -58,6 +58,13 @@ t8_default_scheme_tet_c::t8_element_compare (const t8_element_t *elem1, const t8
   return t8_dtet_compare ((const t8_dtet_t *) elem1, (const t8_dtet_t *) elem2);
 }
 
+int
+t8_default_scheme_tet_c::t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const
+{
+  return t8_dtet_equal ((const t8_dtet_t *) elem1, (const t8_dtet_t *) elem2);
+}
+
+
 void
 t8_default_scheme_tet_c::t8_element_parent (const t8_element_t *elem, t8_element_t *parent) const
 {

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
@@ -110,6 +110,15 @@ struct t8_default_scheme_tet_c: public t8_default_scheme_common_c
   virtual int
   t8_element_compare (const t8_element_t *elem1, const t8_element_t *elem2) const;
 
+  /** Check if two elements are equal.
+  * \param [in] ts     Implementation of a class scheme.
+  * \param [in] elem1  The first element.
+  * \param [in] elem2  The second element.
+  * \return            1 if the elements are equal, 0 if they are not equal
+  */
+  virtual int
+  t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const;
+
   /** Compute the parent of a given element \b elem and store it in \b parent.
    * \b parent needs to be an existing element. No memory is allocated by this function.
    * \b elem and \b parent can point to the same element, then the entries of

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
@@ -88,6 +88,14 @@ t8_dtet_copy (const t8_dtet_t *t, t8_dtet_t *dest);
 int
 t8_dtet_compare (const t8_dtet_t *t1, const t8_dtet_t *t2);
 
+/** Check if two elements are equal.
+* \param [in] elem1  The first element.
+* \param [in] elem2  The second element.
+* \return            1 if the elements are equal, 0 if they are not equal
+*/
+int
+t8_dtet_equal (const t8_dtet_t *elem1, const t8_dtet_t *elem2);
+
 /** Compute the parent of a tetrahedron.
  * \param [in]  elem Input tetrahedron.
  * \param [in,out] parent Existing tetrahedron whose data will be filled with the data of elem's parent.

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_dtri_to_dtet.h
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_dtri_to_dtet.h
@@ -68,6 +68,7 @@ T8_EXTERN_C_BEGIN ();
 #define t8_dtri_is_equal t8_dtet_is_equal
 #define t8_dtri_copy t8_dtet_copy
 #define t8_dtri_compare t8_dtet_compare
+#define t8_dtri_equal t8_dtet_equal
 #define t8_dtri_parent t8_dtet_parent
 #define t8_dtri_ancestor t8_dtet_ancestor
 #define t8_dtri_compute_all_coords t8_dtet_compute_all_coords

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
@@ -60,6 +60,12 @@ t8_default_scheme_tri_c::t8_element_compare (const t8_element_t *elem1, const t8
   return t8_dtri_compare ((const t8_dtri_t *) elem1, (const t8_dtri_t *) elem2);
 }
 
+int
+t8_default_scheme_tri_c::t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const
+{
+  return t8_dtri_equal ((const t8_dtri_t *) elem1, (const t8_dtri_t *) elem2);
+}
+
 void
 t8_default_scheme_tri_c::t8_element_parent (const t8_element_t *elem, t8_element_t *parent) const
 {

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
@@ -114,6 +114,15 @@ struct t8_default_scheme_tri_c: public t8_default_scheme_common_c
   virtual int
   t8_element_compare (const t8_element_t *elem1, const t8_element_t *elem2) const;
 
+  /** Check if two elements are equal.
+  * \param [in] ts     Implementation of a class scheme.
+  * \param [in] elem1  The first element.
+  * \param [in] elem2  The second element.
+  * \return            1 if the elements are equal, 0 if they are not equal
+  */
+  virtual int
+  t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const;
+
   /** Compute the parent of a given element \b elem and store it in \b parent.
    * \b parent needs to be an existing element. No memory is allocated by this function.
    * \b elem and \b parent can point to the same element, then the entries of

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
@@ -106,6 +106,20 @@ t8_dtri_copy (const t8_dtri_t *t, t8_dtri_t *dest)
 }
 
 int
+t8_dtri_equal (const t8_dtri_t *elem1, const t8_dtri_t *elem2)
+{
+  return (elem1->level == elem2->level 
+          && elem1->type == elem2->type
+          && elem1->x == elem2->x
+          && elem1->y == elem2->y 
+#ifdef T8_DTRI_TO_DTET
+          && elem1->z == elem2->z
+#endif
+          );
+
+}
+
+int
 t8_dtri_compare (const t8_dtri_t *t1, const t8_dtri_t *t2)
 {
   int maxlvl;

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
@@ -48,6 +48,14 @@ t8_dtri_copy (const t8_dtri_t *t, t8_dtri_t *dest);
 int
 t8_dtri_compare (const t8_dtri_t *t1, const t8_dtri_t *t2);
 
+/** Check if two elements are equal.
+* \param [in] elem1  The first element.
+* \param [in] elem2  The second element.
+* \return            1 if the elements are equal, 0 if they are not equal
+*/
+int
+t8_dtri_equal (const t8_dtri_t *elem1, const t8_dtri_t *elem2);
+
 /** Compute the parent of a triangle.
  * \param [in]  elem Input triangle.
  * \param [in,out] parent Existing triangle whose data will be filled with the data of elem's parent.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
@@ -61,6 +61,12 @@ t8_default_scheme_vertex_c::t8_element_compare (const t8_element_t *elem1, const
   return t8_dvertex_compare ((const t8_dvertex_t *) elem1, (const t8_dvertex_t *) elem2);
 }
 
+int
+t8_default_scheme_vertex_c::t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const
+{
+  return t8_dvertex_equal ((const t8_dvertex_t *) elem1, (const t8_dvertex_t *) elem2);
+}
+
 void
 t8_default_scheme_vertex_c::t8_element_parent (const t8_element_t *elem, t8_element_t *parent) const
 {

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
@@ -114,6 +114,15 @@ struct t8_default_scheme_vertex_c: public t8_default_scheme_common_c
   virtual int
   t8_element_compare (const t8_element_t *elem1, const t8_element_t *elem2) const;
 
+  /** Check if two elements are equal.
+  * \param [in] ts     Implementation of a class scheme.
+  * \param [in] elem1  The first element.
+  * \param [in] elem2  The second element.
+  * \return            1 if the elements are equal, 0 if they are not equal
+  */
+  virtual int
+  t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const;
+
   /** Compute the parent of a given element \b elem and store it in \b parent.
    *  \b parent needs to be an existing element. No memory is allocated by this function.
    *  \b elem and \b parent can point to the same element, then the entries of

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.c
@@ -35,6 +35,12 @@ t8_dvertex_copy (const t8_dvertex_t *v, t8_dvertex_t *dest)
 }
 
 int
+t8_dvertex_equal (const t8_dvertex_t *elem1, const t8_dvertex_t *elem2)
+{
+  return elem1->level == elem2->level;
+}
+
+int
 t8_dvertex_compare (const t8_dvertex_t *v1, const t8_dvertex_t *v2)
 {
   /* The vertex with the smaller level

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.h
@@ -54,6 +54,14 @@ t8_dvertex_copy (const t8_dvertex_t *v, t8_dvertex_t *dest);
 int
 t8_dvertex_compare (const t8_dvertex_t *l1, const t8_dvertex_t *l2);
 
+/** Check if two elements are equal.
+* \param [in] elem1  The first element.
+* \param [in] elem2  The second element.
+* \return            1 if the elements are equal, 0 if they are not equal
+*/
+int
+t8_dvertex_equal (const t8_dvertex_t *elem1, const t8_dvertex_t *elem2);
+
 /** Compute the parent of a vertex.
  * \param [in]  l   The input vertex.
  * \param [in,out] parent Existing vertex whose data will be filled with the parent

--- a/test/t8_forest/t8_gtest_half_neighbors.cxx
+++ b/test/t8_forest/t8_gtest_half_neighbors.cxx
@@ -116,7 +116,7 @@ TEST_P (forest_half_neighbors, test_half_neighbors)
                                                      child_ids);
           /* Check that the children at face of the neighbor are the half neighbors of the element */
           for (int ineigh = 0; ineigh < num_face_neighs; ineigh++) {
-            ASSERT_TRUE (!neigh_scheme->t8_element_compare (neighbor_face_children[ineigh], half_neighbors[ineigh]))
+            ASSERT_TRUE (neigh_scheme->t8_element_equal (neighbor_face_children[ineigh], half_neighbors[ineigh]))
               << "Half neighbor " << ineigh << " at face " << face << "is not equal to child" << ineigh
               << "of the neighbor element.\n";
           }

--- a/test/t8_forest/t8_gtest_search.cxx
+++ b/test/t8_forest/t8_gtest_search.cxx
@@ -78,7 +78,7 @@ t8_test_search_all_fn (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element
     *(int *) t8_sc_array_index_locidx (matched_leafs, tree_offset + tree_leaf_index) = 1;
     /* Test whether tree_leaf_index is actually the index of the element */
     test_element = t8_forest_get_element (forest, tree_offset + tree_leaf_index, &test_ltreeid);
-    EXPECT_FALSE (ts->t8_element_compare (element, test_element))
+    EXPECT_TRUE (ts->t8_element_equal (element, test_element))
       << "Element and index passed to search callback do not match.";
     EXPECT_EQ (ltreeid, test_ltreeid) << "Tree mismatch in search.";
   }
@@ -107,7 +107,7 @@ t8_test_search_query_all_fn (t8_forest_t forest, t8_locidx_t ltreeid, const t8_e
 
     t8_locidx_t tree_offset = t8_forest_get_tree_element_offset (forest, ltreeid);
     t8_element_t *test_element = t8_forest_get_element (forest, tree_offset + tree_leaf_index, &test_ltreeid);
-    EXPECT_FALSE (ts->t8_element_compare (element, test_element))
+    EXPECT_TRUE (ts->t8_element_equal (element, test_element))
       << "Element and index passed to search callback do not match.";
     EXPECT_EQ (ltreeid, test_ltreeid) << "Tree mismatch in search.";
   }

--- a/test/t8_forest/t8_gtest_transform.cxx
+++ b/test/t8_forest/t8_gtest_transform.cxx
@@ -78,9 +78,9 @@ t8_test_transform_element (t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_
   ts->t8_element_new (1, &transform);
 
   ts->t8_element_transform_face (elem, transform, 0, 0, 0);
-  ASSERT_TRUE (!ts->t8_element_compare (elem, transform)) << "Elements are not equal";
+  ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
   ts->t8_element_transform_face (elem, transform, 0, 0, 1);
-  ASSERT_TRUE (!ts->t8_element_compare (elem, transform)) << "Elements are not equal";
+  ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
   if (eclass == T8_ECLASS_TRIANGLE) {
     /* For triangles we test:
      * 3 times ori = 1 sign = 0  == identity
@@ -94,23 +94,23 @@ t8_test_transform_element (t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_
     for (int itimes = 0; itimes < 3; itimes++) {
       ts->t8_element_transform_face (transform, transform, 1, 0, 0);
     }
-    ASSERT_TRUE (!ts->t8_element_compare (elem, transform)) << "Elements are not equal";
+    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
     /* or = 1 sign = 0, then or = 2 sign = 0 */
     ts->t8_element_transform_face (transform, transform, 1, 0, 0);
     ts->t8_element_transform_face (transform, transform, 2, 0, 0);
-    ASSERT_TRUE (!ts->t8_element_compare (elem, transform)) << "Elements are not equal";
+    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
     /* or = 2 sign = 0, then or = 1 sign = 0 */
     ts->t8_element_transform_face (transform, transform, 2, 0, 0);
     ts->t8_element_transform_face (transform, transform, 1, 0, 0);
-    ASSERT_TRUE (!ts->t8_element_compare (elem, transform)) << "Elements are not equal";
+    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
     /* or = 1 sign = 1, then or = 1 sign = 1 */
     ts->t8_element_transform_face (transform, transform, 1, 1, 0);
     ts->t8_element_transform_face (transform, transform, 1, 1, 0);
-    ASSERT_TRUE (!ts->t8_element_compare (elem, transform)) << "Elements are not equal";
+    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
     /* or = 2 sign = 1, then or = 2 sign = 1 */
     ts->t8_element_transform_face (transform, transform, 2, 1, 0);
     ts->t8_element_transform_face (transform, transform, 2, 1, 0);
-    ASSERT_TRUE (!ts->t8_element_compare (elem, transform)) << "Elements are not equal";
+    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
   }
   else {
     T8_ASSERT (eclass == T8_ECLASS_QUAD);
@@ -128,22 +128,22 @@ t8_test_transform_element (t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_
     for (int itimes = 0; itimes < 4; itimes++) {
       ts->t8_element_transform_face (transform, transform, 1, 0, 1);
     }
-    ASSERT_TRUE (!ts->t8_element_compare (elem, transform)) << "Elements are not equal. Quad. 4 times or 1.";
+    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal. Quad. 4 times or 1.";
     /* 4 times or = 1 sign = 0, if not smaller face */
     for (int itimes = 0; itimes < 4; itimes++) {
       ts->t8_element_transform_face (transform, transform, 1, 0, 0);
     }
-    ASSERT_TRUE (!ts->t8_element_compare (elem, transform))
+    ASSERT_TRUE (ts->t8_element_equal (elem, transform))
       << "Elements are not equal. Quad. 4 times or 1 not smaller.";
     /* or = 1 sign = 0, then or = 3 sign = 0, then ori = 1 sign = 0 */
     ts->t8_element_transform_face (transform, transform, 1, 0, 1);
     ts->t8_element_transform_face (transform, transform, 3, 0, 1);
     ts->t8_element_transform_face (transform, transform, 1, 0, 1);
-    ASSERT_TRUE (!ts->t8_element_compare (elem, transform)) << "Elements are not equal. Quad. or 1 then or 3";
+    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal. Quad. or 1 then or 3";
     /* or = 2 sign = 0, then or = 1 sign = 0 */
     ts->t8_element_transform_face (transform, transform, 2, 0, 1);
     ts->t8_element_transform_face (transform, transform, 1, 0, 1);
-    ASSERT_TRUE (!ts->t8_element_compare (elem, transform)) << "Elements are not equal. Quad. or 2 then or 1";
+    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal. Quad. or 2 then or 1";
     /* TODO: Add tests */
   }
 
@@ -152,12 +152,12 @@ t8_test_transform_element (t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_
     for (int sign = 0; sign < 2; sign++) {
       ts->t8_element_transform_face (elem, transform, iorientation, sign, 1);
       ts->t8_element_transform_face (transform, transform, iorientation, sign, 0);
-      ASSERT_TRUE (!ts->t8_element_compare (elem, transform))
+      ASSERT_TRUE (ts->t8_element_equal (elem, transform))
         << "Elements are not equal. " << t8_eclass_to_string[eclass] << " back forth. Orientation " << iorientation
         << " smaller sign " << sign;
       ts->t8_element_transform_face (elem, transform, iorientation, sign, 0);
       ts->t8_element_transform_face (transform, transform, iorientation, sign, 1);
-      ASSERT_TRUE (!ts->t8_element_compare (elem, transform))
+      ASSERT_TRUE (ts->t8_element_equal (elem, transform))
         << "Elements are not equal. " << t8_eclass_to_string[eclass] << " back forth. Orientation " << iorientation
         << " not smaller sign " << sign;
     }

--- a/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
@@ -105,7 +105,7 @@ t8_forest_replace (t8_forest_t forest_old, t8_forest_t forest_new, t8_locidx_t w
          elidx < ts->t8_element_num_children (parent) && elidx + first_outgoing < tree_num_elements_old; elidx++) {
       child = t8_forest_get_element_in_tree (forest_old, which_tree, first_outgoing + elidx);
       ts->t8_element_parent (child, parent_compare);
-      if (!ts->t8_element_compare (parent, parent_compare)) {
+      if (ts->t8_element_equal (parent, parent_compare)) {
         family_size++;
       }
     }

--- a/test/t8_schemes/t8_gtest_ancestor.cxx
+++ b/test/t8_schemes/t8_gtest_ancestor.cxx
@@ -78,9 +78,9 @@ t8_recursive_ancestor (t8_element_t *element, t8_element_t *child, t8_element_t 
   for (i = 0; i < num_children; i++) {
     ts->t8_element_child (parent, i, child);
     t8_dpyramid_ancestor ((t8_dpyramid_t *) child, level, (t8_dpyramid_t *) test_anc);
-    SC_CHECK_ABORT (!ts->t8_element_compare (parent, test_anc), "Computed ancestor is not equal to the parent\n");
+    SC_CHECK_ABORT (ts->t8_element_equal (parent, test_anc), "Computed ancestor is not equal to the parent\n");
     t8_dpyramid_ancestor ((t8_dpyramid_t *) child, elem_lvl, (t8_dpyramid_t *) test_anc);
-    SC_CHECK_ABORT (!ts->t8_element_compare (element, test_anc),
+    SC_CHECK_ABORT (ts->t8_element_equal (element, test_anc),
                     "Computed ancestor is not equal to the correct ancestor\n");
     t8_recursive_ancestor (element, parent, child, test_anc, ts, maxlvl);
     ts->t8_element_parent (child, parent);

--- a/test/t8_schemes/t8_gtest_descendant.cxx
+++ b/test/t8_schemes/t8_gtest_descendant.cxx
@@ -76,12 +76,12 @@ t8_recursive_descendant (t8_element_t *elem, t8_element_t *desc, t8_element_t *t
     /* first child == first descendant. */
     if (ichild == 0) {
       ts->t8_element_first_descendant (elem, test, level + 1);
-      ASSERT_TRUE (!ts->t8_element_compare (desc, test)) << "wrong first descendant.\n";
+      ASSERT_TRUE (ts->t8_element_equal (desc, test)) << "wrong first descendant.\n";
     }
     /* last child == last descendant. */
     else if (ichild == num_children - 1) {
       ts->t8_element_last_descendant (elem, test, level + 1);
-      ASSERT_TRUE (!ts->t8_element_compare (desc, test)) << "Wrong last descendant.\n";
+      ASSERT_TRUE (ts->t8_element_equal (desc, test)) << "Wrong last descendant.\n";
     }
     else if (level > maxlvl) {
       t8_recursive_descendant (desc, elem, test, ts, maxlvl);
@@ -104,7 +104,7 @@ t8_deep_first_descendant (t8_element_t *elem, t8_element_t *desc, t8_element_t *
     ts->t8_element_copy (desc, test);
   }
   ts->t8_element_first_descendant (elem, test, level);
-  ASSERT_TRUE (!ts->t8_element_compare (desc, test)) << "Wrong deep first descendant.\n";
+  ASSERT_TRUE (ts->t8_element_equal (desc, test)) << "Wrong deep first descendant.\n";
 }
 
 /* Test, if the last descendant of an element is computed correctly over a range
@@ -123,7 +123,7 @@ t8_deep_last_descendant (t8_element_t *elem, t8_element_t *desc, t8_element_t *t
   }
   /* Check for equality. */
   ts->t8_element_last_descendant (elem, test, level);
-  ASSERT_TRUE (!ts->t8_element_compare (desc, test)) << "Wrong deep last descendant.\n";
+  ASSERT_TRUE (ts->t8_element_equal (desc, test)) << "Wrong deep last descendant.\n";
 }
 
 /* Test if the first and last descendant of an element are computed correctly.

--- a/test/t8_schemes/t8_gtest_face_descendant.cxx
+++ b/test/t8_schemes/t8_gtest_face_descendant.cxx
@@ -96,7 +96,7 @@ t8_linear_face_descendant (const t8_element_t *elem, t8_element_t *manual_face_d
 
       ts->t8_element_first_descendant_face (elem, jface, face_desc, ilevel);
       /* Compare the manually computed child with the result of t8_element_first_descendant_face. */
-      ASSERT_FALSE (ts->t8_element_compare (face_desc, manual_face_desc)) << "Wrong first descendant face\n";
+      ASSERT_TRUE (ts->t8_element_equal (face_desc, manual_face_desc)) << "Wrong first descendant face\n";
     }
   }
 
@@ -112,7 +112,7 @@ t8_linear_face_descendant (const t8_element_t *elem, t8_element_t *manual_face_d
 
       /* Compare the manuall computed child with the result of t8_element_last_descendant_face. */
       ts->t8_element_last_descendant_face (elem, jface, face_desc, ilevel);
-      ASSERT_FALSE (ts->t8_element_compare (face_desc, manual_face_desc)) << "Wrong last descendant face\n";
+      ASSERT_TRUE (ts->t8_element_equal (face_desc, manual_face_desc)) << "Wrong last descendant face\n";
     }
   }
 }

--- a/test/t8_schemes/t8_gtest_face_neigh.cxx
+++ b/test/t8_schemes/t8_gtest_face_neigh.cxx
@@ -79,7 +79,7 @@ t8_test_face_neighbor_inside (int num_faces, t8_element_t *element, t8_element_t
     ts->t8_element_face_neighbor_inside (child, neigh, iface, &face_num);
     ts->t8_element_face_neighbor_inside (neigh, element, face_num, &check);
 
-    EXPECT_EQ (ts->t8_element_compare (child, element), 0) << "Got a false neighbor.";
+    EXPECT_TRUE (ts->t8_element_equal (child, element)) << "Got a false neighbor.";
     EXPECT_EQ (check, iface) << "Wrong face.";
   }
 }

--- a/test/t8_schemes/t8_gtest_find_parent.cxx
+++ b/test/t8_schemes/t8_gtest_find_parent.cxx
@@ -79,7 +79,7 @@ t8_recursive_child_find_parent (t8_element_t *element, t8_element_t *child, t8_e
     ts->t8_element_parent (child, test_parent);
     /* If its equal, call child_find_parent, to check if parent-child relation
      * is correct in next level until maxlvl is reached*/
-    ASSERT_TRUE (!ts->t8_element_compare (element, test_parent)) << "Computed child_parent is not the parent.";
+    ASSERT_TRUE (ts->t8_element_equal (element, test_parent)) << "Computed child_parent is not the parent.";
 
     t8_recursive_child_find_parent (child, element, test_parent, ts, level + 1, maxlvl);
     /* After the check we know the parent-function is correct for this child.

--- a/test/t8_schemes/t8_gtest_nca.cxx
+++ b/test/t8_schemes/t8_gtest_nca.cxx
@@ -79,7 +79,7 @@ TEST_P (nca, nca_check_shallow)
       /*Compute the nca */
       ts->t8_element_nca (desc_a, desc_b, check);
       /*expect equality */
-      EXPECT_TRUE ((ts->t8_element_compare (correct_nca, check) == 0));
+      EXPECT_TRUE ((ts->t8_element_equal (correct_nca, check)));
     }
   }
 }
@@ -121,7 +121,7 @@ TEST_P (nca, nca_check_deep)
           }
           else {
             /* Expect equality of correct_nca and check for every other class */
-            EXPECT_TRUE ((ts->t8_element_compare (correct_nca, check) == 0));
+            EXPECT_TRUE ((ts->t8_element_equal (correct_nca, check)));
           }
         }
       }
@@ -177,7 +177,7 @@ t8_recursive_nca_check (t8_element_t *check_nca, t8_element_t *desc_a, t8_elemen
       ts->t8_element_child (parent_b, j, desc_b);
       ts->t8_element_nca (desc_a, desc_b, check);
 
-      if (ts->t8_element_compare (check_nca, check) != 0) {
+      if (!ts->t8_element_equal (check_nca, check)) {
         level_a = ts->t8_element_level (desc_a);
         level_b = ts->t8_element_level (desc_b);
 
@@ -288,8 +288,8 @@ TEST_P (nca, recursive_check_higher_level)
           }
           else {
             ts->t8_element_nca (parent_a, parent_b, check);
-            EXPECT_TRUE ((ts->t8_element_compare (parent_a, check) == 0));
-            EXPECT_TRUE ((ts->t8_element_compare (parent_b, check) == 0));
+            EXPECT_TRUE ((ts->t8_element_equal (parent_a, check)));
+            EXPECT_TRUE ((ts->t8_element_equal (parent_b, check)));
           }
         }
       }

--- a/test/t8_schemes/t8_gtest_successor.cxx
+++ b/test/t8_schemes/t8_gtest_successor.cxx
@@ -77,15 +77,15 @@ t8_recursive_successor (t8_element_t *element, t8_element_t *successor, t8_eleme
      * of this element.
      */
     ts->t8_element_child (element, 0, child);
-    ASSERT_TRUE (!ts->t8_element_compare (child, successor)) << "Wrong Successor, Case1.\n";
+    ASSERT_TRUE (ts->t8_element_equal (child, successor)) << "Wrong Successor, Case1.\n";
     /*Check if the successor in this element is computed correctly */
     for (int ichild = 1; ichild < num_children; ichild++) {
       ts->t8_element_successor (child, successor, maxlvl);
       ts->t8_element_child (element, ichild, child);
-      ASSERT_TRUE (!ts->t8_element_compare (child, successor)) << "Wrong Successor, Case2.\n";
+      ASSERT_TRUE (ts->t8_element_equal (child, successor)) << "Wrong Successor, Case2.\n";
     }
     /*If the iterator is the last element, the test can finish */
-    if (!ts->t8_element_compare (last, child)) {
+    if (ts->t8_element_equal (last, child)) {
       return;
     }
     /*Compute the next successor / "jump" out of the current element */
@@ -120,7 +120,7 @@ t8_deep_successor (t8_element_t *element, t8_element_t *successor, t8_element_t 
     for (int jchild = 0; jchild < num_children_child; jchild++) {
       ts->t8_element_child (child, jchild, element);
       /* Check the computation of the successor. */
-      ASSERT_TRUE (!ts->t8_element_compare (element, successor)) << "Wrong Successor at Maxlvl.\n";
+      ASSERT_TRUE (ts->t8_element_equal (element, successor)) << "Wrong Successor at Maxlvl.\n";
       /* Compute the next successor. */
       ts->t8_element_successor (successor, successor, maxlvl);
     }


### PR DESCRIPTION
**_Describe your changes here:_**
Introduce new interface function t8_element_equal, that only compares its contents and not the order in the scheme.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
