### PR TITLE
Element equality assertion in google-test style

### DIFF
--- a/src/t8_element_c_interface.cxx
+++ b/src/t8_element_c_interface.cxx
@@ -430,6 +430,14 @@ t8_element_debug_print (const t8_eclass_scheme_c *ts, const t8_element_t *elem)
 
   return ts->t8_element_debug_print (elem);
 }
+
+void
+t8_element_to_string (const t8_eclass_scheme_c *ts, const t8_element_t *elem, char *debug_string)
+{
+  T8_ASSERT (ts != NULL);
+
+  ts->t8_element_to_string (elem, debug_string);
+}
 #endif
 
 void

--- a/src/t8_element_c_interface.cxx
+++ b/src/t8_element_c_interface.cxx
@@ -432,11 +432,12 @@ t8_element_debug_print (const t8_eclass_scheme_c *ts, const t8_element_t *elem)
 }
 
 void
-t8_element_to_string (const t8_eclass_scheme_c *ts, const t8_element_t *elem, char *debug_string)
+t8_element_to_string (const t8_eclass_scheme_c *ts, const t8_element_t *elem, char *debug_string, const int string_size)
 {
   T8_ASSERT (ts != NULL);
+  T8_ASSERT (debug_string != NULL);
 
-  ts->t8_element_to_string (elem, debug_string);
+  ts->t8_element_to_string (elem, debug_string, string_size);
 }
 #endif
 

--- a/src/t8_element_c_interface.h
+++ b/src/t8_element_c_interface.h
@@ -653,6 +653,15 @@ t8_element_is_valid (const t8_eclass_scheme_c *ts, const t8_element_t *elem);
  */
 void
 t8_element_debug_print (const t8_eclass_scheme_c *ts, const t8_element_t *elem);
+
+/**
+ * \brief Fill a string with readable information about the element
+ * 
+ * \param[in] elem The element to translate into human-readable information
+ * \param[in, out] debug_string The string to fill. 
+ */
+void
+t8_element_to_string (const t8_eclass_scheme_c *ts, const t8_element_t *elem, char *debug_string);
 #endif
 
 /** Allocate memory for an array of elements of a given class and initialize them.

--- a/src/t8_element_c_interface.h
+++ b/src/t8_element_c_interface.h
@@ -661,7 +661,8 @@ t8_element_debug_print (const t8_eclass_scheme_c *ts, const t8_element_t *elem);
  * \param[in, out] debug_string The string to fill. 
  */
 void
-t8_element_to_string (const t8_eclass_scheme_c *ts, const t8_element_t *elem, char *debug_string);
+t8_element_to_string (const t8_eclass_scheme_c *ts, const t8_element_t *elem, char *debug_string,
+                      const int string_size);
 #endif
 
 /** Allocate memory for an array of elements of a given class and initialize them.

--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -720,7 +720,7 @@ struct t8_eclass_scheme
  * \param[in, out] debug_string The string to fill. 
  */
   virtual void
-  t8_element_to_string (const t8_element_t *elem, char *debug_string) const
+  t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const
     = 0;
 #endif
 

--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -712,6 +712,16 @@ struct t8_eclass_scheme
   virtual void
   t8_element_debug_print (const t8_element_t *elem) const
     = 0;
+
+  /**
+ * \brief Fill a string with readable information about the element
+ * 
+ * \param[in] elem The element to translate into human-readable information
+ * \param[in, out] debug_string The string to fill. 
+ */
+  virtual void
+  t8_element_to_string (const t8_element_t *elem, char *debug_string) const
+    = 0;
 #endif
 
   /** Allocate memory for an array of elements of a given class and initialize them.

--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.cxx
@@ -165,7 +165,7 @@ void
 t8_default_scheme_common_c::t8_element_debug_print (const t8_element_t *elem) const
 {
   char debug_string[BUFSIZ];
-  t8_element_to_string (elem, debug_string);
+  t8_element_to_string (elem, debug_string, BUFSIZ);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.cxx
@@ -166,6 +166,7 @@ t8_default_scheme_common_c::t8_element_debug_print (const t8_element_t *elem) co
 {
   char debug_string[BUFSIZ];
   t8_element_to_string (elem, debug_string, BUFSIZ);
+  t8_debugf ("%s\n", debug_string);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.cxx
@@ -160,4 +160,13 @@ t8_default_scheme_common_c::t8_element_general_function (const t8_element_t *ele
   /* This function is intentionally left blank. */
 }
 
+#if T8_ENABLE_DEBUG
+void
+t8_default_scheme_common_c::t8_element_debug_print (const t8_element_t *elem) const
+{
+  char debug_string[BUFSIZ];
+  t8_element_to_string (elem, debug_string);
+}
+#endif
+
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
@@ -137,6 +137,10 @@ class t8_default_scheme_common_c: public t8_eclass_scheme_c {
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const
     = 0;
+#if T8_ENABLE_DEBUG
+  virtual void
+  t8_element_debug_print (const t8_element_t *elem) const;
+#endif
 };
 
 #endif /* !T8_DEFAULT_COMMON_CXX_HXX */

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -77,7 +77,6 @@ t8_default_scheme_hex_c::t8_element_equal (const t8_element_t *elem1, const t8_e
   return p8est_quadrant_is_equal ((const p8est_quadrant_t *) elem1, (const p8est_quadrant_t *) elem2);
 }
 
-
 void
 t8_default_scheme_hex_c::t8_element_parent (const t8_element_t *elem, t8_element_t *parent) const
 {
@@ -643,11 +642,11 @@ t8_default_scheme_hex_c::t8_element_is_valid (const t8_element_t *elem) const
 }
 
 void
-t8_default_scheme_hex_c::t8_element_debug_print (const t8_element_t *elem) const
+t8_default_scheme_hex_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
   p8est_quadrant_t *hex = (p8est_quadrant_t *) elem;
-  p8est_quadrant_print (SC_LP_DEBUG, hex);
+  snprintf (debug_string, BUFSIZ, "x: %i, y: %i, z: %i, level: %i", hex->x, hex->y, hex->z, hex->level);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -642,11 +642,13 @@ t8_default_scheme_hex_c::t8_element_is_valid (const t8_element_t *elem) const
 }
 
 void
-t8_default_scheme_hex_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
+t8_default_scheme_hex_c::t8_element_to_string (const t8_element_t *elem, char *debug_string,
+                                               const int string_size) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
+  T8_ASSERT (debug_string != NULL);
   p8est_quadrant_t *hex = (p8est_quadrant_t *) elem;
