### PR TITLE
Helper class to test scheme functionality on all elements by DFS

### DIFF
--- a/test/t8_cmesh/t8_gtest_bcast.cxx
+++ b/test/t8_cmesh/t8_gtest_bcast.cxx
@@ -56,4 +56,4 @@ TEST_P (cmesh_hypercube, bcast_equal_no_bcast)
   EXPECT_TRUE (t8_cmesh_is_equal (cmesh_bcast, cmesh_check));
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_bcast, cmesh_hypercube, testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_bcast, cmesh_hypercube, AllEclasses);

--- a/test/t8_cmesh/t8_gtest_bcast.cxx
+++ b/test/t8_cmesh/t8_gtest_bcast.cxx
@@ -30,6 +30,7 @@
 #include <gtest/gtest.h>
 #include <t8_cmesh.h>
 #include <t8_cmesh/t8_cmesh_examples.h>
+#include <test/t8_gtest_macros.hxx>
 
 class cmesh_hypercube: public testing::TestWithParam<t8_eclass> {
  protected:

--- a/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
@@ -74,5 +74,4 @@ TEST_P (cmesh_copy_equality, check_equality_of_copied_cmesh_with_original)
 }
 
 /* Test all cmeshes over all different inputs we get through their id */
-INSTANTIATE_TEST_SUITE_P (t8_gtest_cmesh_copy, cmesh_copy_equality,
-                          testing::Range (0, t8_get_number_of_all_testcases ()));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_cmesh_copy, cmesh_copy_equality, AllCmeshs);

--- a/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
@@ -26,6 +26,7 @@
 #include "t8_cmesh/t8_cmesh_partition.h"
 #include <t8_eclass.h>
 #include <t8_cmesh/t8_cmesh_testcases.h>
+#include <test/t8_gtest_macros.hxx>
 
 /* Test if a cmesh is committed properly and perform the face consistency check. */
 

--- a/test/t8_cmesh/t8_gtest_cmesh_face_is_boundary.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_face_is_boundary.cxx
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 #include <t8_cmesh.h>
 #include <t8_cmesh/t8_cmesh_examples.h>
+#include <test/t8_gtest_macros.hxx>
 
 /* Test for one tree */
 class cmesh_face_boundary_one_tree: public testing::TestWithParam<t8_eclass> {

--- a/test/t8_cmesh/t8_gtest_cmesh_face_is_boundary.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_face_is_boundary.cxx
@@ -62,8 +62,7 @@ TEST_P (cmesh_face_boundary_one_tree, check_face_is_boundary_one_tree)
   }
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_cmesh_face_boundary, cmesh_face_boundary_one_tree,
-                          testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_cmesh_face_boundary, cmesh_face_boundary_one_tree, AllEclasses);
 
 /* For a two tree cmesh, compute a parallel distribution of the trees.
  * If we have more than 1 process, the first half of process (rank < size/2)
@@ -197,4 +196,4 @@ TEST_P (cmesh_face_boundary_two_trees, check_face_is_boundary_two_trees)
 }
 
 INSTANTIATE_TEST_SUITE_P (t8_gtest_cmesh_face_boundary, cmesh_face_boundary_two_trees,
-                          testing::Combine (testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT), testing::Values (0, 1)));
+                          testing::Combine (AllEclasses, testing::Values (0, 1)));

--- a/test/t8_cmesh/t8_gtest_cmesh_partition.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_partition.cxx
@@ -129,5 +129,4 @@ TEST_P (t8_cmesh_partition_class, test_cmesh_partition_concentrate)
 }
 
 /* Test all cmeshes over all different inputs we get through their id */
-INSTANTIATE_TEST_SUITE_P (t8_gtest_cmesh_partition, t8_cmesh_partition_class,
-                          testing::Range (0, t8_get_number_of_all_testcases ()));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_cmesh_partition, t8_cmesh_partition_class, AllCmeshs);

--- a/test/t8_cmesh/t8_gtest_cmesh_partition.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_partition.cxx
@@ -26,6 +26,7 @@
 #include "t8_cmesh/t8_cmesh_trees.h"
 #include "t8_cmesh/t8_cmesh_partition.h"
 #include <t8_cmesh/t8_cmesh_testcases.h>
+#include <test/t8_gtest_macros.hxx>
 
 /* We create a cmesh, partition it and repartition it several times.
  * At the end we result in the same partition as at the beginning and we

--- a/test/t8_cmesh/t8_gtest_cmesh_set_join_by_vertices.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_set_join_by_vertices.cxx
@@ -401,5 +401,4 @@ TEST_P (t8_cmesh_set_join_by_vertices_class, test_cmesh_set_join_by_vertices_par
 }
 
 /* Test all cmeshes over all different inputs we get through their id */
-INSTANTIATE_TEST_SUITE_P (t8_cmesh_set_join_by_vertices, t8_cmesh_set_join_by_vertices_class,
-                          testing::Range (0, t8_get_number_of_all_testcases ()));
+INSTANTIATE_TEST_SUITE_P (t8_cmesh_set_join_by_vertices, t8_cmesh_set_join_by_vertices_class, AllCmeshs);

