### PR TITLE
Add new constructor for similar cmeshes

### DIFF
--- a/test/t8_cmesh_generator/t8_cmesh_example_sets.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_example_sets.hxx
@@ -28,6 +28,7 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 #include "test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_prism_cake_param.hxx"
 #include "test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_from_class_param.hxx"
 #include "test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_bigmesh_param.hxx"
+#include "test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_comm.hxx"
 #include "test/t8_cmesh_generator/t8_gtest_cmesh_cartestian_product.hxx"
 #include "test/t8_cmesh_generator/t8_gtest_cmesh_sum_of_sets.hxx"
 
@@ -45,8 +46,8 @@ auto pretty_print_base_example = [] (const testing::TestParamInfo<cmesh_example_
 
 namespace cmesh_list
 {
-std::vector<example_set *> cart_prod_vec
-  = { new_from_class::cmesh_example, new_prism_cake::cmesh_example, new_bigmesh::cmesh_example };
+std::vector<example_set *> cart_prod_vec = { new_from_class::cmesh_example, new_prism_cake::cmesh_example,
+                                             new_bigmesh::cmesh_example, new_cmesh_comm::cmesh_example };
 
 cmesh_sum_of_sets cmesh_sums (cart_prod_vec);
 

--- a/test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_comm.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_comm.hxx
@@ -1,0 +1,74 @@
+/*
+This file is part of t8code.
+t8code is a C library to manage a collection (a forest) of multiple
+connected adaptive space-trees of general element classes in parallel.
+
+Copyright (C) 2024 the developers
+
+t8code is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+t8code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with t8code; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#ifndef T8_CMESH_NEW_COMM
+#define T8_CMESH_NEW_COMM
+
+#include "test/t8_cmesh_generator/t8_gtest_cmesh_cartestian_product.hxx"
+#include "test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_params.hxx"
+#include <t8_cmesh/t8_cmesh_examples.h>
+
+namespace new_cmesh_comm
+{
+std::string
+make_param_string (const sc_MPI_Comm &comm)
+{
+  std::string delimiter = std::string ("_");
+  std::string params = delimiter + cmesh_params::comm_to_string (comm);
+  return params;
+}
+
+std::function<std::string (const sc_MPI_Comm)> print_function = make_param_string;
+
+std::vector<std::function<t8_cmesh_t (sc_MPI_Comm)>> cmesh_functions = { t8_cmesh_new_periodic_tri,
+                                                                         t8_cmesh_new_periodic_hybrid,
+                                                                         t8_cmesh_new_periodic_line_more_trees,
+                                                                         t8_cmesh_new_line_zigzag,
+                                                                         t8_cmesh_new_prism_deformed,
+                                                                         t8_cmesh_new_pyramid_deformed,
+                                                                         t8_cmesh_new_prism_cake_funny_oriented,
+                                                                         t8_cmesh_new_prism_geometry,
+                                                                         t8_cmesh_new_tet_orientation_test,
+                                                                         t8_cmesh_new_hybrid_gate,
+                                                                         t8_cmesh_new_hybrid_gate_deformed,
+                                                                         t8_cmesh_new_full_hybrid };
+
+std::vector<std::string> names = { "t8_cmesh_new_periodic_tri_",
+                                   "t8_cmesh_new_periodic_hybrid_",
+                                   "t8_cmesh_new_periodic_line_more_trees_",
+                                   "t8_cmesh_new_line_zigzag_",
+                                   "t8_cmesh_new_prism_deformed_",
+                                   "t8_cmesh_new_pyramid_deformed_",
+                                   "t8_cmesh_new_prism_cake_funny_oriented_",
+                                   "t8_cmesh_new_prism_geometry_",
+                                   "t8_cmesh_new_tet_orientation_test_",
+                                   "t8_cmesh_new_hybrid_gate_",
+                                   "t8_cmesh_new_hybrid_gate_deformed_",
+                                   "t8_cmesh_new_full_hybrid_" };
+
+example_set *cmesh_example
+  = (example_set *) new cmesh_cartesian_product_params<decltype (cmesh_params::my_comms.begin ())> (
+    std::make_pair (cmesh_params::my_comms.begin (), cmesh_params::my_comms.end ()), cmesh_functions, print_function,
+    names);
+}  // namespace new_cmesh_comm
+
+#endif /* T8_CMESH_NEW_COMM */

--- a/test/t8_cmesh_generator/t8_gtest_cmesh_cartestian_product.hxx
+++ b/test/t8_cmesh_generator/t8_gtest_cmesh_cartestian_product.hxx
@@ -218,6 +218,25 @@ class cmesh_cartesian_product_params: example_set {
       example_all_combination.push_back (next_example);
     }
   }
+
+  cmesh_cartesian_product_params (std::pair<Iter, Iter>... ranges,
+                                  std::vector<std::function<t8_cmesh_t (typename Iter::value_type...)>> cmesh_functions,
+                                  std::function<std::string (const typename Iter::value_type&...)> param_to_string,
+                                  std::vector<std::string> names)
+  {
+    std::vector<std::tuple<typename Iter::value_type...>> cart_prod;
+    cartesian_product (std::back_inserter (cart_prod), ranges...);
+    T8_ASSERT (cmesh_functions.size () == names.size ());
+    for (int ifunction = 0; (long unsigned int) ifunction < cmesh_functions.size (); ifunction++) {
+      for (int iparam_set = 0; (long unsigned int) iparam_set < cart_prod.size (); iparam_set++) {
+        std::tuple<typename Iter::value_type...> param = cart_prod[iparam_set];
+        cmesh_example_base* next_example
+          = (cmesh_example_base*) new cmesh_example_with_parameter<typename Iter::value_type...> (
+            cmesh_functions[ifunction], param, param_to_string, names[ifunction]);
+        example_all_combination.push_back (next_example);
+      }
+    }
+  }
 };
 
 #endif /* T8_GTEST_CMESH_CREATOR_BASE_HXX */


### PR DESCRIPTION
To reduce the amount of code that needs to be added, I added a constructor for cmeshes that have the same signature. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
