### PR TITLE
Fix Bug 873

### DIFF
--- a/src/t8_cmesh/t8_cmesh_partition.c
+++ b/src/t8_cmesh/t8_cmesh_partition.c
@@ -1596,6 +1596,10 @@ t8_cmesh_partition (t8_cmesh_t cmesh, sc_MPI_Comm comm)
     /* Runtime = current_time - start_time */
     cmesh->profile->partition_runtime = sc_MPI_Wtime () - cmesh->profile->partition_runtime;
   }
+  /* Deactivate the active tree. Tree related data (such as vertices) might have been moved by the new partition and 
+   * has to be loaded again if needed. */
+  cmesh->geometry_handler->active_tree = -cmesh->num_local_trees - 1;
+
   t8_global_productionf ("Done cmesh partition\n");
 }
 

--- a/src/t8_cmesh/t8_cmesh_partition.c
+++ b/src/t8_cmesh/t8_cmesh_partition.c
@@ -1591,14 +1591,14 @@ t8_cmesh_partition (t8_cmesh_t cmesh, sc_MPI_Comm comm)
   /*        Done with local num and tree_offset      */
   /***************************************************/
   t8_cmesh_partition_given (cmesh, cmesh->set_from, tree_offsets, comm);
+  /* Deactivate the active tree. Tree related data (such as vertices) might have been moved by the new partition and 
+   * has to be loaded again if needed. */
+  t8_geom_handler_deactivate_tree (cmesh->geometry_handler);
   /* If profiling is enabled, we measure the runtime of this routine. */
   if (cmesh->profile) {
     /* Runtime = current_time - start_time */
     cmesh->profile->partition_runtime = sc_MPI_Wtime () - cmesh->profile->partition_runtime;
   }
-  /* Deactivate the active tree. Tree related data (such as vertices) might have been moved by the new partition and 
-   * has to be loaded again if needed. */
-  cmesh->geometry_handler->active_tree = -cmesh->num_local_trees - 1;
 
   t8_global_productionf ("Done cmesh partition\n");
 }

--- a/src/t8_geometry/t8_geometry.cxx
+++ b/src/t8_geometry/t8_geometry.cxx
@@ -263,6 +263,13 @@ t8_geom_handler_get_unique_geometry (const t8_geometry_handler_t *geom_handler)
   return *(const t8_geometry_c **) sc_array_index_int (geometries, 0);
 }
 
+void
+t8_geom_handler_deactivate_tree (t8_geometry_handler_t *geom_handler)
+{
+  T8_ASSERT (t8_geom_handler_is_committed (geom_handler));
+  geom_handler->active_tree = -1;
+}
+
 static inline void
 t8_geom_handler_update_tree (t8_geometry_handler_t *geom_handler, t8_cmesh_t cmesh, t8_gloidx_t gtreeid)
 {

--- a/src/t8_geometry/t8_geometry.h
+++ b/src/t8_geometry/t8_geometry.h
@@ -147,6 +147,15 @@ const t8_geometry_c *
 t8_geom_handler_get_unique_geometry (const t8_geometry_handler_t *geom_handler);
 
 /**
+ * Deactivate the current active tree. Can be used to reload data, after it has been moved, for example by the
+ * partition-algorithm
+ * 
+ * \param[in,out] geom_handler The geometry handler, where the tree has to be deactivated.
+ */
+void
+t8_geom_handler_deactivate_tree (t8_geometry_handler_t *geom_handler);
+
+/**
  * Given a geometry's name find that geometry in the geometry handler
  * and return it.
  * \param [in] geom_handler A committed geometry handler.

--- a/src/t8_geometry/t8_geometry.h
+++ b/src/t8_geometry/t8_geometry.h
@@ -151,6 +151,7 @@ t8_geom_handler_get_unique_geometry (const t8_geometry_handler_t *geom_handler);
  * partition-algorithm
  * 
  * \param[in,out] geom_handler The geometry handler, where the tree has to be deactivated.
+ * \note \a geom_handler must be committed before calling this function.
  */
 void
 t8_geom_handler_deactivate_tree (t8_geometry_handler_t *geom_handler);


### PR DESCRIPTION
Cause of the error: 
During partitioning of the cmesh vertex-data of the tree can be moved around. If the active tree of the geometry is the same as befor partitioning the vertex-data has been moved without notifying the geometry. 
Solution:
The active tree of the geometry-handler is set to a negative value that is out of bounds of the possible ltreeids. Therefore the active tree is set again as soon as we want to load tree data and the tree-data is actually loaded. 

Thanks to @lukasdreyer for helping with the bug-hunt.

Closes #873 


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
