### PR TITLE
decrese maxlvl to bring testruntime down

### DIFF
--- a/test/t8_schemes/t8_gtest_equal.cxx
+++ b/test/t8_schemes/t8_gtest_equal.cxx
@@ -77,9 +77,9 @@ class class_test_equal: public TestDFS {
 TEST_P (class_test_equal, test_equal_dfs)
 {
 #ifdef T8_ENABLE_LESS_TESTS
-  const int maxlvl = 4;
+  const int maxlvl = 3;
 #else
-  const int maxlvl = 6;
+  const int maxlvl = 5;
 #endif
   check_recursive_dfs_to_max_lvl (maxlvl);
 }

--- a/test/t8_schemes/t8_gtest_face_descendant.cxx
+++ b/test/t8_schemes/t8_gtest_face_descendant.cxx
@@ -112,9 +112,9 @@ TEST_P (class_descendant, t8_check_face_desc)
 {
 
 #ifdef T8_ENABLE_DEBUG
-  const int maxlvl = 4;
+  const int maxlvl = 3;
 #else
-  const int maxlvl = 6;
+  const int maxlvl = 5;
 #endif
 
   check_recursive_dfs_to_max_lvl (maxlvl);


### PR DESCRIPTION
**_Describe your changes here:_**
There are two tests, that run much longer than the other scheme dfs tests, because their workload to check an element is much higher. For these tests, the max check lvl was decreased.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
