### PR TITLE
Feature test cmesh copy

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -37,6 +37,7 @@ t8code_googletest_programs = \
   test/t8_schemes/t8_gtest_equal \
   test/t8_cmesh/t8_gtest_cmesh_face_is_boundary \
   test/t8_cmesh/t8_gtest_cmesh_partition \
+  test/t8_cmesh/t8_gtest_cmesh_copy \
   test/t8_cmesh/t8_gtest_cmesh_set_partition_offsets \
   test/t8_cmesh/t8_gtest_cmesh_set_join_by_vertices \
   test/t8_forest/t8_gtest_element_volume \
@@ -170,6 +171,10 @@ test_t8_cmesh_t8_gtest_cmesh_face_is_boundary_SOURCES = \
 test_t8_cmesh_t8_gtest_cmesh_partition_SOURCES = \
   test/t8_gtest_main.cxx \
   test/t8_cmesh/t8_gtest_cmesh_partition.cxx
+
+test_t8_cmesh_t8_gtest_cmesh_copy_SOURCES = \
+  test/t8_gtest_main.cxx \
+  test/t8_cmesh/t8_gtest_cmesh_copy.cxx
 
 test_t8_cmesh_t8_gtest_cmesh_set_partition_offsets_SOURCES = \
   test/t8_gtest_main.cxx \
@@ -387,6 +392,10 @@ test_t8_cmesh_t8_gtest_cmesh_partition_LDADD = $(t8_gtest_target_ld_add)
 test_t8_cmesh_t8_gtest_cmesh_partition_LDFLAGS = $(t8_gtest_target_ld_flags)
 test_t8_cmesh_t8_gtest_cmesh_partition_CPPFLAGS = $(t8_gtest_target_cpp_flags)
 
+test_t8_cmesh_t8_gtest_cmesh_copy_LDADD = $(t8_gtest_target_ld_add)
+test_t8_cmesh_t8_gtest_cmesh_copy_LDFLAGS = $(t8_gtest_target_ld_flags)
+test_t8_cmesh_t8_gtest_cmesh_copy_CPPFLAGS = $(t8_gtest_target_cpp_flags)
+
 test_t8_cmesh_t8_gtest_cmesh_set_partition_offsets_LDADD = $(t8_gtest_target_ld_add)
 test_t8_cmesh_t8_gtest_cmesh_set_partition_offsets_LDFLAGS = $(t8_gtest_target_ld_flags)
 test_t8_cmesh_t8_gtest_cmesh_set_partition_offsets_CPPFLAGS = $(t8_gtest_target_cpp_flags)
@@ -527,6 +536,7 @@ test_t8_schemes_t8_gtest_find_parent_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags
 test_t8_schemes_t8_gtest_equal_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_cmesh_t8_gtest_cmesh_face_is_boundary_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_cmesh_t8_gtest_cmesh_partition_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
+test_t8_cmesh_t8_gtest_cmesh_copy_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_cmesh_t8_gtest_cmesh_set_partition_offsets_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_forest_t8_gtest_element_volume_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_cmesh_t8_gtest_multiple_attributes_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)

--- a/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
@@ -33,11 +33,16 @@
  * We test whether the new and original cmesh are equal.
  */
 
