### PR TITLE
remove no longer needed entry for default_triangles

### DIFF
--- a/doc/author_schoenlein.txt
+++ b/doc/author_schoenlein.txt
@@ -1,2 +1,2 @@
-I place my contributions to libsc under the FreeBSD license.
+I place my contributions to t8code under the FreeBSD license.
 Katrin Schönlein (katrin.schoenlein@dlr.de)

--- a/doc/author_schoenlein.txt
+++ b/doc/author_schoenlein.txt
@@ -1,0 +1,2 @@
+I place my contributions to libsc under the FreeBSD license.
+Katrin Schönlein (katrin.schoenlein@dlr.de)

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri.h
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri.h
@@ -67,7 +67,6 @@ typedef struct t8_dtri
   int8_t level;
   t8_dtri_type_t type;
   t8_dtri_coord_t x, y;
-  t8_dtri_coord_t n;
 } t8_dtri_t;
 
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
@@ -211,7 +211,6 @@ t8_dtri_ancestor (const t8_dtri_t *t, int level, t8_dtri_t *ancestor)
     ancestor->type = t->type;
   }
 
-  ancestor->n = t->n;
 #else
   /* The sign of each diff reduces the number of possible types
  * for the ancestor. At the end only one possible type is left,
@@ -1499,8 +1498,6 @@ t8_dtri_init_linear_id (t8_dtri_t *t, t8_linearidx_t id, int level)
   t->y = 0;
 #ifdef T8_DTRI_TO_DTET
   t->z = 0;
-#else
-  t->n = 0;
 #endif
   type = 0; /* This is the type of the root triangle */
   for (i = 1; i <= level; i++) {
@@ -1529,8 +1526,6 @@ t8_dtri_init_root (t8_dtri_t *t)
   t->y = 0;
 #ifdef T8_DTRI_TO_DTET
   t->z = 0;
-#else
-  t->n = 0;
 #endif
 }
 
@@ -1698,9 +1693,6 @@ t8_dtri_is_valid (const t8_dtri_t *t)
   /* for tets the eclass is set. */
   is_valid = is_valid && t->eclass_int8 == T8_ECLASS_TET;
 #endif
-#else
-  /* n is 0 (we currently do not use n) */
-  is_valid = is_valid && t->n == 0;
 #endif
   /* Its type is in the valid range */
   is_valid = is_valid && 0 <= t->type && t->type < T8_DTRI_NUM_TYPES;


### PR DESCRIPTION
**_Describe your changes here:_**

The value n for triangles was never used anywhere. For that reason we deleted it.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
