### PR TITLE
Remove binary vtk option

### DIFF
--- a/src/t8_cmesh/t8_cmesh_vtk_writer.c
+++ b/src/t8_cmesh/t8_cmesh_vtk_writer.c
@@ -103,9 +103,6 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
     }
     fprintf (vtufile, "<?xml version=\"1.0\"?>\n");
     fprintf (vtufile, "<VTKFile type=\"UnstructuredGrid\" version=\"0.1\"");
-#if defined T8_VTK_BINARY && defined T8_VTK_COMPRESSION
-    fprintf (vtufile, " compressor=\"vtkZLibDataCompressor\"");
-#endif
 #ifdef SC_IS_BIGENDIAN
     fprintf (vtufile, " byte_order=\"BigEndian\">\n");
 #else
@@ -122,7 +119,6 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
              " NumberOfComponents=\"3\" format=\"%s\">\n",
              T8_VTK_FLOAT_NAME, T8_VTK_FORMAT_STRING);
 
-#ifdef T8_VTK_ASCII
     for (tree = t8_cmesh_get_first_tree (cmesh); tree != NULL; tree = t8_cmesh_get_next_tree (cmesh, tree)) {
       /*  TODO: Use new geometry here. Need cmesh_get_reference coords function. */
       vertices = t8_cmesh_get_tree_vertices (cmesh, tree->treeid);
@@ -135,8 +131,8 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
         fprintf (vtufile, "     %24.16e %24.16e %24.16e\n", x, y, z);
 #else
         fprintf (vtufile, "          %16.8e %16.8e %16.8e\n", x, y, z);
-#endif
       }
+#endif
     } /* end tree loop */
     if (write_ghosts) {
 
@@ -163,9 +159,6 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
         }
       } /* end ghost loop */
     }
-#else
-    SC_ABORT ("Binary vtk file not implemented\n");
-#endif /* T8_VTK_ASCII */
     fprintf (vtufile, "        </DataArray>\n");
     fprintf (vtufile, "      </Points>\n");
     fprintf (vtufile, "      <Cells>\n");
@@ -175,7 +168,6 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
              "        <DataArray type=\"%s\" Name=\"connectivity\""
              " format=\"%s\">\n",
              T8_VTK_LOCIDX, T8_VTK_FORMAT_STRING);
-#ifdef T8_VTK_ASCII
     for (tree = t8_cmesh_get_first_tree (cmesh), count_vertices = 0; tree != NULL;
          tree = t8_cmesh_get_next_tree (cmesh, tree)) {
       fprintf (vtufile, "         ");
@@ -195,9 +187,6 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
         fprintf (vtufile, "\n");
       }
     }
-#else
-    SC_ABORT ("Binary vtk file not implemented\n");
-#endif /* T8_VTK_ASCII */
     fprintf (vtufile, "        </DataArray>\n");
 
     /* write offset data */
@@ -205,7 +194,6 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
              "        <DataArray type=\"%s\" Name=\"offsets\""
              " format=\"%s\">\n",
              T8_VTK_LOCIDX, T8_VTK_FORMAT_STRING);
-#ifdef T8_VTK_ASCII
     fprintf (vtufile, "         ");
     for (tree = t8_cmesh_get_first_tree (cmesh), sk = 1, offset = 0; tree != NULL;
          tree = t8_cmesh_get_next_tree (cmesh, tree), ++sk) {
@@ -225,16 +213,12 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
       }
     }
     fprintf (vtufile, "\n");
-#else
-    SC_ABORT ("Binary vtk file not implemented\n");
-#endif /* T8_VTK_ASCII */
     fprintf (vtufile, "        </DataArray>\n");
     /* write type data */
     fprintf (vtufile,
              "        <DataArray type=\"UInt8\" Name=\"types\""
              " format=\"%s\">\n",
              T8_VTK_FORMAT_STRING);
-#ifdef T8_VTK_ASCII
     fprintf (vtufile, "         ");
     for (tree = t8_cmesh_get_first_tree (cmesh), sk = 1; tree != NULL;
          tree = t8_cmesh_get_next_tree (cmesh, tree), ++sk) {
@@ -252,9 +236,6 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
       }
     }
     fprintf (vtufile, "\n");
-#else
-    SC_ABORT ("Binary vtk file not implemented\n");
-#endif /* T8_VTK_ASCII */
     fprintf (vtufile, "        </DataArray>\n");
     fprintf (vtufile, "      </Cells>\n");
     /* write treeif data */
@@ -263,7 +244,6 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
              "        <DataArray type=\"%s\" Name=\"treeid\""
              " format=\"%s\">\n",
              T8_VTK_GLOIDX, T8_VTK_FORMAT_STRING);