-  snprintf (debug_string, BUFSIZ, "x: %i, y: %i, z: %i, level: %i", hex->x, hex->y, hex->z, hex->level);
+  snprintf (debug_string, string_size, "x: %i, y: %i, z: %i, level: %i", hex->x, hex->y, hex->z, hex->level);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -599,7 +599,7 @@ struct t8_default_scheme_hex_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_debug_print (const t8_element_t *elem) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -599,7 +599,7 @@ struct t8_default_scheme_hex_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
@@ -65,7 +65,6 @@ t8_default_scheme_line_c::t8_element_equal (const t8_element_t *elem1, const t8_
   return t8_dline_equal ((const t8_dline_t *) elem1, (const t8_dline_t *) elem2);
 }
 
-
 void
 t8_default_scheme_line_c::t8_element_parent (const t8_element_t *elem, t8_element_t *parent) const
 {
@@ -407,10 +406,11 @@ t8_default_scheme_line_c::t8_element_is_valid (const t8_element_t *elem) const
 }
 
 void
-t8_default_scheme_line_c::t8_element_debug_print (const t8_element_t *elem) const
+t8_default_scheme_line_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_dline_debug_print ((const t8_dline_t *) elem);
+  t8_dline_t *line = (t8_dline_t *) elem;
+  snprintf (debug_string, BUFSIZ, "x: %i, level: %i", line->x, line->level);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
@@ -406,11 +406,13 @@ t8_default_scheme_line_c::t8_element_is_valid (const t8_element_t *elem) const
 }
 
 void
-t8_default_scheme_line_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
+t8_default_scheme_line_c::t8_element_to_string (const t8_element_t *elem, char *debug_string,
+                                                const int string_size) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
+  T8_ASSERT (debug_string != NULL);
   t8_dline_t *line = (t8_dline_t *) elem;
-  snprintf (debug_string, BUFSIZ, "x: %i, level: %i", line->x, line->level);
+  snprintf (debug_string, string_size, "x: %i, level: %i", line->x, line->level);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
@@ -609,7 +609,7 @@ struct t8_default_scheme_line_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
@@ -609,7 +609,7 @@ struct t8_default_scheme_line_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_debug_print (const t8_element_t *elem) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
@@ -383,12 +383,6 @@ t8_dline_is_valid (const t8_dline_t *l)
 }
 
 void
-t8_dline_debug_print (const t8_dline_t *l)
-{
-  t8_debugf ("x: %i, level: %i\n", l->x, l->level);
-}
-
-void
 t8_dline_init (t8_dline_t *l)
 {
   l->level = l->x = 0;

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
@@ -289,12 +289,6 @@ t8_dline_linear_id (const t8_dline_t *elem, int level);
 int
 t8_dline_is_valid (const t8_dline_t *l);
 
-/** Print a line
- * \param [in] l  line to be initialized 
- */
-void
-t8_dline_debug_print (const t8_dline_t *l);
-
 /** Set default values for a line, such that it passes \ref t8_dline_is_valid.
  * \param [in] l  line to be initialized
  */

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -452,12 +452,14 @@ t8_default_scheme_prism_c::t8_element_is_valid (const t8_element_t *elem) const
 }
 
 void
-t8_default_scheme_prism_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
+t8_default_scheme_prism_c::t8_element_to_string (const t8_element_t *elem, char *debug_string,
+                                                 const int string_size) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
+  T8_ASSERT (debug_string != NULL);
   t8_dprism_t *prism = (t8_dprism_t *) elem;
-  snprintf (debug_string, BUFSIZ, "x: %i, y: %i, z: %i, type: %i, level: %i", prism->tri.x, prism->tri.y, prism->line.x,
-            prism->tri.type, prism->tri.level);
+  snprintf (debug_string, string_size, "x: %i, y: %i, z: %i, type: %i, level: %i", prism->tri.x, prism->tri.y,
+            prism->line.x, prism->tri.type, prism->tri.level);
 }
 
 #endif /* T8_ENABLE_DEBUG */

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -106,7 +106,6 @@ t8_default_scheme_prism_c::t8_element_equal (const t8_element_t *elem1, const t8
   return t8_dprism_equal ((const t8_dprism_t *) elem1, (const t8_dprism_t *) elem2);
 }
 
-
 void
 t8_default_scheme_prism_c::t8_element_parent (const t8_element_t *elem, t8_element_t *parent) const
 {
@@ -453,11 +452,14 @@ t8_default_scheme_prism_c::t8_element_is_valid (const t8_element_t *elem) const
 }
 
 void
-t8_default_scheme_prism_c::t8_element_debug_print (const t8_element_t *elem) const
+t8_default_scheme_prism_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_dprism_debug_print ((const t8_dprism_t *) elem);
+  t8_dprism_t *prism = (t8_dprism_t *) elem;
+  snprintf (debug_string, BUFSIZ, "x: %i, y: %i, z: %i, type: %i, level: %i", prism->tri.x, prism->tri.y, prism->line.x,
+            prism->tri.type, prism->tri.level);
 }
+
 #endif /* T8_ENABLE_DEBUG */
 
 /* Constructor */

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
@@ -587,7 +587,7 @@ struct t8_default_scheme_prism_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
@@ -587,7 +587,7 @@ struct t8_default_scheme_prism_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_debug_print (const t8_element_t *elem) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -43,10 +43,10 @@ t8_dprism_copy (const t8_dprism_t *p, t8_dprism_t *dest)
   T8_ASSERT (dest->line.level == dest->tri.level);
 }
 
-int 
-t8_dprism_equal (const t8_dprism_t *elem1, const t8_dprism_t *elem2) 
+int
+t8_dprism_equal (const t8_dprism_t *elem1, const t8_dprism_t *elem2)
 {
-  return t8_dline_equal(&elem1->line, &elem2->line) && t8_dtri_equal(&elem1->tri, &elem2->tri);
+  return t8_dline_equal (&elem1->line, &elem2->line) && t8_dtri_equal (&elem1->tri, &elem2->tri);
 }
 
 int
@@ -634,11 +634,4 @@ t8_dprism_is_valid (const t8_dprism_t *p)
   const t8_dtri_t *tri = &p->tri;
   const int same_level = line->level == tri->level;
   return t8_dtri_is_valid (tri) && t8_dline_is_valid (line) && same_level;
-}
-
-void
-t8_dprism_debug_print (const t8_dprism_t *p)
-{
-  t8_dtri_debug_print (&p->tri);
-  t8_dline_debug_print (&p->line);
 }

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
@@ -62,7 +62,7 @@ t8_dprism_compare (const t8_dprism_t *p1, const t8_dprism_t *p2);
 * \param [in] elem2  The second element.
 * \return            1 if the elements are equal, 0 if they are not equal
 */
