### PR TITLE
Bugfixes in curved geometry

### DIFF
--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -1250,6 +1250,35 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp, sc_hash_t *vertices, 
               continue;
             }
 
+            /* If one vertex lies on a geometry of a higher dim as the other, we have to check,
+             * if the geometry of lower dimension is on that geometry. */
+            {
+              int is_on_geom = 1;
+              for (int i_edge = 0; i_edge < 2; ++i_edge) {
+                if (edge_geometry_dim == 2 && edge_nodes[i_edge].entity_dim == 1) {
+                  if (!occ_geometry->t8_geom_is_edge_on_face (edge_nodes[i_edge].entity_tag, edge_geometry_tag)) {
+                    is_on_geom = 0;
+                    break;
+                  }
+                }
+                else if (edge_geometry_dim == 2 && edge_nodes[i_edge].entity_dim == 0) {
+                  if (!occ_geometry->t8_geom_is_vertex_on_face (edge_nodes[i_edge].entity_tag, edge_geometry_tag)) {
+                    is_on_geom = 0;
+                    break;
+                  }
+                }
+                else if (edge_geometry_dim == 1 && edge_nodes[i_edge].entity_dim == 0) {
+                  if (!occ_geometry->t8_geom_is_vertex_on_edge (edge_nodes[i_edge].entity_tag, edge_geometry_tag)) {
+                    is_on_geom = 0;
+                    break;
+                  }
+                }
+              }
+              if (!is_on_geom) {
+                continue;
+              }
+            }
+
             /* If both nodes are on a vertex we still got no edge. 
              * But we can look if both vertices share an edge and use this edge. 
              * If not we can skip this edge. */

--- a/src/t8_geometry/t8_geometry_helpers.c
+++ b/src/t8_geometry/t8_geometry_helpers.c
@@ -324,6 +324,7 @@ t8_geom_get_ref_intersection (int edge_index, const double *ref_coords, double r
     else if (ref_coords[1] == ref_opposite_vertex[1]) {
       ref_intersection[0] = 0;
       ref_intersection[1] = 1;
+      break;
     }
     else {
       /* intersectionX = (x1y2-y1x2)(x3-x4)-(x1-x2)(x3y4-y3x4)

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_occ.cxx
@@ -302,7 +302,7 @@ t8_geometry_occ::t8_geom_evaluate_occ_triangle (t8_cmesh_t cmesh, t8_gloidx_t gt
             t8_geom_linear_interpolation (&ref_intersection[0], parameters, 1, 1, &interpolated_curve_parameter);
           }
           /* Retrieve curve */
-          T8_ASSERT (edges[i_edge] <= occ_shape_face_map.Size ());
+          T8_ASSERT (edges[i_edge] <= occ_shape_edge_map.Size ());
           curve = BRep_Tool::Curve (TopoDS::Edge (occ_shape_edge_map.FindKey (edges[i_edge])), first, last);
           /* Check if curve is valid */
           T8_ASSERT (!curve.IsNull ());


### PR DESCRIPTION
**_Describe your changes here:_**
Fixes some bugs in the curved geometry:
1. Checks if two nodes are on the same geometry, if both nodes of an edge lie on geometries with different dimensions.
2. Adds a break so that the default of that switch is not reached
3. Uses the right lookup table for edges


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
