### PR TITLE
Added missing `t8_cmesh.h` include in `t8_geometry_with_vertices.h`

### DIFF
--- a/src/t8_geometry/t8_geometry_with_vertices.h
+++ b/src/t8_geometry/t8_geometry_with_vertices.h
@@ -28,6 +28,8 @@
 #ifndef T8_GEOMETRY_WITH_VERTICES_H
 #define T8_GEOMETRY_WITH_VERTICES_H
 
+#include <t8_cmesh.h>
+
 T8_EXTERN_C_BEGIN ();
 
 /** Set the vertex coordinates of a tree in the cmesh.


### PR DESCRIPTION
**_Describe your changes here:_**

This PR fixes the root cause for https://github.com/DLR-AMR/T8code.jl/issues/47 in T8code.jl.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
