### PR TITLE
Fix typo, and delete documentation in .c-file (duplicate)

### DIFF
--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -671,7 +671,7 @@ t8_cmesh_get_attribute (const t8_cmesh_t cmesh, const int package_id, const int 
  * \param [in]     package_id   The identifier of a valid software package. \see sc_package_register
  * \param [in]     key          A key used to identify the attribute under all
  *                              attributes of this tree with the same \a package_id.
- * \param [in]     tree_id      The local number of the tree.
+ * \param [in]     ltree_id     The local number of the tree.
  * \param [in]     data_count   The number of entries in the array that are requested. 
  *                              This must be smaller or equal to the \a data_count parameter
  *                              of the corresponding call to \ref t8_cmesh_set_attribute_gloidx_array

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -388,22 +388,6 @@ t8_cmesh_get_attribute (const t8_cmesh_t cmesh, const int package_id, const int 
     cmesh->trees, is_ghost ? t8_cmesh_ltreeid_to_ghostid (cmesh, ltree_id) : ltree_id, package_id, key, NULL, is_ghost);
 }
 
-/* Return the attribute pointer of a tree for a gloidx_t array.
- * \param [in]     cmesh        The cmesh.
- * \param [in]     package_id   The identifier of a valid software package. \see sc_package_register
- * \param [in]     key          A key used to identify the attribute under all
- *                              attributes of this tree with the same \a package_id.
- * \param [in]     tree_id      The local number of the tree.
- * \param [out]    data_count   The number of entries in the array that are requested. 
- *                              This must be smaller or equal to the \a data_count parameter
- *                              of the corresponding call to \ref t8_cmesh_set_attribute_gloidx_array
- * \return         The attribute pointer of the tree \a ltree_id or NULL if the attribute is not found.
- * \note \a cmesh must be committed before calling this function.
- * \note No check is performed whether the attribute actually stored \a data_count many entries since
- *       we do not store the number of data entries of the attribute array.
- *       You can keep track of the data count yourself by using another attribute.
- * \see t8_cmesh_set_attribute_gloidx_array
- */
 t8_gloidx_t *
 t8_cmesh_get_attribute_gloidx_array (const t8_cmesh_t cmesh, const int package_id, const int key,
                                      const t8_locidx_t ltree_id, const size_t data_count)


### PR DESCRIPTION
This PR fixes a typo in the documentation. 
Furhtermore the documentation was duplicated in the .c-file and therefore deleted. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