-int 
+int
 t8_dprism_equal (const t8_dprism_t *elem1, const t8_dprism_t *elem2);
 
 /** Initialize a prism as the prism with a given global id in a uniform
@@ -335,13 +335,6 @@ t8_dprism_linear_id (const t8_dprism_t *p, int level);
  */
 int
 t8_dprism_is_valid (const t8_dprism_t *p);
-
-/**
- * Print the coordinates, the level and the type of a prism.
- * \param [in] p  prism to be considered.
- */
-void
-t8_dprism_debug_print (const t8_dprism_t *p);
 
 T8_EXTERN_C_END ();
 

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -422,11 +422,13 @@ t8_default_scheme_pyramid_c::t8_element_is_valid (const t8_element_t *elem) cons
 }
 
 void
-t8_default_scheme_pyramid_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
+t8_default_scheme_pyramid_c::t8_element_to_string (const t8_element_t *elem, char *debug_string,
+                                                   const int string_size) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
+  T8_ASSERT (debug_string != NULL);
   t8_dpyramid_t *pyra = (t8_dpyramid_t *) elem;
-  snprintf (debug_string, BUFSIZ, "x: %i, y: %i, z: %i, type: %i, level: %i, switch_shape_at_level: %i",
+  snprintf (debug_string, string_size, "x: %i, y: %i, z: %i, type: %i, level: %i, switch_shape_at_level: %i",
             pyra->pyramid.x, pyra->pyramid.y, pyra->pyramid.x, pyra->pyramid.type, pyra->pyramid.level,
             pyra->switch_shape_at_level);
 }

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -127,7 +127,6 @@ t8_default_scheme_pyramid_c::t8_element_equal (const t8_element_t *elem1, const 
   return t8_dpyramid_equal ((const t8_dpyramid_t *) elem1, (const t8_dpyramid_t *) elem2);
 }
 
-
 void
 t8_default_scheme_pyramid_c::t8_element_copy (const t8_element_t *source, t8_element_t *dest) const
 {
@@ -423,10 +422,13 @@ t8_default_scheme_pyramid_c::t8_element_is_valid (const t8_element_t *elem) cons
 }
 
 void
-t8_default_scheme_pyramid_c::t8_element_debug_print (const t8_element_t *elem) const
+t8_default_scheme_pyramid_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_dpyramid_debug_print ((const t8_dpyramid_t *) elem);
+  t8_dpyramid_t *pyra = (t8_dpyramid_t *) elem;
+  snprintf (debug_string, BUFSIZ, "x: %i, y: %i, z: %i, type: %i, level: %i, switch_shape_at_level: %i",
+            pyra->pyramid.x, pyra->pyramid.y, pyra->pyramid.x, pyra->pyramid.type, pyra->pyramid.level,
+            pyra->switch_shape_at_level);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
@@ -579,7 +579,7 @@ struct t8_default_scheme_pyramid_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_debug_print (const t8_element_t *elem) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
@@ -579,7 +579,7 @@ struct t8_default_scheme_pyramid_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -383,10 +383,11 @@ t8_dpyramid_copy (const t8_dpyramid_t *source, t8_dpyramid_t *dest)
   memcpy (dest, source, sizeof (t8_dpyramid_t));
 }
 
-int 
-t8_dpyramid_equal (const t8_dpyramid_t *elem1, const t8_dpyramid_t *elem2) 
+int
+t8_dpyramid_equal (const t8_dpyramid_t *elem1, const t8_dpyramid_t *elem2)
 {
-  return t8_dtet_equal(&elem1->pyramid, &elem2->pyramid) && elem1->switch_shape_at_level == elem2->switch_shape_at_level;
+  return t8_dtet_equal (&elem1->pyramid, &elem2->pyramid)
+         && elem1->switch_shape_at_level == elem2->switch_shape_at_level;
 }
 
 int
@@ -1784,11 +1785,4 @@ t8_dpyramid_is_valid (const t8_dpyramid_t *p)
   }
 
   return is_valid;
-}
-
-void
-t8_dpyramid_debug_print (const t8_dpyramid_t *p)
-{
-  t8_debugf ("x: %i, y: %i, z: %i, type %i, level: %i, switches_shape_at_level: %i\n", p->pyramid.x, p->pyramid.y,
-             p->pyramid.z, p->pyramid.type, p->pyramid.level, p->switch_shape_at_level);
 }

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
@@ -386,13 +386,6 @@ t8_dpyramid_nearest_common_ancestor (const t8_dpyramid_t *pyra1, const t8_dpyram
 int
 t8_dpyramid_is_valid (const t8_dpyramid_t *p);
 
-/**
- * Print the coordinates, the level and the type of a pyramid
- * \param[in] p        The pyramid to print
- */
-void
-t8_dpyramid_debug_print (const t8_dpyramid_t *p);
-
 T8_EXTERN_C_END ();
 
 #endif /* T8_DPYRAMID_BITS_H */

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -772,11 +772,13 @@ t8_default_scheme_quad_c::t8_element_is_valid (const t8_element_t *elem) const
 }
 
 void
-t8_default_scheme_quad_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
+t8_default_scheme_quad_c::t8_element_to_string (const t8_element_t *elem, char *debug_string,
+                                                const int string_size) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
+  T8_ASSERT (debug_string != NULL);
   p4est_quadrant_t *quad = (p4est_quadrant_t *) elem;
-  snprintf (debug_string, BUFSIZ, "x: %i, y: %i, level: %i", quad->x, quad->y, quad->level);
+  snprintf (debug_string, string_size, "x: %i, y: %i, level: %i", quad->x, quad->y, quad->level);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -100,7 +100,6 @@ t8_default_scheme_quad_c::t8_element_equal (const t8_element_t *elem1, const t8_
   return p4est_quadrant_is_equal ((const p4est_quadrant_t *) elem1, (const p4est_quadrant_t *) elem2);
 }
 
-
 void
 t8_default_scheme_quad_c::t8_element_parent (const t8_element_t *elem, t8_element_t *parent) const
 {
@@ -773,11 +772,11 @@ t8_default_scheme_quad_c::t8_element_is_valid (const t8_element_t *elem) const
 }
 
 void
-t8_default_scheme_quad_c::t8_element_debug_print (const t8_element_t *elem) const
+t8_default_scheme_quad_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
   p4est_quadrant_t *quad = (p4est_quadrant_t *) elem;