--- a/test/t8_cmesh/t8_gtest_cmesh_set_join_by_vertices.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_set_join_by_vertices.cxx
@@ -27,6 +27,7 @@
 #include <t8_cmesh/t8_cmesh_examples.h>
 #include <t8_cmesh/t8_cmesh_helpers.h>
 #include <t8_cmesh/t8_cmesh_testcases.h>
+#include <test/t8_gtest_macros.hxx>
 
 #include <p8est_geometry.h>
 

--- a/test/t8_cmesh/t8_gtest_hypercube.cxx
+++ b/test/t8_cmesh/t8_gtest_hypercube.cxx
@@ -64,5 +64,4 @@ TEST_P (cmesh_hypercube_trees, check_cmesh_and_its_trees)
 /* Use the testing range for eclass with [T8_ECLASS_ZERO, T8_ECLASS_COUNT]. For the generation of the cmesh with or withaout broadcast
  * the booleans 0 and 1 are used. Analogue with partition. */
 INSTANTIATE_TEST_SUITE_P (t8_gtest_hypercube, cmesh_hypercube_trees,
-                          testing::Combine (testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT), testing::Values (0, 1),
-                                            testing::Values (0, 1)));
+                          testing::Combine (AllEclasses, testing::Values (0, 1), testing::Values (0, 1)));

--- a/test/t8_cmesh/t8_gtest_hypercube.cxx
+++ b/test/t8_cmesh/t8_gtest_hypercube.cxx
@@ -27,6 +27,7 @@
 #include <t8_cmesh.h>
 #include "t8_cmesh/t8_cmesh_trees.h"
 #include <t8_cmesh/t8_cmesh_examples.h>
+#include <test/t8_gtest_macros.hxx>
 
 /* Create class for parameterized Test with multiple test parameters */
 class cmesh_hypercube_trees: public testing::TestWithParam<std::tuple<t8_eclass, int, int>> {

--- a/test/t8_forest/t8_gtest_element_general_function.cxx
+++ b/test/t8_forest/t8_gtest_element_general_function.cxx
@@ -29,6 +29,7 @@
 #include <t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid.h>
 #include <t8_cmesh/t8_cmesh_examples.h>
 #include <t8_forest/t8_forest_general.h>
+#include <test/t8_gtest_macros.hxx>
 
 /*
  * In this file we test whether the t8_element_general_function

--- a/test/t8_forest/t8_gtest_element_general_function.cxx
+++ b/test/t8_forest/t8_gtest_element_general_function.cxx
@@ -104,4 +104,4 @@ TEST_P (forest_element_function, test_element_general_function)
 }
 
 INSTANTIATE_TEST_SUITE_P (t8_gtest_element_general_function, forest_element_function,
-                          testing::Combine (testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT), testing::Range (0, 6)));
+                          testing::Combine (AllEclasses, testing::Range (0, 6)));

--- a/test/t8_forest/t8_gtest_element_volume.cxx
+++ b/test/t8_forest/t8_gtest_element_volume.cxx
@@ -116,4 +116,4 @@ TEST_P (t8_forest_volume, volume_check)
 }
 
 INSTANTIATE_TEST_SUITE_P (t8_gtest_element_volume, t8_forest_volume,
-                          testing::Combine (testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT), testing::Range (0, 4)));
+                          testing::Combine (AllEclasses, testing::Range (0, 4)));

--- a/test/t8_forest/t8_gtest_element_volume.cxx
+++ b/test/t8_forest/t8_gtest_element_volume.cxx
@@ -28,6 +28,7 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 #include <t8_cmesh/t8_cmesh_examples.h>
 #include <t8_forest/t8_forest_general.h>
 #include <t8_forest/t8_forest_geometrical.h>
+#include <test/t8_gtest_macros.hxx>
 
 /**
  * This file tests the volume-computation of elements.

--- a/test/t8_forest/t8_gtest_find_owner.cxx
+++ b/test/t8_forest/t8_gtest_find_owner.cxx
@@ -169,4 +169,4 @@ TEST_P (forest_find_owner, find_multiple_owners)
   sc_array_reset (&owners);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_find_owner, forest_find_owner, testing::Range (T8_ECLASS_VERTEX, T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_find_owner, forest_find_owner, AllEclasses);

--- a/test/t8_forest/t8_gtest_find_owner.cxx
+++ b/test/t8_forest/t8_gtest_find_owner.cxx
@@ -32,6 +32,7 @@
 #include <t8_cmesh/t8_cmesh_examples.h>
 #include <t8_forest/t8_forest_partition.h>
 #include <t8_forest/t8_forest_private.h>
+#include <test/t8_gtest_macros.hxx>
 
 class forest_find_owner: public testing::TestWithParam<t8_eclass> {
  protected:

--- a/test/t8_forest/t8_gtest_forest_commit.cxx
+++ b/test/t8_forest/t8_gtest_forest_commit.cxx
@@ -28,6 +28,7 @@
 #include <t8_forest/t8_forest_partition.h>
 #include <t8_forest/t8_forest_private.h>
 #include "t8_cmesh/t8_cmesh_testcases.h"
+#include <test/t8_gtest_macros.hxx>
 
 /* In this test, we adapt, balance and partition a uniform forest.
  * We do this in two ways:

--- a/test/t8_forest/t8_gtest_forest_commit.cxx
+++ b/test/t8_forest/t8_gtest_forest_commit.cxx
@@ -170,4 +170,4 @@ TEST_P (forest_commit, test_forest_commit)
   t8_debugf ("Done testing forest commit.");
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_forest_commit, forest_commit, testing::Range (0, t8_get_number_of_all_testcases ()));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_forest_commit, forest_commit, AllCmeshs);

--- a/test/t8_forest/t8_gtest_ghost_and_owner.cxx
+++ b/test/t8_forest/t8_gtest_ghost_and_owner.cxx
@@ -141,5 +141,4 @@ TEST_P (forest_ghost_owner, test_ghost_owner)
   }
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_ghost_and_owner, forest_ghost_owner,
-                          testing::Range (0, t8_get_number_of_all_testcases ()));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_ghost_and_owner, forest_ghost_owner, AllCmeshs);

--- a/test/t8_forest/t8_gtest_ghost_and_owner.cxx
+++ b/test/t8_forest/t8_gtest_ghost_and_owner.cxx
@@ -28,6 +28,7 @@
 #include <t8_forest/t8_forest_private.h>
 #include <t8_cmesh.h>
 #include "t8_cmesh/t8_cmesh_testcases.h"
+#include <test/t8_gtest_macros.hxx>
 
 /* This test program tests the forest ghost layer.
  * We adapt a forest and create its ghost layer. Afterwards, we

--- a/test/t8_forest/t8_gtest_ghost_exchange.cxx
+++ b/test/t8_forest/t8_gtest_ghost_exchange.cxx
@@ -28,6 +28,7 @@
 #include <t8_forest/t8_forest_private.h>
 #include <t8_cmesh.h>
 #include "t8_cmesh/t8_cmesh_testcases.h"
+#include <test/t8_gtest_macros.hxx>
 
 /* TODO: when this test works for all cmeshes remove if statement in test_cmesh_ghost_exchange_all () */
 

--- a/test/t8_forest/t8_gtest_ghost_exchange.cxx
+++ b/test/t8_forest/t8_gtest_ghost_exchange.cxx
@@ -193,5 +193,4 @@ TEST_P (forest_ghost_exchange, test_ghost_exchange)
   }
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_ghost_exchange, forest_ghost_exchange,
-                          testing::Range (0, t8_get_number_of_all_testcases ()));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_ghost_exchange, forest_ghost_exchange, AllCmeshs);

