### PR TITLE
Feature test cmesh set partition offset

### DIFF
--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -1165,8 +1165,10 @@ t8_cmesh_reset (t8_cmesh_t *pcmesh)
     sc_MPI_Comm comm;
     /* Check whether a correct communicator was stored at tree_offsets.
      * This is useful for debugging. */
-    comm = t8_shmem_array_get_comm (cmesh->tree_offsets);
-    T8_ASSERT (t8_cmesh_comm_is_valid (cmesh, comm));
+    if (t8_cmesh_is_committed (cmesh)) {
+      comm = t8_shmem_array_get_comm (cmesh->tree_offsets);
+      T8_ASSERT (t8_cmesh_comm_is_valid (cmesh, comm));
+    }
 #endif
     /* Destroy the shared memory array */
     t8_shmem_array_destroy (&cmesh->tree_offsets);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -26,6 +26,7 @@ t8code_googletest_programs = \
   test/t8_schemes/t8_gtest_find_parent \
   test/t8_cmesh/t8_gtest_cmesh_face_is_boundary \
   test/t8_cmesh/t8_gtest_cmesh_partition \
+  test/t8_cmesh/t8_gtest_cmesh_set_partition_offsets \
   test/t8_cmesh/t8_gtest_cmesh_set_join_by_vertices \
   test/t8_forest/t8_gtest_element_volume \
   test/t8_cmesh/t8_gtest_multiple_attributes \
@@ -149,6 +150,10 @@ test_t8_cmesh_t8_gtest_cmesh_face_is_boundary_SOURCES = \
 test_t8_cmesh_t8_gtest_cmesh_partition_SOURCES = \
   test/t8_gtest_main.cxx \
   test/t8_cmesh/t8_gtest_cmesh_partition.cxx
+
+test_t8_cmesh_t8_gtest_cmesh_set_partition_offsets_SOURCES = \
+  test/t8_gtest_main.cxx \
+  test/t8_cmesh/t8_gtest_cmesh_set_partition_offsets.cxx
   
 test_t8_forest_t8_gtest_element_volume_SOURCES = \
   test/t8_gtest_main.cxx \
@@ -339,6 +344,10 @@ test_t8_cmesh_t8_gtest_cmesh_partition_LDADD = $(t8_gtest_target_ld_add)
 test_t8_cmesh_t8_gtest_cmesh_partition_LDFLAGS = $(t8_gtest_target_ld_flags)
 test_t8_cmesh_t8_gtest_cmesh_partition_CPPFLAGS = $(t8_gtest_target_cpp_flags)
 
+test_t8_cmesh_t8_gtest_cmesh_set_partition_offsets_LDADD = $(t8_gtest_target_ld_add)
+test_t8_cmesh_t8_gtest_cmesh_set_partition_offsets_LDFLAGS = $(t8_gtest_target_ld_flags)
+test_t8_cmesh_t8_gtest_cmesh_set_partition_offsets_CPPFLAGS = $(t8_gtest_target_cpp_flags)
+
 test_t8_forest_t8_gtest_element_volume_LDADD = $(t8_gtest_target_ld_add)
 test_t8_forest_t8_gtest_element_volume_LDFLAGS = $(t8_gtest_target_ld_flags)
 test_t8_forest_t8_gtest_element_volume_CPPFLAGS = $(t8_gtest_target_cpp_flags)
@@ -454,6 +463,7 @@ test_t8_schemes_t8_gtest_descendant_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_schemes_t8_gtest_find_parent_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_cmesh_t8_gtest_cmesh_face_is_boundary_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_cmesh_t8_gtest_cmesh_partition_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
+test_t8_cmesh_t8_gtest_cmesh_set_partition_offsets_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_forest_t8_gtest_element_volume_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_cmesh_t8_gtest_multiple_attributes_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_schemes_t8_gtest_successor_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)

--- a/test/t8_cmesh/t8_gtest_cmesh_set_partition_offsets.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_set_partition_offsets.cxx
@@ -21,6 +21,7 @@
 */
 
 #include <gtest/gtest.h>