-  p4est_quadrant_print (SC_LP_DEBUG, quad);
+  snprintf (debug_string, BUFSIZ, "x: %i, y: %i, level: %i", quad->x, quad->y, quad->level);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -630,7 +630,7 @@ struct t8_default_scheme_quad_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -630,7 +630,7 @@ struct t8_default_scheme_quad_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_debug_print (const t8_element_t *elem) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
@@ -64,7 +64,6 @@ t8_default_scheme_tet_c::t8_element_equal (const t8_element_t *elem1, const t8_e
   return t8_dtet_equal ((const t8_dtet_t *) elem1, (const t8_dtet_t *) elem2);
 }
 
-
 void
 t8_default_scheme_tet_c::t8_element_parent (const t8_element_t *elem, t8_element_t *parent) const
 {
@@ -513,10 +512,12 @@ t8_default_scheme_tet_c::t8_element_is_valid (const t8_element_t *t) const
 }
 
 void
-t8_default_scheme_tet_c::t8_element_debug_print (const t8_element_t *t) const
+t8_default_scheme_tet_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
 {
-  T8_ASSERT (t8_element_is_valid (t));
-  t8_dtet_debug_print ((const t8_dtet_t *) t);
+  T8_ASSERT (t8_element_is_valid (elem));
+  t8_dtet_t *tet = (t8_dtet_t *) elem;
+  snprintf (debug_string, BUFSIZ, "x: %i, y: %i, z: %i, type: %i, level: %i", tet->x, tet->y, tet->z, tet->type,
+            tet->level);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
@@ -512,9 +512,11 @@ t8_default_scheme_tet_c::t8_element_is_valid (const t8_element_t *t) const
 }
 
 void
-t8_default_scheme_tet_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
+t8_default_scheme_tet_c::t8_element_to_string (const t8_element_t *elem, char *debug_string,
+                                               const int string_size) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
+  T8_ASSERT (debug_string != NULL);
   t8_dtet_t *tet = (t8_dtet_t *) elem;
   snprintf (debug_string, BUFSIZ, "x: %i, y: %i, z: %i, type: %i, level: %i", tet->x, tet->y, tet->z, tet->type,
             tet->level);

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
@@ -550,7 +550,7 @@ struct t8_default_scheme_tet_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_debug_print (const t8_element_t *elem) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
@@ -550,7 +550,7 @@ struct t8_default_scheme_tet_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
@@ -372,9 +372,6 @@ t8_dtet_get_level (const t8_dtet_t *t);
 int
 t8_dtet_is_valid (const t8_dtet_t *t);
 
-void
-t8_dtet_debug_print (const t8_dtet_t *t);
-
 /** Set sensible default values for a tet.
  * \param [in,out] t A tet.
  */

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
@@ -522,11 +522,13 @@ t8_default_scheme_tri_c::t8_element_is_valid (const t8_element_t *t) const
 }
 
 void
-t8_default_scheme_tri_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
+t8_default_scheme_tri_c::t8_element_to_string (const t8_element_t *elem, char *debug_string,
+                                               const int string_size) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
+  T8_ASSERT (debug_string != NULL);
   t8_dtri_t *tri = (t8_dtri_t *) elem;
-  snprintf (debug_string, BUFSIZ, "x: %i, y: %i, type: %i, level: %i", tri->x, tri->y, tri->type, tri->level);
+  snprintf (debug_string, string_size, "x: %i, y: %i, type: %i, level: %i", tri->x, tri->y, tri->type, tri->level);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
@@ -522,10 +522,11 @@ t8_default_scheme_tri_c::t8_element_is_valid (const t8_element_t *t) const
 }
 
 void
-t8_default_scheme_tri_c::t8_element_debug_print (const t8_element_t *t) const
+t8_default_scheme_tri_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
 {
-  T8_ASSERT (t8_element_is_valid (t));
-  t8_dtri_debug_print ((const t8_dtri_t *) t);
+  T8_ASSERT (t8_element_is_valid (elem));
+  t8_dtri_t *tri = (t8_dtri_t *) elem;
+  snprintf (debug_string, BUFSIZ, "x: %i, y: %i, type: %i, level: %i", tri->x, tri->y, tri->type, tri->level);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
@@ -544,7 +544,7 @@ struct t8_default_scheme_tri_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
@@ -544,7 +544,7 @@ struct t8_default_scheme_tri_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_debug_print (const t8_element_t *elem) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
@@ -108,15 +108,11 @@ t8_dtri_copy (const t8_dtri_t *t, t8_dtri_t *dest)
 int
 t8_dtri_equal (const t8_dtri_t *elem1, const t8_dtri_t *elem2)
 {
-  return (elem1->level == elem2->level 
-          && elem1->type == elem2->type
-          && elem1->x == elem2->x
-          && elem1->y == elem2->y 
+  return (elem1->level == elem2->level && elem1->type == elem2->type && elem1->x == elem2->x && elem1->y == elem2->y
 #ifdef T8_DTRI_TO_DTET
           && elem1->z == elem2->z
 #endif
-          );
-
+  );
 }
 
 int
@@ -1710,16 +1706,6 @@ t8_dtri_is_valid (const t8_dtri_t *t)
   is_valid = is_valid && 0 <= t->type && t->type < T8_DTRI_NUM_TYPES;
 
   return is_valid;
-}
-
-void
-t8_dtri_debug_print (const t8_dtri_t *t)
-{
-#ifdef T8_DTRI_TO_DTET
-  t8_debugf ("x: %i, y: %i, z: %i, type: %i, level: %i\n", t->x, t->y, t->z, t->type, t->level);
-#else
-  t8_debugf ("x: %i, y: %i, type: %i, level: %i\n", t->x, t->y, t->type, t->level);
-#endif /* T8_DTRI_TO_DTET */
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
@@ -396,12 +396,6 @@ t8_dtri_get_level (const t8_dtri_t *t);
 int
 t8_dtri_is_valid (const t8_dtri_t *t);
 
-/** Print a triangle
- * \param [in] t  triangle to be considered.
- */
-void
-t8_dtri_debug_print (const t8_dtri_t *t);
-
 #ifdef T8_ENABLE_DEBUG
 /** Set sensible default values for a triangle.
  * \param [in,out] t A triangle.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
@@ -296,11 +296,13 @@ t8_default_scheme_vertex_c::t8_element_is_valid (const t8_element_t *elem) const
 }
 
 void
-t8_default_scheme_vertex_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
+t8_default_scheme_vertex_c::t8_element_to_string (const t8_element_t *elem, char *debug_string,
+                                                  const int string_size) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
+  T8_ASSERT (debug_string != NULL);
   t8_dvertex_t *vertex = (t8_dvertex_t *) elem;
-  snprintf (debug_string, BUFSIZ, "level: %i", vertex->level);
+  snprintf (debug_string, string_size, "level: %i", vertex->level);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
@@ -296,10 +296,11 @@ t8_default_scheme_vertex_c::t8_element_is_valid (const t8_element_t *elem) const
 }
 
 void
-t8_default_scheme_vertex_c::t8_element_debug_print (const t8_element_t *elem) const
+t8_default_scheme_vertex_c::t8_element_to_string (const t8_element_t *elem, char *debug_string) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_dvertex_debug_print ((const t8_dvertex_t *) elem);
+  t8_dvertex_t *vertex = (t8_dvertex_t *) elem;
+  snprintf (debug_string, BUFSIZ, "level: %i", vertex->level);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
@@ -636,7 +636,7 @@ struct t8_default_scheme_vertex_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
 };
 

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
@@ -636,7 +636,7 @@ struct t8_default_scheme_vertex_c: public t8_default_scheme_common_c
   * \param [in]        elem  The element to print
   */
   virtual void
-  t8_element_debug_print (const t8_element_t *elem) const;
+  t8_element_to_string (const t8_element_t *elem, char *debug_string) const;
 #endif
 };
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -2,6 +2,8 @@
 #Non-recursive Makefile.am in test
 #Included from toplevel directory
 