--- a/test/t8_forest/t8_gtest_half_neighbors.cxx
+++ b/test/t8_forest/t8_gtest_half_neighbors.cxx
@@ -136,4 +136,4 @@ TEST_P (forest_half_neighbors, test_half_neighbors)
 }
 
 INSTANTIATE_TEST_SUITE_P (t8_gtest_half_neighbors, forest_half_neighbors,
-                          testing::Combine (testing::Range (T8_ECLASS_VERTEX, T8_ECLASS_COUNT), testing::Range (0, 3)));
+                          testing::Combine (AllEclasses, testing::Range (0, 3)));

--- a/test/t8_forest/t8_gtest_half_neighbors.cxx
+++ b/test/t8_forest/t8_gtest_half_neighbors.cxx
@@ -33,6 +33,7 @@
 #include <t8_cmesh/t8_cmesh_examples.h>
 #include <t8_forest/t8_forest_partition.h>
 #include <t8_forest/t8_forest_private.h>
+#include <test/t8_gtest_macros.hxx>
 
 class forest_half_neighbors: public testing::TestWithParam<std::tuple<t8_eclass, int>> {
  protected:

--- a/test/t8_forest/t8_gtest_search.cxx
+++ b/test/t8_forest/t8_gtest_search.cxx
@@ -28,6 +28,7 @@
 #include <t8_forest/t8_forest_general.h>
 #include <t8_forest/t8_forest_iterate.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
+#include <test/t8_gtest_macros.hxx>
 
 class forest_search: public testing::TestWithParam<std::tuple<t8_eclass, int>> {
  protected:

--- a/test/t8_forest/t8_gtest_search.cxx
+++ b/test/t8_forest/t8_gtest_search.cxx
@@ -151,5 +151,4 @@ TEST_P (forest_search, test_search_one_query_matches_all)
   sc_array_reset (&queries);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_search, forest_search,
-                          testing::Combine (testing::Range (T8_ECLASS_VERTEX, T8_ECLASS_COUNT), testing::Range (0, 6)));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_search, forest_search, testing::Combine (AllEclasses, testing::Range (0, 6)));

--- a/test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
@@ -26,6 +26,7 @@
 #include <t8_forest/t8_forest.h>
 #include <t8_forest/t8_forest_types.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
