### PR TITLE
in cmesh_reset only check comm valid if cmesh is committed

### DIFF
--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -1159,8 +1159,10 @@ t8_cmesh_reset (t8_cmesh_t *pcmesh)
     sc_MPI_Comm comm;
     /* Check whether a correct communicator was stored at tree_offsets.
      * This is useful for debugging. */
-    comm = t8_shmem_array_get_comm (cmesh->tree_offsets);
-    T8_ASSERT (t8_cmesh_comm_is_valid (cmesh, comm));
+    if (t8_cmesh_is_committed (cmesh)) {
+      comm = t8_shmem_array_get_comm (cmesh->tree_offsets);
+      T8_ASSERT (t8_cmesh_comm_is_valid (cmesh, comm));
+    }
 #endif
     /* Destroy the shared memory array */
     t8_shmem_array_destroy (&cmesh->tree_offsets);


### PR DESCRIPTION
**_Describe your changes here:_**

When destroying a cmesh in debugging mode we did not checkwhether the communicator was created before checking whether it is valid.
This resulted in a crash in certain scenarios, i.e. setting a partition offset, not committing the cmesh and destroying it.

Related to #869  #868 

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