+t8code_googletest_installed_headers = test/t8_gtest_custom_assertion.hxx
+
 t8code_googletest_programs = \
   test/t8_gtest_cmesh_bcast \
   test/t8_schemes/t8_gtest_nca \

--- a/test/t8_forest/t8_gtest_half_neighbors.cxx
+++ b/test/t8_forest/t8_gtest_half_neighbors.cxx
@@ -21,6 +21,8 @@
 */
 
 #include <gtest/gtest.h>
+#include <test/t8_gtest_custom_assertion.hxx>
+
 #include <t8_eclass.h>
 #include <t8_cmesh.h>
 #include <t8_forest/t8_forest_general.h>
@@ -116,9 +118,8 @@ TEST_P (forest_half_neighbors, test_half_neighbors)
                                                      child_ids);
           /* Check that the children at face of the neighbor are the half neighbors of the element */
           for (int ineigh = 0; ineigh < num_face_neighs; ineigh++) {
-            ASSERT_TRUE (neigh_scheme->t8_element_equal (neighbor_face_children[ineigh], half_neighbors[ineigh]))
-              << "Half neighbor " << ineigh << " at face " << face << "is not equal to child" << ineigh
-              << "of the neighbor element.\n";
+            EXPECT_ELEM_EQ (neigh_scheme, neighbor_face_children[ineigh], half_neighbors[ineigh])
+              << "ineigh = " << ineigh << " face = " << face;
           }
           neigh_scheme->t8_element_destroy (num_face_neighs, neighbor_face_children);
           T8_FREE (child_ids);

--- a/test/t8_forest/t8_gtest_search.cxx
+++ b/test/t8_forest/t8_gtest_search.cxx
@@ -21,6 +21,7 @@
 */
 
 #include <gtest/gtest.h>
+#include <test/t8_gtest_custom_assertion.hxx>
 #include <t8_eclass.h>
 #include <t8_cmesh.h>
 #include <t8_cmesh/t8_cmesh_examples.h>
@@ -78,8 +79,8 @@ t8_test_search_all_fn (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element
     *(int *) t8_sc_array_index_locidx (matched_leafs, tree_offset + tree_leaf_index) = 1;
     /* Test whether tree_leaf_index is actually the index of the element */
     test_element = t8_forest_get_element (forest, tree_offset + tree_leaf_index, &test_ltreeid);
-    EXPECT_TRUE (ts->t8_element_equal (element, test_element))
-      << "Element and index passed to search callback do not match.";
+
+    EXPECT_ELEM_EQ (ts, element, test_element);
     EXPECT_EQ (ltreeid, test_ltreeid) << "Tree mismatch in search.";
   }
   return 1;
@@ -107,8 +108,7 @@ t8_test_search_query_all_fn (t8_forest_t forest, t8_locidx_t ltreeid, const t8_e
 
     t8_locidx_t tree_offset = t8_forest_get_tree_element_offset (forest, ltreeid);
     t8_element_t *test_element = t8_forest_get_element (forest, tree_offset + tree_leaf_index, &test_ltreeid);
-    EXPECT_TRUE (ts->t8_element_equal (element, test_element))
-      << "Element and index passed to search callback do not match.";
+    EXPECT_ELEM_EQ (ts, element, test_element);
     EXPECT_EQ (ltreeid, test_ltreeid) << "Tree mismatch in search.";
   }
   return 1;

--- a/test/t8_forest/t8_gtest_transform.cxx
+++ b/test/t8_forest/t8_gtest_transform.cxx
@@ -28,6 +28,8 @@
  */
 
 #include <gtest/gtest.h>
+#include <test/t8_gtest_custom_assertion.hxx>
+
 #include <t8_eclass.h>
 #include <t8_cmesh.h>
 #include <t8_cmesh/t8_cmesh_examples.h>