+#include <test/t8_gtest_macros.hxx>
 #include <t8_cmesh.h>
 #include <t8_schemes/t8_default/t8_default_cxx.hxx>
 #include "t8_cmesh/t8_cmesh_trees.h"
@@ -30,21 +31,40 @@
 /* At the time of this writing (November 15 2023) t8_cmesh_offset_concentrate
  * has a comment stating it does not work with non-derived cmeshes.
  * We write the tests in this file to check this.
+ * 
+ * Theses tests will create an offset array, build a new cmesh
+ * with trees of the same eclass, set the offset array and commit the cmesh.
+ * We will iterate through all eclasses and all tree counts up to a given maximum.
  */
+
+/* The maximum number of trees for a cmesh to test with.
+ * We will test all numbers of trees from 0 to the maximum. */
+#define T8_TEST_PARTITION_OFFSET_MAX_TREE_NUM 100
+
+class cmesh_set_partition_offsets: public testing::TestWithParam<std::tuple<t8_eclass, int>> {
+ protected:
+  void
+  SetUp () override
+  {
+    ieclass = std::get<0> (GetParam ());
+    inum_trees = std::get<1> (GetParam ());
+  }
+  t8_eclass_t ieclass;
+  t8_gloidx_t inum_trees;
+};
 
 /* call t8_cmesh_offset_concentrate for non-derived cmesh 
  * and destroy it before commit. */
-TEST (t8_cmesh_set_partition_offsets, test_set_offsets_nocommit)
+TEST_P (cmesh_set_partition_offsets, test_set_offsets_nocommit)
 {
   t8_cmesh_t cmesh;
-  const t8_gloidx_t num_trees = 1;
   const int main_process = 0;
   /* Build a valid offset array. For this test it is onlt necessary that 
    * the array corresponds to any valid partition.
    * We use the offset_concentrate function to build an offset array for a partition
    * that concentrates all trees at one process. */
   t8_shmem_init (sc_MPI_COMM_WORLD);
-  t8_shmem_array_t shmem_array = t8_cmesh_offset_concentrate (main_process, sc_MPI_COMM_WORLD, num_trees);
+  t8_shmem_array_t shmem_array = t8_cmesh_offset_concentrate (main_process, sc_MPI_COMM_WORLD, inum_trees);
 
   /* Initialize the cmesh */
   t8_cmesh_init (&cmesh);
@@ -57,18 +77,17 @@ TEST (t8_cmesh_set_partition_offsets, test_set_offsets_nocommit)
 
 /* call t8_cmesh_offset_concentrate for non-derived cmesh 
  * and commit it. */
-TEST (t8_cmesh_set_partition_offsets, test_set_offsets_commit)
+TEST_P (cmesh_set_partition_offsets, test_set_offsets_commit)
 {
   t8_cmesh_t cmesh;
-  const t8_gloidx_t num_trees = 1;
   const int main_process = 0;
   sc_MPI_Comm comm = sc_MPI_COMM_WORLD;
-  /* Build a valid offset array. For this test it is onlt necessary that 
+  /* Build a valid offset array. For this test it is only necessary that 
    * the array corresponds to any valid partition.
    * We use the offset_concentrate function to build an offset array for a partition
    * that concentrates all trees at one process. */
   t8_shmem_init (comm);
-  t8_shmem_array_t shmem_array = t8_cmesh_offset_concentrate (main_process, comm, num_trees);
+  t8_shmem_array_t shmem_array = t8_cmesh_offset_concentrate (main_process, comm, inum_trees);
 
   /* Initialize the cmesh */
   t8_cmesh_init (&cmesh);
@@ -77,14 +96,41 @@ TEST (t8_cmesh_set_partition_offsets, test_set_offsets_commit)
   t8_cmesh_set_partition_offsets (cmesh, shmem_array);
 
   /* Specify a dimension */
-  t8_cmesh_set_dimension (cmesh, 0);
+  const int dim = t8_eclass_to_dimension[ieclass];
+  t8_cmesh_set_dimension (cmesh, dim);
 
   /* Set class for the trees */
-  t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_VERTEX);
+  for (int itree = 0; itree < inum_trees; ++itree) {
+    t8_cmesh_set_tree_class (cmesh, itree, ieclass);
+  }
 
   /* Commit the cmesh */
   t8_cmesh_commit (cmesh, comm);
 
+  /* Check that the cmesh was partitioned according to the offset */
+
+  ASSERT_TRUE (t8_cmesh_is_committed (cmesh));
+
+  /* Get the mpirank */
+  int mpirank;
+  int mpiret;
+
+  mpiret = sc_MPI_Comm_rank (comm, &mpirank);
+  SC_CHECK_MPI (mpiret);
+
+  /* Get the local number of trees */
+  const t8_locidx_t num_local_trees = t8_cmesh_get_num_local_trees (cmesh);
+  /* Compute the reference value, num_trees for mpirank main_process,
+   * 0 on each other rank. */
+  const t8_locidx_t expected_num_local_trees = mpirank == main_process ? inum_trees : 0;
+
+  EXPECT_EQ (num_local_trees, expected_num_local_trees);
+  EXPECT_EQ (t8_cmesh_get_num_trees (cmesh), inum_trees);
+
   /* Destroy the cmesh */
   t8_cmesh_unref (&cmesh);
 }
