### PR TITLE
Remove scale parameter from cmesh vtk

### DIFF
--- a/benchmarks/time_forest_partition.cxx
+++ b/benchmarks/time_forest_partition.cxx
@@ -254,7 +254,7 @@ t8_time_forest_cmesh_mshfile (t8_cmesh_t cmesh, const char *vtu_prefix, sc_MPI_C
       snprintf (forest_vtu, BUFSIZ, "%s_forest_partition_%03d", vtu_prefix, time_step);
       snprintf (cmesh_vtu, BUFSIZ, "%s_cmesh_partition_%03d", vtu_prefix, time_step);
       t8_forest_write_vtk (forest_partition, forest_vtu);
-      t8_cmesh_vtk_write_file (t8_forest_get_cmesh (forest_partition), cmesh_vtu, 1.0);
+      t8_cmesh_vtk_write_file (t8_forest_get_cmesh (forest_partition), cmesh_vtu);
       t8_debugf ("Wrote partitioned forest and cmesh\n");
     }
     if (cmesh_is_partitioned) {

--- a/benchmarks/time_partition.cxx
+++ b/benchmarks/time_partition.cxx
@@ -132,7 +132,7 @@ t8_time_cmesh_partition_brick (int x, int y, int z, sc_MPI_Comm comm, int no_vtk
 
     mpiret = sc_MPI_Comm_rank (comm, &mpirank);
     SC_CHECK_MPI (mpiret);
-    t8_cmesh_vtk_write_file (cmesh_partition, "cmesh_box_partition", 1.0);
+    t8_cmesh_vtk_write_file (cmesh_partition, "cmesh_box_partition");
   }
   /* memory clean-up */
   t8_cmesh_destroy (&cmesh_partition);

--- a/example/IO/cmesh/gmsh/t8_load_and_refine_square_w_hole.cxx
+++ b/example/IO/cmesh/gmsh/t8_load_and_refine_square_w_hole.cxx
@@ -27,7 +27,6 @@
 
 #include <sc_refcount.h>
 #include <t8_cmesh.h>
-#include <t8_cmesh_vtk_writer.h>
 #include <t8_cmesh/t8_cmesh_partition.h>
 #include <t8_cmesh_readmshfile.h>
 #include <t8_forest/t8_forest_general.h>

--- a/example/IO/cmesh/gmsh/t8_read_msh_file.cxx
+++ b/example/IO/cmesh/gmsh/t8_read_msh_file.cxx
@@ -40,7 +40,7 @@ t8_read_msh_file_vtk (t8_cmesh_t cmesh, const char *prefix)
   SC_CHECK_MPI (mpiret);
 
   snprintf (fileprefix, BUFSIZ, "%s_t8_msh", prefix);
-  if (!t8_cmesh_vtk_write_file (cmesh, fileprefix, 1.)) {
+  if (!t8_cmesh_vtk_write_file (cmesh, fileprefix)) {
     t8_debugf ("Wrote to file %s\n", fileprefix);
   }
   else {

--- a/example/IO/cmesh/t8_cmesh_load_save.cxx
+++ b/example/IO/cmesh/t8_cmesh_load_save.cxx
@@ -40,14 +40,14 @@ t8_cmesh_load_distribute (const char *fileprefix, int num_files, int no_vtk)
   else {
     t8_debugf ("Successfully loaded cmesh from %s files\n", fileprefix);
     if (!no_vtk) {
-      t8_cmesh_vtk_write_file (cmesh, "cmesh_dist_loaded", 1.0);
+      t8_cmesh_vtk_write_file (cmesh, "cmesh_dist_loaded");
     }
     t8_cmesh_init (&cmesh_partition);
     t8_cmesh_set_derive (cmesh_partition, cmesh);
     t8_cmesh_set_partition_uniform (cmesh_partition, 0, t8_scheme_new_default_cxx ());
     t8_cmesh_commit (cmesh_partition, sc_MPI_COMM_WORLD);
     if (!no_vtk) {
-      t8_cmesh_vtk_write_file (cmesh_partition, "cmesh_dist_loaded_partition", 1.0);
+      t8_cmesh_vtk_write_file (cmesh_partition, "cmesh_dist_loaded_partition");
     }
     t8_cmesh_destroy (&cmesh_partition);
   }

--- a/example/IO/cmesh/tetgen/t8_forest_from_tetgen.cxx
+++ b/example/IO/cmesh/tetgen/t8_forest_from_tetgen.cxx
@@ -45,7 +45,7 @@ t8_cmesh_from_tetgen (const char *prefix, int do_partition)
     t8_debugf ("Successfully constructed cmesh from %s files.\n", prefix);
     t8_debugf ("cmesh has:\n\t%lli tetrahedra\n", (long long) t8_cmesh_get_num_trees (cmesh));
     snprintf (fileprefix, BUFSIZ, "%s_t8_tetgen_%04d", prefix, mpirank);
-    if (!t8_cmesh_vtk_write_file (cmesh, fileprefix, 1.)) {
+    if (!t8_cmesh_vtk_write_file (cmesh, fileprefix)) {
       t8_debugf ("Wrote to file %s\n", fileprefix);
     }
     else {

--- a/example/IO/cmesh/tetgen/t8_read_tetgen_file.cxx
+++ b/example/IO/cmesh/tetgen/t8_read_tetgen_file.cxx
@@ -42,7 +42,7 @@ t8_read_tetgen_file_build_cmesh (const char *prefix, int do_dup, int do_partitio
     t8_debugf ("Successfully constructed cmesh from %s files.\n", prefix);
     t8_debugf ("cmesh has:\n\t%lli tetrahedra\n", (long long) t8_cmesh_get_num_trees (cmesh));
     snprintf (fileprefix, BUFSIZ, "%s_t8_tetgen", prefix);
-    if (!t8_cmesh_vtk_write_file (cmesh, fileprefix, 1.)) {
+    if (!t8_cmesh_vtk_write_file (cmesh, fileprefix)) {
       t8_debugf ("Wrote to file %s\n", fileprefix);
     }
     else {
@@ -60,7 +60,7 @@ t8_read_tetgen_file_build_cmesh (const char *prefix, int do_dup, int do_partitio
       t8_debugf ("Successfully partitioned %s.\n", "cmesh");
       t8_debugf ("cmesh has:\n\t%li local tetrahedra\n", (long) t8_cmesh_get_num_local_trees (cmesh_partitioned));
       snprintf (fileprefix, BUFSIZ, "%s_t8_tetgen_partitioned", prefix);
-      if (!t8_cmesh_vtk_write_file (cmesh_partitioned, fileprefix, 1.)) {
+      if (!t8_cmesh_vtk_write_file (cmesh_partitioned, fileprefix)) {
         t8_debugf ("Wrote to file %s\n", fileprefix);
       }
       else {

--- a/example/IO/cmesh/tetgen/t8_time_tetgen_file.cxx
+++ b/example/IO/cmesh/tetgen/t8_time_tetgen_file.cxx
@@ -24,7 +24,6 @@
 #include <t8.h>
 #include <t8_cmesh.h>
 #include <t8_cmesh_tetgen.h>
-#include <t8_cmesh_vtk_writer.h>
 #include <sc_flops.h>
 #include <sc_statistics.h>
 #include <sc_options.h>

--- a/example/IO/cmesh/triangle/t8_read_triangle_file.cxx
+++ b/example/IO/cmesh/triangle/t8_read_triangle_file.cxx
@@ -48,7 +48,7 @@ t8_read_triangle_file_build_cmesh (const char *prefix, int do_dup, int do_partit
       t8_cmesh_set_partition_uniform (cmesh_part, 1, t8_scheme_new_default_cxx ());
       t8_cmesh_commit (cmesh_part, sc_MPI_COMM_WORLD);
       snprintf (fileprefix, BUFSIZ, "%s_t8_triangle_partition", prefix);
-      if (!t8_cmesh_vtk_write_file (cmesh_part, fileprefix, 1.0)) {
+      if (!t8_cmesh_vtk_write_file (cmesh_part, fileprefix)) {
         t8_debugf ("Wrote to file %s\n", fileprefix);
       }
       t8_cmesh_destroy (&cmesh_part);
@@ -56,7 +56,7 @@ t8_read_triangle_file_build_cmesh (const char *prefix, int do_dup, int do_partit
     t8_debugf ("Successfully constructed cmesh from %s files.\n", prefix);
     t8_debugf ("cmesh has:\n\t%lli triangles\n", (long long) t8_cmesh_get_num_trees (cmesh));
     snprintf (fileprefix, BUFSIZ, "%s_t8_triangle", prefix);
-    if (!t8_cmesh_vtk_write_file (cmesh, fileprefix, 1.)) {
+    if (!t8_cmesh_vtk_write_file (cmesh, fileprefix)) {
       t8_debugf ("Wrote to file %s\n", fileprefix);
     }
     else {

--- a/example/IO/cmesh/vtk/t8_cmesh_read_from_vtk.cxx
+++ b/example/IO/cmesh/vtk/t8_cmesh_read_from_vtk.cxx
@@ -49,7 +49,7 @@ t8_forest_construct_from_vtk (const char *prefix, sc_MPI_Comm comm, const int va
   }
   char out_file[BUFSIZ];
   snprintf (out_file, BUFSIZ - 9, "%s_cmesh_in", out_prefix);
-  t8_cmesh_vtk_write_file (cmesh_in, out_file, 1.0);
+  t8_cmesh_vtk_write_file (cmesh_in, out_file);
   t8_cmesh_t cmesh;
 
   if (partition) {
@@ -58,7 +58,7 @@ t8_forest_construct_from_vtk (const char *prefix, sc_MPI_Comm comm, const int va
     t8_cmesh_set_partition_uniform (cmesh, 0, t8_scheme_new_default_cxx ());
     t8_cmesh_commit (cmesh, comm);
     snprintf (out_file, BUFSIZ - 16, "%s_cmesh_partition", out_prefix);
-    t8_cmesh_vtk_write_file (cmesh, out_file, 1.0);
+    t8_cmesh_vtk_write_file (cmesh, out_file);
   }
   else {
     cmesh = cmesh_in;

--- a/example/advect/t8_advection.cxx
+++ b/example/advect/t8_advection.cxx
@@ -1631,7 +1631,7 @@ main (int argc, char *argv[])
     cmesh = t8_advect_create_cmesh (sc_MPI_COMM_WORLD, cube_type, mshfile, level, dim, use_occ_geometry);
     u = t8_advect_choose_flow (flow_arg);
     if (!no_vtk) {
-      t8_cmesh_vtk_write_file (cmesh, "advection_cmesh", 1.0);
+      t8_cmesh_vtk_write_file (cmesh, "advection_cmesh");
     }
     /* Computation */
     t8_advect_solve (cmesh, u, t8_levelset_sphere, &ls_data, level, level + reflevel, T, cfl, sc_MPI_COMM_WORLD,

--- a/example/cmesh/t8_cmesh_geometry_examples.cxx
+++ b/example/cmesh/t8_cmesh_geometry_examples.cxx
@@ -114,7 +114,7 @@ main (int argc, char **argv)
 
     t8_forest_t forest = t8_forest_new_uniform (cmesh, t8_scheme_new_default_cxx (), uniform_level, 0, comm);
 
-    t8_cmesh_vtk_write_file (cmesh, prefix_cmesh, 1.0);
+    t8_cmesh_vtk_write_file (cmesh, prefix_cmesh);
     t8_global_productionf ("Wrote %s.\n", prefix_cmesh);
 
     t8_write_forest_to_vtu (forest, prefix_forest);
@@ -134,7 +134,7 @@ main (int argc, char **argv)
 
     t8_forest_t forest = t8_forest_new_uniform (cmesh, t8_scheme_new_default_cxx (), uniform_level, 0, comm);
 
-    t8_cmesh_vtk_write_file (cmesh, prefix_cmesh, 1.0);
+    t8_cmesh_vtk_write_file (cmesh, prefix_cmesh);
     t8_global_productionf ("Wrote %s.\n", prefix_cmesh);
 
     t8_write_forest_to_vtu (forest, prefix_forest);
@@ -154,7 +154,7 @@ main (int argc, char **argv)
 
     t8_forest_t forest = t8_forest_new_uniform (cmesh, t8_scheme_new_default_cxx (), uniform_level, 0, comm);
 
-    t8_cmesh_vtk_write_file (cmesh, prefix_cmesh, 1.0);
+    t8_cmesh_vtk_write_file (cmesh, prefix_cmesh);
     t8_global_productionf ("Wrote %s.\n", prefix_cmesh);
 
     t8_write_forest_to_vtu (forest, prefix_forest);
@@ -177,7 +177,7 @@ main (int argc, char **argv)
 
     t8_forest_t forest = t8_forest_new_uniform (cmesh, t8_scheme_new_default_cxx (), uniform_level, 0, comm);
 
-    t8_cmesh_vtk_write_file (cmesh, prefix_cmesh, 1.0);
+    t8_cmesh_vtk_write_file (cmesh, prefix_cmesh);
     t8_global_productionf ("Wrote %s.\n", prefix_cmesh);
 
     t8_write_forest_to_vtu (forest, prefix_forest);

--- a/example/cmesh/t8_cmesh_hypercube_pad.cxx
+++ b/example/cmesh/t8_cmesh_hypercube_pad.cxx
@@ -55,7 +55,7 @@ main (int argc, char **argv)
   t8_global_productionf (" [step1] Local number of trees:\t%i\n", local_num_trees);
   t8_global_productionf (" [step1] Global number of trees:\t%li\n", global_num_trees);
 
-  t8_cmesh_vtk_write_file (cmesh, prefix, 1.0);
+  t8_cmesh_vtk_write_file (cmesh, prefix);
 
   t8_cmesh_destroy (&cmesh);
 

--- a/example/cmesh/t8_cmesh_partition.cxx
+++ b/example/cmesh/t8_cmesh_partition.cxx
@@ -49,7 +49,7 @@ t8_random_partition (int level)
   cmesh = t8_cmesh_new_from_p8est (conn, sc_MPI_COMM_WORLD, 1);
   p8est_connectivity_destroy (conn);
   snprintf (file, BUFSIZ, "t8_brick_random");
-  t8_cmesh_vtk_write_file (cmesh, file, 1.);
+  t8_cmesh_vtk_write_file (cmesh, file);
 
   t8_cmesh_init (&cmesh_part);
 
@@ -70,14 +70,14 @@ t8_random_partition (int level)
     t8_cmesh_commit (cmesh_part2, sc_MPI_COMM_WORLD);
 
     snprintf (file, BUFSIZ, "t8_brick_partition_random2");
-    t8_cmesh_vtk_write_file (cmesh_part2, file, 1.0);
+    t8_cmesh_vtk_write_file (cmesh_part2, file);
   }
   else {
     cmesh_part2 = cmesh_part;
     t8_cmesh_ref (cmesh_part);
   }
   snprintf (file, BUFSIZ, "t8_brick_partition_random");
-  t8_cmesh_vtk_write_file (cmesh_part, file, 1.0);
+  t8_cmesh_vtk_write_file (cmesh_part, file);
   t8_cmesh_destroy (&cmesh);
   t8_cmesh_unref (&cmesh_part);
   t8_cmesh_destroy (&cmesh_part2);
@@ -106,7 +106,7 @@ t8_partition (int level, int partition_from)
   cmesh = t8_cmesh_new_from_p4est (conn, sc_MPI_COMM_WORLD, partition_from);
   p4est_connectivity_destroy (conn);
   snprintf (file, BUFSIZ, "t8_brick");
-  t8_cmesh_vtk_write_file (cmesh, file, 1.);
+  t8_cmesh_vtk_write_file (cmesh, file);
 
   t8_cmesh_init (&cmesh_part);
   /* We still need access to cmesh later */
@@ -123,14 +123,14 @@ t8_partition (int level, int partition_from)
                                     t8_cmesh_offset_concentrate (1, sc_MPI_COMM_WORLD, t8_cmesh_get_num_trees (cmesh)));
     t8_cmesh_commit (cmesh_part2, sc_MPI_COMM_WORLD);
     snprintf (file, BUFSIZ, "t8_brick_partition2");
-    t8_cmesh_vtk_write_file (cmesh_part2, file, 1.0);
+    t8_cmesh_vtk_write_file (cmesh_part2, file);
   }
   else {
     cmesh_part2 = cmesh_part;
     t8_cmesh_ref (cmesh_part);
   }
   snprintf (file, BUFSIZ, "t8_brick_partition");
-  t8_cmesh_vtk_write_file (cmesh_part, file, 1.0);
+  t8_cmesh_vtk_write_file (cmesh_part, file);
   t8_cmesh_destroy (&cmesh);
   t8_cmesh_unref (&cmesh_part);
   t8_cmesh_destroy (&cmesh_part2);

--- a/example/forest/t8_test_face_iterate.cxx
+++ b/example/forest/t8_test_face_iterate.cxx
@@ -110,7 +110,7 @@ t8_test_fiterate_refine_and_partition (t8_cmesh_t cmesh, int level, sc_MPI_Comm 
   t8_cmesh_t cmesh_partition;
 
   if (!no_vtk) {
-    t8_cmesh_vtk_write_file (cmesh, "test_fiterate_cmesh0", 1.0);
+    t8_cmesh_vtk_write_file (cmesh, "test_fiterate_cmesh0");
   }
   if (partition_cmesh) {
     /* partition the initial cmesh according to a uniform forest */
@@ -124,7 +124,7 @@ t8_test_fiterate_refine_and_partition (t8_cmesh_t cmesh, int level, sc_MPI_Comm 
     cmesh_partition = cmesh;
   }
   if (!no_vtk) {
-    t8_cmesh_vtk_write_file (cmesh_partition, "test_fiterate_cmesh1", 1.0);
+    t8_cmesh_vtk_write_file (cmesh_partition, "test_fiterate_cmesh1");
   }
   forest = t8_forest_new_uniform (cmesh_partition, t8_scheme_new_default_cxx (), level, 0, comm);
 

--- a/example/forest/t8_test_ghost.cxx
+++ b/example/forest/t8_test_ghost.cxx
@@ -119,7 +119,7 @@ t8_test_ghost_refine_and_partition (t8_cmesh_t cmesh, const int level, sc_MPI_Co
   t8_forest_adapt_t adapt_fn;
 
   if (!no_vtk) {
-    t8_cmesh_vtk_write_file (cmesh, "test_ghost_cmesh0", 1.0);
+    t8_cmesh_vtk_write_file (cmesh, "test_ghost_cmesh0");
   }
   if (partition_cmesh) {
     /* partition the initial cmesh according to a uniform forest */
@@ -133,7 +133,7 @@ t8_test_ghost_refine_and_partition (t8_cmesh_t cmesh, const int level, sc_MPI_Co
     cmesh_partition = cmesh;
   }
   if (!no_vtk) {
-    t8_cmesh_vtk_write_file (cmesh_partition, "test_ghost_cmesh1", 1.0);
+    t8_cmesh_vtk_write_file (cmesh_partition, "test_ghost_cmesh1");
   }
   forest = t8_forest_new_uniform (cmesh_partition, t8_scheme_new_default_cxx (), level, 1, comm);
 

--- a/example/forest/t8_test_ghost_large_level_diff.cxx
+++ b/example/forest/t8_test_ghost_large_level_diff.cxx
@@ -145,7 +145,7 @@ t8_ghost_large_level_diff (const char *prefix, int dim, int level, int refine, i
   t8_cmesh_set_partition_uniform (cmesh_partition, level, t8_scheme_new_default_cxx ());
   t8_cmesh_commit (cmesh_partition, comm);
   if (!no_vtk) {
-    t8_cmesh_vtk_write_file (cmesh_partition, "partitioned_cmesh", 1.0);
+    t8_cmesh_vtk_write_file (cmesh_partition, "partitioned_cmesh");
   }
 
   /* New */

--- a/src/t8_cmesh/t8_cmesh_vtk_writer.c
+++ b/src/t8_cmesh/t8_cmesh_vtk_writer.c
@@ -55,14 +55,12 @@ t8_cmesh_get_num_vertices (t8_cmesh_t cmesh, int count_ghosts)
   return num_vertices;
 }
 
-/* TODO: implement for scale < 1 */
 static int
-t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double scale, int write_ghosts)
+t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, int write_ghosts)
 {
   T8_ASSERT (cmesh != NULL);
   T8_ASSERT (t8_cmesh_is_committed (cmesh));
   T8_ASSERT (fileprefix != NULL);
-  T8_ASSERT (scale == 1.); /* scale = 1 not implemented yet */
 
   if (cmesh->mpirank == 0) {
     /* Write the pvtu header file. */
@@ -333,8 +331,7 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
 }
 
 int
-t8_cmesh_vtk_write_file (t8_cmesh_t cmesh, const char *fileprefix, double scale)
+t8_cmesh_vtk_write_file (t8_cmesh_t cmesh, const char *fileprefix)
 {
-  T8_ASSERT (scale == 1.0);
-  return t8_cmesh_vtk_write_file_ext (cmesh, fileprefix, 1.0, 1);
+  return t8_cmesh_vtk_write_file_ext (cmesh, fileprefix, 1);
 }

--- a/src/t8_cmesh_vtk_writer.h
+++ b/src/t8_cmesh_vtk_writer.h
@@ -36,7 +36,7 @@ T8_EXTERN_C_BEGIN ();
 
 /* TODO: document this function */
 int
-t8_cmesh_vtk_write_file (t8_cmesh_t cmesh, const char *fileprefix, double scale);
+t8_cmesh_vtk_write_file (t8_cmesh_t cmesh, const char *fileprefix);
 
 T8_EXTERN_C_END ();
 

--- a/tutorials/general/t8_step1_coarsemesh.cxx
+++ b/tutorials/general/t8_step1_coarsemesh.cxx
@@ -76,7 +76,7 @@ t8_step1_build_tetcube_coarse_mesh (sc_MPI_Comm comm)
 static void
 t8_step1_write_cmesh_vtk (t8_cmesh_t cmesh, const char *prefix)
 {
-  t8_cmesh_vtk_write_file (cmesh, prefix, 1.0);
+  t8_cmesh_vtk_write_file (cmesh, prefix);
 }
 
 /* Destroy a cmesh. This will free all allocated memory.

--- a/tutorials/general/t8_tutorial_build_cmesh.cxx
+++ b/tutorials/general/t8_tutorial_build_cmesh.cxx
@@ -492,9 +492,9 @@ t8_tutorial_build_cmesh_main (int argc, char **argv)
   t8_global_productionf ("[tutorial] A 3D hybrid cmesh (in style of a gate) has been created.\n");
 
   /* Output the meshes to vtu files. */
-  t8_cmesh_vtk_write_file (cmesh_2D, prefix_2D, 1.0);
+  t8_cmesh_vtk_write_file (cmesh_2D, prefix_2D);
   t8_global_productionf ("[tutorial] Wrote the 2D cmesh to vtu files.\n");
-  t8_cmesh_vtk_write_file (cmesh_3D, prefix_3D, 1.0);
+  t8_cmesh_vtk_write_file (cmesh_3D, prefix_3D);
   t8_global_productionf ("[tutorial] Wrote the 3D cmesh to vtu files.\n");
 
   /*


### PR DESCRIPTION
**_Describe your changes here:_**

The cmesh vtk function had a scale parameter that was never implemented.
Since the desired feature is the same as Paraviews Shrink filter, we will also never implement it.

Removed the scale parameter from the interface.

Note that this will trigger a major release.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