@@ -78,9 +80,9 @@ t8_test_transform_element (t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_
   ts->t8_element_new (1, &transform);
 
   ts->t8_element_transform_face (elem, transform, 0, 0, 0);
-  ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
+  EXPECT_ELEM_EQ (ts, elem, transform);
   ts->t8_element_transform_face (elem, transform, 0, 0, 1);
-  ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
+  EXPECT_ELEM_EQ (ts, elem, transform);
   if (eclass == T8_ECLASS_TRIANGLE) {
     /* For triangles we test:
      * 3 times ori = 1 sign = 0  == identity
@@ -94,23 +96,24 @@ t8_test_transform_element (t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_
     for (int itimes = 0; itimes < 3; itimes++) {
       ts->t8_element_transform_face (transform, transform, 1, 0, 0);
     }
-    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
+
+    EXPECT_ELEM_EQ (ts, elem, transform);
     /* or = 1 sign = 0, then or = 2 sign = 0 */
     ts->t8_element_transform_face (transform, transform, 1, 0, 0);
     ts->t8_element_transform_face (transform, transform, 2, 0, 0);
-    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
+    EXPECT_ELEM_EQ (ts, elem, transform);
     /* or = 2 sign = 0, then or = 1 sign = 0 */
     ts->t8_element_transform_face (transform, transform, 2, 0, 0);
     ts->t8_element_transform_face (transform, transform, 1, 0, 0);
-    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
+    EXPECT_ELEM_EQ (ts, elem, transform);
     /* or = 1 sign = 1, then or = 1 sign = 1 */
     ts->t8_element_transform_face (transform, transform, 1, 1, 0);
     ts->t8_element_transform_face (transform, transform, 1, 1, 0);
-    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
+    EXPECT_ELEM_EQ (ts, elem, transform);
     /* or = 2 sign = 1, then or = 2 sign = 1 */
     ts->t8_element_transform_face (transform, transform, 2, 1, 0);
     ts->t8_element_transform_face (transform, transform, 2, 1, 0);
-    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal";
+    EXPECT_ELEM_EQ (ts, elem, transform);
   }
   else {
     T8_ASSERT (eclass == T8_ECLASS_QUAD);
@@ -128,21 +131,23 @@ t8_test_transform_element (t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_
     for (int itimes = 0; itimes < 4; itimes++) {
       ts->t8_element_transform_face (transform, transform, 1, 0, 1);
     }
-    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal. Quad. 4 times or 1.";
+    EXPECT_ELEM_EQ (ts, elem, transform);
     /* 4 times or = 1 sign = 0, if not smaller face */
     for (int itimes = 0; itimes < 4; itimes++) {
       ts->t8_element_transform_face (transform, transform, 1, 0, 0);
     }
-    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal. Quad. 4 times or 1 not smaller.";
+    EXPECT_ELEM_EQ (ts, elem, transform);
     /* or = 1 sign = 0, then or = 3 sign = 0, then ori = 1 sign = 0 */
     ts->t8_element_transform_face (transform, transform, 1, 0, 1);
     ts->t8_element_transform_face (transform, transform, 3, 0, 1);
     ts->t8_element_transform_face (transform, transform, 1, 0, 1);
-    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal. Quad. or 1 then or 3";
+    EXPECT_ELEM_EQ (ts, elem, transform);
+    ;
     /* or = 2 sign = 0, then or = 1 sign = 0 */
     ts->t8_element_transform_face (transform, transform, 2, 0, 1);
     ts->t8_element_transform_face (transform, transform, 1, 0, 1);
-    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal. Quad. or 2 then or 1";
+    EXPECT_ELEM_EQ (ts, elem, transform);
+    ;
     /* TODO: Add tests */
   }
 
@@ -151,14 +156,10 @@ t8_test_transform_element (t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_
     for (int sign = 0; sign < 2; sign++) {
       ts->t8_element_transform_face (elem, transform, iorientation, sign, 1);
       ts->t8_element_transform_face (transform, transform, iorientation, sign, 0);
-      ASSERT_TRUE (ts->t8_element_equal (elem, transform))
-        << "Elements are not equal. " << t8_eclass_to_string[eclass] << " back forth. Orientation " << iorientation
-        << " smaller sign " << sign;
+      EXPECT_ELEM_EQ (ts, elem, transform) << "Orientation " << iorientation << " smaller sign " << sign;
       ts->t8_element_transform_face (elem, transform, iorientation, sign, 0);
       ts->t8_element_transform_face (transform, transform, iorientation, sign, 1);
-      ASSERT_TRUE (ts->t8_element_equal (elem, transform))
-        << "Elements are not equal. " << t8_eclass_to_string[eclass] << " back forth. Orientation " << iorientation
-        << " not smaller sign " << sign;
+      EXPECT_ELEM_EQ (ts, elem, transform) << "Orientation " << iorientation << " not smaller sign " << sign;
     }
   }
 

--- a/test/t8_forest/t8_gtest_transform.cxx
+++ b/test/t8_forest/t8_gtest_transform.cxx
@@ -133,8 +133,7 @@ t8_test_transform_element (t8_eclass_scheme_c *ts, const t8_element_t *elem, t8_
     for (int itimes = 0; itimes < 4; itimes++) {
       ts->t8_element_transform_face (transform, transform, 1, 0, 0);
     }
-    ASSERT_TRUE (ts->t8_element_equal (elem, transform))
-      << "Elements are not equal. Quad. 4 times or 1 not smaller.";
+    ASSERT_TRUE (ts->t8_element_equal (elem, transform)) << "Elements are not equal. Quad. 4 times or 1 not smaller.";
     /* or = 1 sign = 0, then or = 3 sign = 0, then ori = 1 sign = 0 */
     ts->t8_element_transform_face (transform, transform, 1, 0, 1);
     ts->t8_element_transform_face (transform, transform, 3, 0, 1);

--- a/test/t8_gtest_custom_assertion.hxx
+++ b/test/t8_gtest_custom_assertion.hxx
@@ -30,12 +30,12 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 /**
  * \brief Test two elements for equality and print the elements if they aren't equal
  * 
- * \param ts_expr The name of the scheme \a ts
- * \param elem_1_expr The name of the first element \a elem_1
- * \param elem_2_expr The name of the second element \a elem_2
- * \param ts The scheme to use to check the equality
- * \param elem_1 The element to compare with \a elem_2
- * \param elem_2 the element to compare with \a elem_1
+ * \param[in] ts_expr The name of the scheme \a ts
+ * \param[in] elem_1_expr The name of the first element \a elem_1
+ * \param[in] elem_2_expr The name of the second element \a elem_2
+ * \param[in] ts The scheme to use to check the equality
+ * \param[in] elem_1 The element to compare with \a elem_2
+ * \param[in] elem_2 the element to compare with \a elem_1
  * \return testing::AssertionResult 
  */
 testing::AssertionResult

--- a/test/t8_gtest_custom_assertion.hxx
+++ b/test/t8_gtest_custom_assertion.hxx
@@ -51,8 +51,8 @@ element_equality (const char *ts_expr, const char *elem_1_expr, const char *elem
     char elem_2_string[BUFSIZ];
     ts->t8_element_to_string (elem_1, elem_1_string);
     ts->t8_element_to_string (elem_2, elem_2_string);
-    return testing::AssertionFailure () << elem_1_expr << ": " << elem_1_string << " is not equal to \n"
-                                        << elem_2_expr << ": " << elem_2_string << " given scheme " << ts_expr;
+    return testing::AssertionFailure () << elem_1_expr << " " << elem_1_string << " is not equal to \n"
+                                        << elem_2_expr << " " << elem_2_string << " given scheme " << ts_expr;
 #else
     return testing::AssertionFailure () << elem_1_expr << " is not equal to \n"
                                         << elem_2_expr << " given scheme " << ts_expr;

--- a/test/t8_gtest_custom_assertion.hxx
+++ b/test/t8_gtest_custom_assertion.hxx
@@ -1,0 +1,63 @@
+/*
+This file is part of t8code.
+t8code is a C library to manage a collection (a forest) of multiple
+connected adaptive space-trees of general element classes in parallel.
+
+Copyright (C) 2023 the developers
+
+t8code is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+t8code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with t8code; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_gtest_custom_assertion.cxx
+* Provide customized GoogleTest functions for improved error-output
+*/
+
+#include <gtest/gtest.h>
+#include <t8_schemes/t8_default/t8_default_cxx.hxx>
+
+/**
+ * \brief Test two elements for equality and print the elements if they aren't equal
+ * 
+ * \param ts_expr The name of the scheme \a ts
+ * \param elem_1_expr The name of the first element \a elem_1
+ * \param elem_2_expr The name of the second element \a elem_2
+ * \param ts The scheme to use to check the equality
+ * \param elem_1 The element to compare with \a elem_2
+ * \param elem_2 the element to compare with \a elem_1
+ * \return testing::AssertionResult 
+ */
+testing::AssertionResult
+element_equality (const char *ts_expr, const char *elem_1_expr, const char *elem_2_expr, const t8_eclass_scheme_c *ts,
+                  const t8_element_t *elem_1, const t8_element_t *elem_2)
+{
+  if (ts->t8_element_equal (elem_1, elem_2)) {
+    return testing::AssertionSuccess ();
+  }
+  else {
+#if T8_ENABLE_DEBUG
+    char elem_1_string[BUFSIZ];
+    char elem_2_string[BUFSIZ];
+    ts->t8_element_to_string (elem_1, elem_1_string);
+    ts->t8_element_to_string (elem_2, elem_2_string);
+    return testing::AssertionFailure () << elem_1_expr << ": " << elem_1_string << " is not equal to \n"
+                                        << elem_2_expr << ": " << elem_2_string << " given scheme " << ts_expr;
+#else
+    return testing::AssertionFailure () << elem_1_expr << " is not equal to \n"
+                                        << elem_2_expr << " given scheme " << ts_expr;
+#endif
+  }
+}
+
+#define EXPECT_ELEM_EQ(scheme, elem1, elem2) EXPECT_PRED_FORMAT3 (element_equality, (scheme), (elem1), (elem2))

--- a/test/t8_gtest_custom_assertion.hxx
+++ b/test/t8_gtest_custom_assertion.hxx
@@ -49,8 +49,8 @@ element_equality (const char *ts_expr, const char *elem_1_expr, const char *elem
 #if T8_ENABLE_DEBUG
     char elem_1_string[BUFSIZ];
     char elem_2_string[BUFSIZ];
-    ts->t8_element_to_string (elem_1, elem_1_string);
-    ts->t8_element_to_string (elem_2, elem_2_string);
+    ts->t8_element_to_string (elem_1, elem_1_string, BUFSIZ);
+    ts->t8_element_to_string (elem_2, elem_2_string, BUFSIZ);
     return testing::AssertionFailure () << elem_1_expr << " " << elem_1_string << " is not equal to \n"
                                         << elem_2_expr << " " << elem_2_string << " given scheme " << ts_expr;
 #else

--- a/test/t8_schemes/t8_gtest_ancestor.cxx
+++ b/test/t8_schemes/t8_gtest_ancestor.cxx
@@ -26,6 +26,7 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include <gtest/gtest.h>
+#include <test/t8_gtest_custom_assertion.hxx>
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
@@ -78,10 +79,9 @@ t8_recursive_ancestor (t8_element_t *element, t8_element_t *child, t8_element_t 
   for (i = 0; i < num_children; i++) {
     ts->t8_element_child (parent, i, child);
     t8_dpyramid_ancestor ((t8_dpyramid_t *) child, level, (t8_dpyramid_t *) test_anc);
-    SC_CHECK_ABORT (ts->t8_element_equal (parent, test_anc), "Computed ancestor is not equal to the parent\n");
+    EXPECT_ELEM_EQ (ts, parent, test_anc);
     t8_dpyramid_ancestor ((t8_dpyramid_t *) child, elem_lvl, (t8_dpyramid_t *) test_anc);
-    SC_CHECK_ABORT (ts->t8_element_equal (element, test_anc),
-                    "Computed ancestor is not equal to the correct ancestor\n");
+    EXPECT_ELEM_EQ (ts, element, test_anc);
     t8_recursive_ancestor (element, parent, child, test_anc, ts, maxlvl);
     ts->t8_element_parent (child, parent);
   }

--- a/test/t8_schemes/t8_gtest_descendant.cxx
+++ b/test/t8_schemes/t8_gtest_descendant.cxx
@@ -24,6 +24,7 @@
 #include <gtest/gtest.h>
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
+#include <test/t8_gtest_custom_assertion.hxx>
 
 /* This program tests the descendant function of an element. */
 
@@ -76,12 +77,12 @@ t8_recursive_descendant (t8_element_t *elem, t8_element_t *desc, t8_element_t *t
     /* first child == first descendant. */
     if (ichild == 0) {
       ts->t8_element_first_descendant (elem, test, level + 1);
-      ASSERT_TRUE (ts->t8_element_equal (desc, test)) << "wrong first descendant.\n";
+      EXPECT_ELEM_EQ (ts, desc, test);
     }
     /* last child == last descendant. */
     else if (ichild == num_children - 1) {
       ts->t8_element_last_descendant (elem, test, level + 1);
-      ASSERT_TRUE (ts->t8_element_equal (desc, test)) << "Wrong last descendant.\n";
+      EXPECT_ELEM_EQ (ts, desc, test);
     }
     else if (level > maxlvl) {
       t8_recursive_descendant (desc, elem, test, ts, maxlvl);
@@ -104,7 +105,7 @@ t8_deep_first_descendant (t8_element_t *elem, t8_element_t *desc, t8_element_t *
     ts->t8_element_copy (desc, test);
   }
   ts->t8_element_first_descendant (elem, test, level);
-  ASSERT_TRUE (ts->t8_element_equal (desc, test)) << "Wrong deep first descendant.\n";
+  EXPECT_ELEM_EQ (ts, desc, test);
 }
 
 /* Test, if the last descendant of an element is computed correctly over a range
@@ -123,7 +124,7 @@ t8_deep_last_descendant (t8_element_t *elem, t8_element_t *desc, t8_element_t *t
   }
   /* Check for equality. */
   ts->t8_element_last_descendant (elem, test, level);
-  ASSERT_TRUE (ts->t8_element_equal (desc, test)) << "Wrong deep last descendant.\n";
+  EXPECT_ELEM_EQ (ts, desc, test);
 }
 
 /* Test if the first and last descendant of an element are computed correctly.

--- a/test/t8_schemes/t8_gtest_face_descendant.cxx
+++ b/test/t8_schemes/t8_gtest_face_descendant.cxx
@@ -24,6 +24,7 @@
 #include <gtest/gtest.h>
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
+#include <test/t8_gtest_custom_assertion.hxx>
 
 class class_descendant: public testing::TestWithParam<t8_eclass_t> {
  protected:
@@ -96,7 +97,7 @@ t8_linear_face_descendant (const t8_element_t *elem, t8_element_t *manual_face_d
 
       ts->t8_element_first_descendant_face (elem, jface, face_desc, ilevel);
       /* Compare the manually computed child with the result of t8_element_first_descendant_face. */
-      ASSERT_TRUE (ts->t8_element_equal (face_desc, manual_face_desc)) << "Wrong first descendant face\n";
+      EXPECT_ELEM_EQ (ts, face_desc, manual_face_desc);
     }
   }
 
@@ -112,7 +113,7 @@ t8_linear_face_descendant (const t8_element_t *elem, t8_element_t *manual_face_d
 
       /* Compare the manuall computed child with the result of t8_element_last_descendant_face. */
       ts->t8_element_last_descendant_face (elem, jface, face_desc, ilevel);
-      ASSERT_TRUE (ts->t8_element_equal (face_desc, manual_face_desc)) << "Wrong last descendant face\n";
+      EXPECT_ELEM_EQ (ts, face_desc, manual_face_desc);
     }
   }
 }

--- a/test/t8_schemes/t8_gtest_face_neigh.cxx
+++ b/test/t8_schemes/t8_gtest_face_neigh.cxx
@@ -21,6 +21,7 @@
 */
 
 #include <gtest/gtest.h>
+#include <test/t8_gtest_custom_assertion.hxx>
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
 #include <t8_element_c_interface.h>
@@ -80,7 +81,7 @@ t8_test_face_neighbor_inside (int num_faces, t8_element_t *element, t8_element_t
     ts->t8_element_face_neighbor_inside (neigh, element, face_num, &check);
 
     EXPECT_TRUE (ts->t8_element_equal (child, element)) << "Got a false neighbor.";
-    EXPECT_EQ (check, iface) << "Wrong face.";
+    EXPECT_ELEM_EQ (ts, child, element);
   }
 }
 

--- a/test/t8_schemes/t8_gtest_find_parent.cxx
+++ b/test/t8_schemes/t8_gtest_find_parent.cxx
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
+#include <test/t8_gtest_custom_assertion.hxx>
 
 class class_find_parent: public testing::TestWithParam<t8_eclass_t> {
  protected:
@@ -79,7 +80,7 @@ t8_recursive_child_find_parent (t8_element_t *element, t8_element_t *child, t8_e
     ts->t8_element_parent (child, test_parent);
     /* If its equal, call child_find_parent, to check if parent-child relation
      * is correct in next level until maxlvl is reached*/
-    ASSERT_TRUE (ts->t8_element_equal (element, test_parent)) << "Computed child_parent is not the parent.";
+    EXPECT_ELEM_EQ (ts, element, test_parent);
 
     t8_recursive_child_find_parent (child, element, test_parent, ts, level + 1, maxlvl);
     /* After the check we know the parent-function is correct for this child.

--- a/test/t8_schemes/t8_gtest_nca.cxx
+++ b/test/t8_schemes/t8_gtest_nca.cxx
@@ -26,6 +26,7 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include <gtest/gtest.h>
+#include <test/t8_gtest_custom_assertion.hxx>
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
 
@@ -75,11 +76,11 @@ TEST_P (nca, nca_check_shallow)
   for (i = 0; i < num_children - 1; i++) {
     ts->t8_element_child (correct_nca, i, desc_a);
     for (j = i + 1; j < num_children; j++) {
-      ts->t8_element_child (correct_nca, j, desc_b);
+      ts->t8_element_child (correct_nca, 1, desc_b);
       /*Compute the nca */
       ts->t8_element_nca (desc_a, desc_b, check);
       /*expect equality */
-      EXPECT_TRUE ((ts->t8_element_equal (correct_nca, check)));
+      EXPECT_ELEM_EQ (ts, check, correct_nca);
     }
   }
 }