+#include <test/t8_gtest_macros.hxx>
 
 /** In this test, we are given a forest with 3 global trees. 
  * We adapt the forest so that all 6 compositions of empty 

--- a/test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
@@ -168,4 +168,4 @@ TEST_P (global_tree, test_empty_global_tree)
 }
 
 INSTANTIATE_TEST_SUITE_P (t8_gtest_empty_global_tree, global_tree,
-                          testing::Combine (testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT), testing::Range (0, 6)));
+                          testing::Combine (AllEclasses, testing::Range (0, 6)));

--- a/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
@@ -238,5 +238,4 @@ TEST_P (forest_iterate, test_iterate_replace)
   }
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_iterate_replace, forest_iterate,
-                          testing::Range (0, t8_get_number_of_all_testcases ()));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_iterate_replace, forest_iterate, AllCmeshs);

--- a/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
@@ -27,6 +27,7 @@
 #include <t8_forest/t8_forest.h>
 #include <t8_forest/t8_forest_iterate.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
+#include <test/t8_gtest_macros.hxx>
 
 /* In this test, we first adapt a forest and store every callback return value.
  * In the next step, we call t8_forest_iterate_replace. Instead of interpolating

--- a/test/t8_forest_incomplete/t8_gtest_permute_hole.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_permute_hole.cxx
@@ -175,4 +175,4 @@ TEST_P (forest_permute, test_permute_hole)
   }
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_permute_hole, forest_permute, testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_permute_hole, forest_permute, AllEclasses);

--- a/test/t8_forest_incomplete/t8_gtest_permute_hole.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_permute_hole.cxx
@@ -26,6 +26,7 @@
 #include <t8_forest/t8_forest.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
 #include <bitset>
+#include <test/t8_gtest_macros.hxx>
 
 #define MAX_NUM_ELEMENTS 32 /* number of digits for binary representation */
 

--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -151,4 +151,4 @@ TEST (gtest_eclass, eclass_order)
   EXPECT_EQ (t8_eclass_compare (T8_ECLASS_HEX, T8_ECLASS_TET), 1);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_eclass, gtest_eclass, testing::Range ((int) T8_ECLASS_ZERO, (int) T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_eclass, gtest_eclass, AllEclasses);

--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -26,15 +26,16 @@
 #include <t8_cmesh.h>
 #include <t8_cmesh/t8_cmesh_examples.h>
 #include <t8_vec.h>
+#include <test/t8_gtest_macros.hxx>
 
-class gtest_eclass: public testing::TestWithParam<int> {
+class gtest_eclass: public testing::TestWithParam<t8_eclass_t> {
  protected:
   void
   SetUp () override
   {
     ieclass = GetParam ();
   }
-  int ieclass;
+  t8_eclass_t ieclass;
 };
 
 TEST (gtest_eclass, eclassCountIs8)

--- a/test/t8_gtest_macros.hxx
+++ b/test/t8_gtest_macros.hxx
@@ -30,8 +30,7 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 #ifndef T8_GTEST_MACROS_HXX
 #define T8_GTEST_MACROS_HXX
 
-
-#define AllImplementations testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT)
-
+#define AllEclasses testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT)
+#define AllCmeshs testing::Range (0, t8_get_number_of_all_testcases ())
 
 #endif /* T8_GTEST_MACROS_HXX */

--- a/test/t8_gtest_macros.hxx
+++ b/test/t8_gtest_macros.hxx
@@ -20,8 +20,8 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-/** \file t8_gtest_custom_assertion.cxx
-* Provide customized GoogleTest functions for improved error-output
+/** \file t8_gtest_macros.hxx
+* Provide macros for instantiating parameterized tests
 */
 
 #include <gtest/gtest.h>

--- a/test/t8_gtest_macros.hxx
+++ b/test/t8_gtest_macros.hxx
@@ -1,0 +1,37 @@
+/*
+This file is part of t8code.
+t8code is a C library to manage a collection (a forest) of multiple
+connected adaptive space-trees of general element classes in parallel.
+
+Copyright (C) 2023 the developers
+
+t8code is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+t8code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with t8code; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_gtest_custom_assertion.cxx
+* Provide customized GoogleTest functions for improved error-output
+*/
+
+#include <gtest/gtest.h>
+#include <t8_eclass.h>
+
+#ifndef T8_GTEST_MACROS_HXX
+#define T8_GTEST_MACROS_HXX
+
+
+#define AllImplementations testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT)
+
+
+#endif /* T8_GTEST_MACROS_HXX */

--- a/test/t8_schemes/t8_gtest_default.cxx
+++ b/test/t8_schemes/t8_gtest_default.cxx
@@ -87,5 +87,4 @@ TEST_P (gtest_default_scheme, is_default)
   EXPECT_TRUE (t8_eclass_scheme_is_default (eclass_scheme));
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_default_scheme, gtest_default_scheme,
-                          testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_default_scheme, gtest_default_scheme, AllEclasses);

--- a/test/t8_schemes/t8_gtest_default.cxx
+++ b/test/t8_schemes/t8_gtest_default.cxx
@@ -36,6 +36,7 @@
 #include <t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx>
 #include <t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx>
 #include <t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx>
+#include <test/t8_gtest_macros.hxx>
 
 class gtest_default_scheme: public testing::TestWithParam<t8_eclass_t> {
  protected:

--- a/test/t8_schemes/t8_gtest_descendant.cxx
+++ b/test/t8_schemes/t8_gtest_descendant.cxx
@@ -156,5 +156,4 @@ TEST_P (class_schemes_descendant, test_recursive_descendant)
   t8_large_step_descendant (elem, desc, test, ts, maxlvl);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_descendant, class_schemes_descendant,
-                          testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_descendant, class_schemes_descendant, AllEclasses);