-#ifdef T8_VTK_ASCII
     fprintf (vtufile, "         ");
     for (tree = t8_cmesh_get_first_tree (cmesh), sk = 1, offset = 0; tree != NULL;
          tree = t8_cmesh_get_next_tree (cmesh, tree), ++sk) {
@@ -292,16 +272,12 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
       }
     }
     fprintf (vtufile, "\n");
-#else
-    SC_ABORT ("Binary vtk file not implemented\n");
-#endif /* T8_VTK_ASCII */
     fprintf (vtufile, "        </DataArray>\n");
     /* write mpirank data */
     fprintf (vtufile,
              "        <DataArray type=\"%s\" Name=\"mpirank\""
              " format=\"%s\">\n",
              "Int32", T8_VTK_FORMAT_STRING);
-#ifdef T8_VTK_ASCII
     fprintf (vtufile, "         ");
     for (tree = t8_cmesh_get_first_tree (cmesh), sk = 1, offset = 0; tree != NULL;
          tree = t8_cmesh_get_next_tree (cmesh, tree), ++sk) {
@@ -318,9 +294,6 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
       }
     }
     fprintf (vtufile, "\n");
-#else
-    SC_ABORT ("Binary vtk file not implemented\n");
-#endif /* T8_VTK_ASCII */
     fprintf (vtufile, "        </DataArray>\n");
     fprintf (vtufile, "      </CellData>\n");
     /* write type data */

--- a/src/t8_cmesh/t8_cmesh_vtk_writer.c
+++ b/src/t8_cmesh/t8_cmesh_vtk_writer.c
@@ -131,8 +131,8 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
         fprintf (vtufile, "     %24.16e %24.16e %24.16e\n", x, y, z);
 #else
         fprintf (vtufile, "          %16.8e %16.8e %16.8e\n", x, y, z);
-      }
 #endif
+      }
       } /* end tree loop */
       if (write_ghosts) {
 

--- a/src/t8_cmesh/t8_cmesh_vtk_writer.c
+++ b/src/t8_cmesh/t8_cmesh_vtk_writer.c
@@ -133,8 +133,8 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
         fprintf (vtufile, "          %16.8e %16.8e %16.8e\n", x, y, z);
 #endif
       }
-      } /* end tree loop */
-      if (write_ghosts) {
+    } /* end tree loop */
+    if (write_ghosts) {
 
       /* Write the vertices of the ghost trees */
       num_ghosts = t8_cmesh_get_num_ghosts (cmesh);

--- a/src/t8_cmesh/t8_cmesh_vtk_writer.c
+++ b/src/t8_cmesh/t8_cmesh_vtk_writer.c
@@ -133,8 +133,8 @@ t8_cmesh_vtk_write_file_ext (t8_cmesh_t cmesh, const char *fileprefix, double sc
         fprintf (vtufile, "          %16.8e %16.8e %16.8e\n", x, y, z);
       }
 #endif
-    } /* end tree loop */
-    if (write_ghosts) {
+      } /* end tree loop */
+      if (write_ghosts) {
 
       /* Write the vertices of the ghost trees */
       num_ghosts = t8_cmesh_get_num_ghosts (cmesh);

--- a/src/t8_forest/t8_forest_vtk.cxx
+++ b/src/t8_forest/t8_forest_vtk.cxx
@@ -1275,9 +1275,6 @@ t8_forest_vtk_write_file (t8_forest_t forest, const char *fileprefix, const int 
   }
   T8_ASSERT (forest->ghosts != NULL || !write_ghosts);
 
-  /* Currently we only support output in ascii format, not binary */
-  T8_ASSERT (T8_VTK_ASCII == 1);
-
   /* process 0 creates the .pvtu file */
   if (forest->mpirank == 0) {
     if (t8_write_pvtu (fileprefix, forest->mpisize, write_treeid, write_mpirank, write_level, write_element_id,

--- a/src/t8_vtk.h
+++ b/src/t8_vtk.h
@@ -47,7 +47,6 @@
 #define T8_VTK_FLOAT_TYPE double
 #endif
 
-#define T8_VTK_ASCII 1
 #define T8_VTK_FORMAT_STRING "ascii"
 
 #if T8_WITH_VTK

--- a/src/t8_vtk.h
+++ b/src/t8_vtk.h
@@ -47,12 +47,8 @@
 #define T8_VTK_FLOAT_TYPE double
 #endif
 
-#ifndef T8_VTK_BINARY
 #define T8_VTK_ASCII 1
 #define T8_VTK_FORMAT_STRING "ascii"
-#else
-#define T8_VTK_FORMAT_STRING "binary"
-#endif
 
 #if T8_WITH_VTK
 #define t8_vtk_locidx_array_type_t vtkTypeInt32Array


### PR DESCRIPTION
**_Describe your changes here:_**

The cmesh vtk had macros distinguishing between binary/compressed VTK output and ascii output.
Even though only the ascii version was implemented.

Since we do not plan on implementing the compressed output, and the setting was not even in the configure, we remove it completely.
This cleans up the code.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