--- a/test/t8_schemes/t8_gtest_nca.cxx
+++ b/test/t8_schemes/t8_gtest_nca.cxx
@@ -76,7 +76,7 @@ TEST_P (nca, nca_check_shallow)
   for (i = 0; i < num_children - 1; i++) {
     ts->t8_element_child (correct_nca, i, desc_a);
     for (j = i + 1; j < num_children; j++) {
-      ts->t8_element_child (correct_nca, 1, desc_b);
+      ts->t8_element_child (correct_nca, j, desc_b);
       /*Compute the nca */
       ts->t8_element_nca (desc_a, desc_b, check);
       /*expect equality */
@@ -122,7 +122,7 @@ TEST_P (nca, nca_check_deep)
           }
           else {
             /* Expect equality of correct_nca and check for every other class */
-            EXPECT_TRUE ((ts->t8_element_equal (correct_nca, check)));
+            EXPECT_ELEM_EQ (ts, correct_nca, check);
           }
         }
       }
@@ -289,8 +289,8 @@ TEST_P (nca, recursive_check_higher_level)
           }
           else {
             ts->t8_element_nca (parent_a, parent_b, check);
-            EXPECT_TRUE ((ts->t8_element_equal (parent_a, check)));
-            EXPECT_TRUE ((ts->t8_element_equal (parent_b, check)));
+            EXPECT_ELEM_EQ (ts, parent_a, check);
+            EXPECT_ELEM_EQ (ts, parent_b, check);
           }
         }
       }