--- a/test/t8_schemes/t8_gtest_descendant.cxx
+++ b/test/t8_schemes/t8_gtest_descendant.cxx
@@ -25,6 +25,7 @@
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
 #include <test/t8_gtest_custom_assertion.hxx>
+#include <test/t8_gtest_macros.hxx>
 
 /* This program tests the descendant function of an element. */
 

--- a/test/t8_schemes/t8_gtest_dfs_base.hxx
+++ b/test/t8_schemes/t8_gtest_dfs_base.hxx
@@ -27,8 +27,6 @@
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
 
-#define AllImplementations testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT)
-
 class TestDFS : public testing::TestWithParam<t8_eclass_t> {
  public:
 /** recursive tests check something for all descendants of a starting element upto maxlevel
@@ -36,22 +34,22 @@ class TestDFS : public testing::TestWithParam<t8_eclass_t> {
   virtual void
   check_element (const t8_element_t *elem){};
 
-  /** recursive depth first search to iterate over all descendants of elem up to maxlvl */
+  /** recursive depth first search to iterate over all descendants of elem up to max_dfs_recursion_level */
   void
-  check_recursive_dfs_to_max_lvl ()
+  check_recursive_dfs_to_max_lvl (int max_dfs_recursion_level)
   {
     int level = ts->t8_element_level (element);
-    ASSERT_LE (level, maxlvl);
-    ASSERT_LT (maxlvl, ts->t8_element_maxlevel ());
+    ASSERT_LE (level, max_dfs_recursion_level);
+    ASSERT_LT (max_dfs_recursion_level, ts->t8_element_maxlevel ());
 
     check_element (element);
 
-    if (ts->t8_element_level (element) < maxlvl) {
+    if (ts->t8_element_level (element) < max_dfs_recursion_level) {
       /* iterate over all children */
       const int num_children = ts->t8_element_num_children (element);
       for (int ichild = 0; ichild < num_children; ichild++) {
         ts->t8_element_child (element, ichild, element);
-        check_recursive_dfs_to_max_lvl ();
+        check_recursive_dfs_to_max_lvl (max_dfs_recursion_level);
         ts->t8_element_parent (element, element);
       }
     }
@@ -88,8 +86,6 @@ class TestDFS : public testing::TestWithParam<t8_eclass_t> {
   t8_eclass_t eclass;
   t8_eclass_scheme_c *ts;
   t8_element_t *element;
-
-  const int maxlvl = 4;
 };
 
 #endif /*T8_GTEST_SCHEME_HELPER_H*/

--- a/test/t8_schemes/t8_gtest_dfs_base.hxx
+++ b/test/t8_schemes/t8_gtest_dfs_base.hxx
@@ -29,19 +29,20 @@
 
 class TestDFS : public testing::TestWithParam<t8_eclass_t> {
  public:
-/** recursive tests check something for all descendants of a starting element upto maxlevel
+/** recursive tests check something for all descendants of a starting element (currently only root) upto maxlevel
 */
   virtual void
   check_element (const t8_element_t *elem){};
 
   /** recursive depth first search to iterate over all descendants of elem up to max_dfs_recursion_level */
   void
-  check_recursive_dfs_to_max_lvl (int max_dfs_recursion_level)
+  check_recursive_dfs_to_max_lvl (const int max_dfs_recursion_level)
   {
     int level = ts->t8_element_level (element);
     ASSERT_LE (level, max_dfs_recursion_level);
     ASSERT_LT (max_dfs_recursion_level, ts->t8_element_maxlevel ());
 
+    /** call the implementation of the specific test*/
     check_element (element);
 
     if (ts->t8_element_level (element) < max_dfs_recursion_level) {

--- a/test/t8_schemes/t8_gtest_element_count_leafs.cxx
+++ b/test/t8_schemes/t8_gtest_element_count_leafs.cxx
@@ -22,6 +22,7 @@
 
 #include <gtest/gtest.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
+#include <test/t8_gtest_macros.hxx>
 
 /*
  * In this file we test whether the t8_element_count_leafs{_from_root}

--- a/test/t8_schemes/t8_gtest_element_count_leafs.cxx
+++ b/test/t8_schemes/t8_gtest_element_count_leafs.cxx
@@ -130,5 +130,4 @@ TEST_P (class_element_leafs, test_element_count_leafs_one_level)
   class_scheme->t8_element_destroy (1, &element);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_element_count_leafs, class_element_leafs,
-                          testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_element_count_leafs, class_element_leafs, AllEclasses);

--- a/test/t8_schemes/t8_gtest_element_ref_coords.cxx
+++ b/test/t8_schemes/t8_gtest_element_ref_coords.cxx
@@ -260,5 +260,4 @@ TEST_P (class_ref_coords, t8_check_elem_ref_coords)
 }
 
 INSTANTIATE_TEST_SUITE_P (t8_gtest_element_ref_coords, class_ref_coords,
-                          testing::Combine (testing::Range (T8_ECLASS_VERTEX, T8_ECLASS_COUNT),
-                                            testing::Range (0, MAX_LEVEL_REF_COORD_TEST + 1)));
+                          testing::Combine (AllEclasses, testing::Range (0, MAX_LEVEL_REF_COORD_TEST + 1)));

--- a/test/t8_schemes/t8_gtest_element_ref_coords.cxx
+++ b/test/t8_schemes/t8_gtest_element_ref_coords.cxx
@@ -32,6 +32,7 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
 #include <t8_forest/t8_forest.h>
 #include <t8_cmesh/t8_cmesh_examples.h>
+#include <test/t8_gtest_macros.hxx>
 
 #if T8_ENABLE_LESS_TESTS
 #define MAX_LEVEL_REF_COORD_TEST 3

--- a/test/t8_schemes/t8_gtest_face_descendant.cxx
+++ b/test/t8_schemes/t8_gtest_face_descendant.cxx
@@ -170,5 +170,4 @@ TEST_P (class_descendant, t8_check_face_desc)
   ts->t8_element_destroy (1, &tmp);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_element_face_descendant, class_descendant,
-                          testing::Range (T8_ECLASS_VERTEX, T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_element_face_descendant, class_descendant, AllEclasses);

--- a/test/t8_schemes/t8_gtest_face_descendant.cxx
+++ b/test/t8_schemes/t8_gtest_face_descendant.cxx
@@ -25,6 +25,7 @@
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
 #include <test/t8_gtest_custom_assertion.hxx>
+#include <test/t8_gtest_macros.hxx>
 
 class class_descendant: public testing::TestWithParam<t8_eclass_t> {
  protected:

--- a/test/t8_schemes/t8_gtest_face_neigh.cxx
+++ b/test/t8_schemes/t8_gtest_face_neigh.cxx
@@ -205,5 +205,5 @@ TEST_P (face_neigh, recursive_check_diff)
 }
 
 /* *INDENT-OFF* */
-INSTANTIATE_TEST_SUITE_P (t8_gtest_face_neigh, face_neigh, testing::Range (T8_ECLASS_VERTEX, T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_face_neigh, face_neigh, AllEclasses);
 /* *INDENT-ON* */

--- a/test/t8_schemes/t8_gtest_face_neigh.cxx
+++ b/test/t8_schemes/t8_gtest_face_neigh.cxx
@@ -25,6 +25,7 @@
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
 #include <t8_element_c_interface.h>
+#include <test/t8_gtest_macros.hxx>
 
 #include <t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid.h>
 

--- a/test/t8_schemes/t8_gtest_find_parent.cxx
+++ b/test/t8_schemes/t8_gtest_find_parent.cxx
@@ -24,7 +24,8 @@
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
 #include <test/t8_gtest_custom_assertion.hxx>
-#include "t8_gtest_scheme_helper.hxx"
+#include "t8_gtest_dfs_base.hxx"
+#include <test/t8_gtest_macros.hxx>
 
 class class_find_parent: public TestDFS{
   virtual void
@@ -64,7 +65,12 @@ class class_find_parent: public TestDFS{
 
 TEST_P (class_find_parent, t8_compute_child_find_parent)
 {
-  check_recursive_dfs_to_max_lvl();
+#ifdef T8_ENABLE_LESS_TESTS
+  const int maxlvl = 4;
+#else
+  const int maxlvl = 6;
+#endif
+  check_recursive_dfs_to_max_lvl(maxlvl);
 }
 
 INSTANTIATE_TEST_SUITE_P (t8_gtest_find_parent, class_find_parent, AllImplementations);

--- a/test/t8_schemes/t8_gtest_find_parent.cxx
+++ b/test/t8_schemes/t8_gtest_find_parent.cxx
@@ -27,8 +27,8 @@
 #include "t8_gtest_scheme_helper.hxx"
 
 class class_find_parent: public TestDFS{
-  void
-  check_element () override
+  virtual void
+  check_element ()
   {
     const int num_children = ts->t8_element_num_children (element);
     for (int ichild = 0; ichild < num_children; ichild++) {

--- a/test/t8_schemes/t8_gtest_find_parent.cxx
+++ b/test/t8_schemes/t8_gtest_find_parent.cxx
@@ -24,81 +24,47 @@
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
 #include <test/t8_gtest_custom_assertion.hxx>
+#include "t8_gtest_scheme_helper.hxx"
 
-class class_find_parent: public testing::TestWithParam<t8_eclass_t> {
+class class_find_parent: public TestDFS{
+  void
+  check_element () override
+  {
+    const int num_children = ts->t8_element_num_children (element);
+    for (int ichild = 0; ichild < num_children; ichild++) {
+      ts->t8_element_child (element, ichild, child);
+      /* Compute parent of child */
+      ts->t8_element_parent (child, test_parent);
+      /* Check that it is equal to the original element */
+      EXPECT_ELEM_EQ (ts, element, test_parent);    }
+  }
  protected:
   void
   SetUp () override
   {
-    eclass = GetParam ();
-
-    scheme = t8_scheme_new_default_cxx ();
-    /* Get scheme for eclass */
-    ts = scheme->eclass_schemes[eclass];
-
+    dfs_test_setup();
     /* Get element and initialize it */
-    ts->t8_element_new (1, &element);
     ts->t8_element_new (1, &child);
     ts->t8_element_new (1, &test_parent);
 
-    ts->t8_element_set_linear_id (element, 0, 0);
   }
   void
   TearDown () override
   {
     /* Destroy element */
-    ts->t8_element_destroy (1, &element);
     ts->t8_element_destroy (1, &child);
     ts->t8_element_destroy (1, &test_parent);
 
-    /* Destroy scheme */
-    t8_scheme_cxx_unref (&scheme);
+    /* Destroy DFS test */
+    dfs_test_teardown();
   }
-  t8_eclass_t eclass;
-  t8_scheme_cxx *scheme;
-  t8_eclass_scheme_c *ts;
-  t8_element_t *element;
   t8_element_t *child;
   t8_element_t *test_parent;
 };
 
-static void
-t8_recursive_child_find_parent (t8_element_t *element, t8_element_t *child, t8_element_t *test_parent,
-                                t8_eclass_scheme_c *ts, int level, const int maxlvl)
-{
-  T8_ASSERT (level <= maxlvl && maxlvl <= ts->t8_element_maxlevel () - 1);
-
-  /* Get number of children */
-  const int num_children = ts->t8_element_num_children (element);
-  /* Get child and test_parent, to check if test_parent = parent of child */
-  if (level == maxlvl)
-    return;
-  for (int ichild = 0; ichild < num_children; ichild++) {
-    /* Compute child i */
-    ts->t8_element_child (element, ichild, child);
-    /* Compute parent of child */
-    ts->t8_element_parent (child, test_parent);
-    /* If its equal, call child_find_parent, to check if parent-child relation
-     * is correct in next level until maxlvl is reached*/
-    EXPECT_ELEM_EQ (ts, element, test_parent);
-
-    t8_recursive_child_find_parent (child, element, test_parent, ts, level + 1, maxlvl);
-    /* After the check we know the parent-function is correct for this child.
-     * Therefore we can use it to recompute the element*/
-    ts->t8_element_parent (child, element);
-  }
-}
-
 TEST_P (class_find_parent, t8_compute_child_find_parent)
 {
-#ifdef T8_ENABLE_LESS_TESTS
-  const int maxlvl = 4;
-#else
-  const int maxlvl = 6;
-#endif
-
-  /* Check for correct parent-child relation */
-  t8_recursive_child_find_parent (element, child, test_parent, ts, 0, maxlvl);
+  check_recursive_dfs_to_max_lvl();
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_find_parent, class_find_parent, testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_find_parent, class_find_parent, AllImplementations);

--- a/test/t8_schemes/t8_gtest_find_parent.cxx
+++ b/test/t8_schemes/t8_gtest_find_parent.cxx
@@ -27,7 +27,7 @@
 #include "t8_gtest_dfs_base.hxx"
 #include <test/t8_gtest_macros.hxx>
 
-class class_find_parent: public TestDFS{
+class class_find_parent: public TestDFS {
   virtual void
   check_element ()
   {
@@ -37,17 +37,18 @@ class class_find_parent: public TestDFS{
       /* Compute parent of child */
       ts->t8_element_parent (child, test_parent);
       /* Check that it is equal to the original element */
-      EXPECT_ELEM_EQ (ts, element, test_parent);    }
+      EXPECT_ELEM_EQ (ts, element, test_parent);
+    }
   }
+
  protected:
   void
   SetUp () override
   {
-    dfs_test_setup();
+    dfs_test_setup ();
     /* Get element and initialize it */
     ts->t8_element_new (1, &child);
     ts->t8_element_new (1, &test_parent);
-
   }
   void
   TearDown () override
@@ -57,7 +58,7 @@ class class_find_parent: public TestDFS{
     ts->t8_element_destroy (1, &test_parent);
 
     /* Destroy DFS test */
-    dfs_test_teardown();
+    dfs_test_teardown ();
   }
   t8_element_t *child;
   t8_element_t *test_parent;
@@ -70,7 +71,7 @@ TEST_P (class_find_parent, t8_compute_child_find_parent)
 #else
   const int maxlvl = 6;
 #endif
-  check_recursive_dfs_to_max_lvl(maxlvl);
+  check_recursive_dfs_to_max_lvl (maxlvl);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_find_parent, class_find_parent, AllImplementations);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_find_parent, class_find_parent, AllEclasses);

--- a/test/t8_schemes/t8_gtest_init_linear_id.cxx
+++ b/test/t8_schemes/t8_gtest_init_linear_id.cxx
@@ -26,6 +26,7 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
 #include <sc_functions.h>
 #include <t8_cmesh/t8_cmesh_examples.h>
+#include <test/t8_gtest_macros.hxx>
 
 class linear_id: public testing::TestWithParam<t8_eclass> {
  protected:

--- a/test/t8_schemes/t8_gtest_init_linear_id.cxx
+++ b/test/t8_schemes/t8_gtest_init_linear_id.cxx
@@ -147,4 +147,4 @@ TEST_P (linear_id, id_at_other_level)
   }
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_test_init_linear_id, linear_id, testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_test_init_linear_id, linear_id, AllEclasses);

--- a/test/t8_schemes/t8_gtest_nca.cxx
+++ b/test/t8_schemes/t8_gtest_nca.cxx
@@ -29,6 +29,7 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 #include <test/t8_gtest_custom_assertion.hxx>
 #include <t8_eclass.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
+#include <test/t8_gtest_macros.hxx>
 
 class nca: public testing::TestWithParam<t8_eclass> {
  protected:

--- a/test/t8_schemes/t8_gtest_nca.cxx
+++ b/test/t8_schemes/t8_gtest_nca.cxx
@@ -308,4 +308,4 @@ TEST_P (nca, recursive_check_higher_level)
   ts->t8_element_destroy (1, &correct_nca_high_level);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_nca, nca, testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT));
+INSTANTIATE_TEST_SUITE_P (t8_gtest_nca, nca, AllEclasses);

--- a/test/t8_schemes/t8_gtest_scheme_helper.hxx
+++ b/test/t8_schemes/t8_gtest_scheme_helper.hxx
@@ -1,0 +1,98 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2023 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#ifndef T8_GTEST_SCHEME_HELPER_H
+#define T8_GTEST_SCHEME_HELPER_H
+
+#include <gtest/gtest.h>
+#include <t8_eclass.h>
+#include <t8_schemes/t8_default/t8_default_cxx.hxx>
+
+#define AllImplementations testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT)
+
+class TestDFS : public testing::TestWithParam<t8_eclass_t> {
+ public:
+/** recursive tests check something for all descendants of a starting element upto maxlevel
+*/
+  virtual void
+  check_element (const t8_element_t *elem) = 0;
+
+  /** recursive depth first search to iterate over all descendants of elem up to maxlvl */
+  void
+  check_recursive_dfs_to_max_lvl ()
+  {
+    int level = ts->t8_element_level (element);
+    ASSERT_LE (level, maxlvl);
+    ASSERT_LT (maxlvl, ts->t8_element_maxlevel ());
+
+    check_element (element);
+
+    if (ts->t8_element_level (element) < maxlvl) {
+      t8_debugf ("iterate over children:\n");
+      /* iterate over all children */
+      int num_children = ts->t8_element_num_children (element);
+      for (int ichild = 0; ichild < num_children; ichild++) {
+        ts->t8_element_child (element, ichild, element);
+        check_recursive_dfs_to_max_lvl ();
+        ts->t8_element_parent (element, element);
+      }
+    }
+  }
+
+  void
+  dfs_test_setup()
+  {
+    scheme = t8_scheme_new_default_cxx();
+    eclass = GetParam ();
+    ts = scheme->eclass_schemes[eclass];
+    ts->t8_element_new (1, &element);
+    ts->t8_element_set_linear_id (element, 0, 0);
+  }
+  void
+  dfs_test_teardown()
+  {
+    ts->t8_element_destroy (1, &element);
+    t8_scheme_cxx_unref (&scheme);
+  }
+
+  void
+  SetUp () override
+  {
+    dfs_test_setup();
+  }
+  void
+  TearDown () override
+  {
+    dfs_test_teardown();
+  }
+
+  virtual ~TestDFS() = default;
+
+  t8_scheme_cxx *scheme;
+  t8_eclass_t eclass;
+  t8_eclass_scheme_c *ts;
+  t8_element_t *element;
+
+  const int maxlvl = 4;
+};
+
+#endif /*T8_GTEST_SCHEME_HELPER_H*/

--- a/test/t8_schemes/t8_gtest_scheme_helper.hxx
+++ b/test/t8_schemes/t8_gtest_scheme_helper.hxx
@@ -84,8 +84,6 @@ class TestDFS : public testing::TestWithParam<t8_eclass_t> {
     dfs_test_teardown();
   }
 
-  virtual ~TestDFS() = default;
-
   t8_scheme_cxx *scheme;
   t8_eclass_t eclass;
   t8_eclass_scheme_c *ts;

--- a/test/t8_schemes/t8_gtest_scheme_helper.hxx
+++ b/test/t8_schemes/t8_gtest_scheme_helper.hxx
@@ -34,7 +34,7 @@ class TestDFS : public testing::TestWithParam<t8_eclass_t> {
 /** recursive tests check something for all descendants of a starting element upto maxlevel
 */
   virtual void
-  check_element (const t8_element_t *elem) = 0;
+  check_element (const t8_element_t *elem){};
 
   /** recursive depth first search to iterate over all descendants of elem up to maxlvl */
   void
@@ -47,7 +47,6 @@ class TestDFS : public testing::TestWithParam<t8_eclass_t> {
     check_element (element);
 
     if (ts->t8_element_level (element) < maxlvl) {
-      t8_debugf ("iterate over children:\n");
       /* iterate over all children */
       int num_children = ts->t8_element_num_children (element);
       for (int ichild = 0; ichild < num_children; ichild++) {

--- a/test/t8_schemes/t8_gtest_scheme_helper.hxx
+++ b/test/t8_schemes/t8_gtest_scheme_helper.hxx
@@ -48,7 +48,7 @@ class TestDFS : public testing::TestWithParam<t8_eclass_t> {
 
     if (ts->t8_element_level (element) < maxlvl) {
       /* iterate over all children */
-      int num_children = ts->t8_element_num_children (element);
+      const int num_children = ts->t8_element_num_children (element);
       for (int ichild = 0; ichild < num_children; ichild++) {
         ts->t8_element_child (element, ichild, element);
         check_recursive_dfs_to_max_lvl ();


### PR DESCRIPTION
**_Describe your changes here:_**

Helper class to test scheme functionality on all elements by DFS

Also enables this for `find_parent`, more to come

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