-class t8_cmesh_copy: public testing::TestWithParam<int> {
+/* Note: This test currently fails on many cmeshes and is thus deavtivated.
+ * See: https://github.com/DLR-AMR/t8code/issues/920*/
+* /
+
+  class t8_cmesh_copy: public testing::TestWithParam<int> {
  protected:
   void
   SetUp () override
   {
+    /* Skip test since cmesh copy is not yet working. See https://github.com/DLR-AMR/t8code/issues/920 */
     GTEST_SKIP ();
     cmesh_id = GetParam ();
 
@@ -50,6 +55,7 @@ class t8_cmesh_copy: public testing::TestWithParam<int> {
   void
   TearDown () override
   {
+    /* Skip test since cmesh copy is not yet working. See https://github.com/DLR-AMR/t8code/issues/920 */
     GTEST_SKIP ();
     /* Unref both cmeshes */
     t8_cmesh_unref (&cmesh);

--- a/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
@@ -22,57 +22,60 @@
 
 #include <gtest/gtest.h>
 #include <t8_cmesh.h>
+#include <t8_schemes/t8_default/t8_default_cxx.hxx>
 #include "t8_cmesh/t8_cmesh_trees.h"
 #include "t8_cmesh/t8_cmesh_partition.h"
-#include <t8_eclass.h>
 #include <t8_cmesh/t8_cmesh_testcases.h>
 #include <test/t8_gtest_macros.hxx>
 
-/* Test if a cmesh is committed properly and perform the face consistency check. */
+/* We create and commit a cmesh, then derive a new cmesh
+ * from it without any changes.
+ * We test whether the new and original cmesh are equal.
+ */
 
-class cmesh_copy_equality: public testing::TestWithParam<int> {
+class t8_cmesh_copy: public testing::TestWithParam<int> {
  protected:
   void
   SetUp () override
   {
+    GTEST_SKIP ();
     cmesh_id = GetParam ();
 
+    /* Create cmesh from cmesh_id */
     cmesh_original = t8_test_create_cmesh (cmesh_id);
-    /* Set up the cmesh copy */
-    t8_cmesh_init (&cmesh_copy);
-    /* We need the original cmesh later, so we ref it */
-    t8_cmesh_ref (cmesh_original);
-    t8_cmesh_set_derive (cmesh_copy, cmesh_original);
-    t8_cmesh_commit (cmesh_copy, sc_MPI_COMM_WORLD);
+    /* Initialized test cmesh that we derive in the test */
+    t8_cmesh_init (&cmesh);
   }
+
   void
   TearDown () override
   {
-    t8_cmesh_unref (&cmesh_original);
-    t8_cmesh_unref (&cmesh_copy);
+    GTEST_SKIP ();
+    /* Unref both cmeshes */
+    t8_cmesh_unref (&cmesh);
   }
 
-  t8_cmesh_t cmesh_original;
-  t8_cmesh_t cmesh_copy;
   int cmesh_id;
+  t8_cmesh_t cmesh;
+  t8_cmesh_t cmesh_original;
 };
 
-/* Test wheater the original cmaeh and its copy are committed and face consistent. Test will fail, if one of these is false. */
-TEST_P (cmesh_copy_equality, check_cmeshes_and_their_trees)
+static void
+test_cmesh_committed (t8_cmesh_t cmesh)
 {
-
-  EXPECT_TRUE (t8_cmesh_is_committed (cmesh_original));
-  EXPECT_TRUE (t8_cmesh_is_committed (cmesh_copy));
-  EXPECT_TRUE (t8_cmesh_trees_is_face_consistent (cmesh_original, cmesh_original->trees));
-  EXPECT_TRUE (t8_cmesh_trees_is_face_consistent (cmesh_copy, cmesh_copy->trees));
+  ASSERT_TRUE (t8_cmesh_is_committed (cmesh)) << "Cmesh commit failed.";
+  ASSERT_TRUE (t8_cmesh_trees_is_face_consistent (cmesh, cmesh->trees)) << "Cmesh face consistency failed.";
 }
 
-/* Test the equality of the original and copied cmeshs*/
-TEST_P (cmesh_copy_equality, check_equality_of_copied_cmesh_with_original)
+TEST_P (t8_cmesh_copy, test_cmesh_copy)
 {
+  t8_cmesh_set_derive (cmesh, cmesh_original);
+  t8_cmesh_commit (cmesh, sc_MPI_COMM_WORLD);
 
-  EXPECT_TRUE (t8_cmesh_is_equal (cmesh_original, cmesh_copy));
+  test_cmesh_committed (cmesh);
+
+  EXPECT_TRUE (t8_cmesh_is_equal (cmesh, cmesh_original));
 }
 
 /* Test all cmeshes over all different inputs we get through their id */
-INSTANTIATE_TEST_SUITE_P (t8_gtest_cmesh_copy, cmesh_copy_equality, AllCmeshs);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_cmesh_copy, t8_cmesh_copy, AllCmeshs);

--- a/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
@@ -34,10 +34,10 @@
  */
 
 /* Note: This test currently fails on many cmeshes and is thus deavtivated.
- * See: https://github.com/DLR-AMR/t8code/issues/920*/
-* /
+ * See: https://github.com/DLR-AMR/t8code/issues/920
+ */
 
-  class t8_cmesh_copy: public testing::TestWithParam<int> {
+class t8_cmesh_copy: public testing::TestWithParam<int> {
  protected:
   void
   SetUp () override
@@ -83,5 +83,5 @@ TEST_P (t8_cmesh_copy, test_cmesh_copy)
   EXPECT_TRUE (t8_cmesh_is_equal (cmesh, cmesh_original));
 }
 
-/* Test all cmeshes over all different inputs we get through their id */
+/* Test all cmeshes over all different inputs */
 INSTANTIATE_TEST_SUITE_P (t8_gtest_cmesh_copy, t8_cmesh_copy, AllCmeshs);


### PR DESCRIPTION
**_Describe your changes here:_**

Added a test for cmesh_copy (i.e. derive without any additions).
The test fails currently on several test cases and is thus deactivated.

See also #920 


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