--- a/test/t8_schemes/t8_gtest_successor.cxx
+++ b/test/t8_schemes/t8_gtest_successor.cxx
@@ -24,6 +24,7 @@
 #include <gtest/gtest.h>
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
+#include <test/t8_gtest_custom_assertion.hxx>
 
 class class_successor: public testing::TestWithParam<t8_eclass_t> {
  protected:
@@ -77,12 +78,12 @@ t8_recursive_successor (t8_element_t *element, t8_element_t *successor, t8_eleme
      * of this element.
      */
     ts->t8_element_child (element, 0, child);
-    ASSERT_TRUE (ts->t8_element_equal (child, successor)) << "Wrong Successor, Case1.\n";
+    EXPECT_ELEM_EQ (ts, child, successor);
     /*Check if the successor in this element is computed correctly */
     for (int ichild = 1; ichild < num_children; ichild++) {
       ts->t8_element_successor (child, successor, maxlvl);
       ts->t8_element_child (element, ichild, child);
-      ASSERT_TRUE (ts->t8_element_equal (child, successor)) << "Wrong Successor, Case2.\n";
+      EXPECT_ELEM_EQ (ts, child, successor);
     }
     /*If the iterator is the last element, the test can finish */
     if (ts->t8_element_equal (last, child)) {


### PR DESCRIPTION
Adds a header where customized googletest functions can be implemented.
Implements an assertion for two elements to check equality and prints the elements in debug-modus



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