+
+/* Make atest suite that iterates over all classes and a tree count from 0 to the maximum. */
+INSTANTIATE_TEST_SUITE_P (t8_cmesh_set_partition_offsets, cmesh_set_partition_offsets,
+                          testing::Combine (AllEclasses, testing::Values (0, T8_TEST_PARTITION_OFFSET_MAX_TREE_NUM)));

--- a/test/t8_cmesh/t8_gtest_cmesh_set_partition_offsets.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_set_partition_offsets.cxx
@@ -36,6 +36,8 @@
  * with trees of the same eclass, set the offset array and commit the cmesh.
  * We will iterate through all eclasses and all tree counts up to a given maximum.
  */
+/* TODO: Currently only the offset t8_cmesh_offset_concentrate is tested.
+ *       We can extend this test case to check for different offset arrays.  */
 
 /* The maximum number of trees for a cmesh to test with.
  * We will test all numbers of trees from 0 to the maximum. */

--- a/test/t8_cmesh/t8_gtest_cmesh_set_partition_offsets.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_set_partition_offsets.cxx
@@ -1,0 +1,55 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#include <gtest/gtest.h>
+#include <t8_cmesh.h>
+#include <t8_schemes/t8_default/t8_default_cxx.hxx>
+#include "t8_cmesh/t8_cmesh_trees.h"
+#include "t8_cmesh/t8_cmesh_partition.h"
+#include <t8_cmesh/t8_cmesh_testcases.h>
+
+/* We create a cmesh, partition it and repartition it several times.
+ * At the end we result in the same partition as at the beginning and we
+ * compare this cmesh with the initial one. If they are equal the test is
+ * passed.
+ */
+
+TEST (t8_cmesh_set_partition_offsets, test_set_offsets)
+{
+  t8_cmesh_t cmesh;
+  const t8_gloidx_t num_trees = 1;
+  const int main_process = 0;
+  /* Build a valid offset array. For this test it is onlt necessary that 
+   * the array corresponds to any valid partition.
+   * We use the offset_concentrate function to build an offset array for a partition
+   * that concentrates all trees at one process. */
+  t8_shmem_init (sc_MPI_COMM_WORLD);
+  t8_shmem_array_t shmem_array = t8_cmesh_offset_concentrate (main_process, sc_MPI_COMM_WORLD, num_trees);
+
+  /* Initialize the cmesh */
+  t8_cmesh_init (&cmesh);
+
+  /* Set the partition offsets */
+  t8_cmesh_set_partition_offsets (cmesh, shmem_array);
+  /* Destroy the cmesh */
+  t8_cmesh_unref (&cmesh);
+}


### PR DESCRIPTION
**_Describe your changes here:_**

Add two test cases for the t8_cmesh_set_partition_offsets function with an underived cmesh.

We build a cmesh from scratch and call t8_cmesh_set_partition_offsets.
in the first test, we destroy the cmesh immediately, in the second we commit the cmesh and check whether it was partitioned correctly.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
