### PR TITLE
Feature bugfix cmesh set partition offsets

### DIFF
--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -184,8 +184,6 @@ void
 t8_cmesh_set_partition_range (t8_cmesh_t cmesh, int set_face_knowledge, t8_gloidx_t first_local_tree,
                               t8_gloidx_t last_local_tree);
 
-/* TODO: It is currently not possible to call this function for a non derived
- *       cmesh. Investigate. */
 /** Declare if the cmesh is understood as a partitioned cmesh and specify
  * the first local tree for each process.
  * This call is only valid when the cmesh is not yet committed via a call

--- a/src/t8_cmesh/t8_cmesh_commit.c
+++ b/src/t8_cmesh/t8_cmesh_commit.c
@@ -207,7 +207,7 @@ t8_cmesh_commit_partitioned_new (t8_cmesh_t cmesh, sc_MPI_Comm comm)
   sc_mempool_t *ghost_facejoin_mempool;
   t8_ghost_facejoin_t *ghost_facejoin = NULL, *temp_facejoin, **facejoin_pp;
   size_t joinfaces_it, iz;
-  t8_gloidx_t last_tree = cmesh->num_local_trees + cmesh->first_tree - 1, id1, id2;
+  t8_gloidx_t id1, id2;
   t8_locidx_t temp_local_id = 0;
   t8_locidx_t num_hashes;
   t8_gloidx_t *face_neigh_g, *face_neigh_g2;
@@ -251,6 +251,10 @@ t8_cmesh_commit_partitioned_new (t8_cmesh_t cmesh, sc_MPI_Comm comm)
   /* The first_tree and first_tree_shared entries must be set by now */
   T8_ASSERT (cmesh->first_tree >= 0);
   T8_ASSERT (cmesh->first_tree_shared >= 0);
+
+  /* Compute the global id of the cmeshes last_tree.
+   * This must happen after cmesh->first_tree is computed. */
+  const t8_gloidx_t last_tree = cmesh->num_local_trees + cmesh->first_tree - 1;
 
   num_hashes = cmesh->num_local_trees > 0 ? cmesh->num_local_trees : 10;
   ghost_facejoin_mempool = sc_mempool_new (sizeof (t8_ghost_facejoin_t));


### PR DESCRIPTION
**_Describe your changes here:_**

Fixes a bug in `t8_cmesh_commit_partitioned_new`.
The `last_tree` value was computed from a yet unset variable `cmesh->first_tree`.
Needed to move the computation down after `cmesh->first_tree` was calculated.

A PR with tests will follow.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
