### PR TITLE
Let t8ddy update latest dev redirection

### DIFF
--- a/.github/workflows/add_release_documentation.yml
+++ b/.github/workflows/add_release_documentation.yml
@@ -131,6 +131,7 @@ jobs:
         rm xx01
         cd ../doc
         echo '<meta http-equiv="refresh" content="0; URL=$GITHUB_REF_NAME/index.html" />' > latest.html
+        ./generate_redirections.sh $GITHUB_REF_NAME
     - name: Create Pull Request at DLR-AMR/t8code-website
       if: ${{ env.MINOR_RELEASE == 'true' }}
       uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/add_release_documentation.yml
+++ b/.github/workflows/add_release_documentation.yml
@@ -129,6 +129,8 @@ jobs:
         echo " - [t8code $GITHUB_REF_NAME](../doc/$GITHUB_REF_NAME/index.html)" >> 4_Documentation.md
         cat xx01 >> 4_Documentation.md
         rm xx01
+        cd ../doc
+        echo '<meta http-equiv="refresh" content="0; URL=$GITHUB_REF_NAME/index.html" />' > latest.html
     - name: Create Pull Request at DLR-AMR/t8code-website
       if: ${{ env.MINOR_RELEASE == 'true' }}
       uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/add_release_documentation.yml
+++ b/.github/workflows/add_release_documentation.yml
@@ -119,18 +119,23 @@ jobs:
       if: ${{ env.MINOR_RELEASE == 'true' }}
       run: |
         cd t8code-website/content
+        # Generate new folder for the newest documentation and copy documentation
         mkdir -p doc/$GITHUB_REF_NAME
         cp -r ../../t8code/build_debug/doc/html/* doc/$GITHUB_REF_NAME/
+        # Add a link to the newest documentation in the documentation webpage
         cd pages
         today=`date +'%Y-%m-%d %H:%M'`
         sed -i s/"^Date:.*"/"Date: $today"/g 4_Documentation.md
-        csplit -z 4_Documentation.md /"t8code dev"/+1
+        # Split documentation webpage after t8code latest and append newest documentation
+        csplit -z 4_Documentation.md /"t8code latest"/+1
         mv xx00 4_Documentation.md
         echo " - [t8code $GITHUB_REF_NAME](../doc/$GITHUB_REF_NAME/index.html)" >> 4_Documentation.md
         cat xx01 >> 4_Documentation.md
         rm xx01
+        # Refresh redirect to t8code latest
         cd ../doc
         echo '<meta http-equiv="refresh" content="0; URL=$GITHUB_REF_NAME/index.html" />' > latest.html
+        # Refresh redirections for complete latest documentation
         ./generate_redirections.sh $GITHUB_REF_NAME
     - name: Create Pull Request at DLR-AMR/t8code-website
       if: ${{ env.MINOR_RELEASE == 'true' }}


### PR DESCRIPTION
**_Describe your changes here:_**
Let T8ddy automatically rewrite the redirection to the latest documentation


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
