### PR TITLE
Add new test

### DIFF
--- a/test/t8_cmesh_generator/t8_cmesh_example_sets.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_example_sets.hxx
@@ -29,6 +29,7 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 #include "test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_from_class_param.hxx"
 #include "test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_bigmesh_param.hxx"
 #include "test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_comm.hxx"
+#include "test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_hypercube_param.hxx"
 #include "test/t8_cmesh_generator/t8_gtest_cmesh_cartestian_product.hxx"
 #include "test/t8_cmesh_generator/t8_gtest_cmesh_sum_of_sets.hxx"
 
@@ -46,8 +47,9 @@ auto pretty_print_base_example = [] (const testing::TestParamInfo<cmesh_example_
 
 namespace cmesh_list
 {
-std::vector<example_set *> cart_prod_vec = { new_from_class::cmesh_example, new_prism_cake::cmesh_example,
-                                             new_bigmesh::cmesh_example, new_cmesh_comm::cmesh_example };
+std::vector<example_set *> cart_prod_vec
+  = { new_from_class::cmesh_example, new_prism_cake::cmesh_example,      new_bigmesh::cmesh_example,
+      new_cmesh_comm::cmesh_example, new_hypercube_cmesh::cmesh_example, new_hypercube_cmesh::cmesh_example_pyra };
 
 cmesh_sum_of_sets cmesh_sums (cart_prod_vec);
 

--- a/test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_hypercube_param.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_hypercube_param.hxx
@@ -1,0 +1,80 @@
+/*
+This file is part of t8code.
+t8code is a C library to manage a collection (a forest) of multiple
+connected adaptive space-trees of general element classes in parallel.
+
+Copyright (C) 2024 the developers
+
+t8code is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+t8code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with t8code; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#ifndef T8_CMESH_NEW_HYPERCUBE_PAD_PARAM_HXX
+#define T8_CMESH_NEW_HYPERCUBE_PAD_PARAM_HXX
+
+#include <t8_eclass.h>
+#include "test/t8_cmesh_generator/t8_gtest_cmesh_cartestian_product.hxx"
+#include "test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_params.hxx"
+#include <t8_cmesh/t8_cmesh_examples.h>
+
+namespace new_hypercube_cmesh
+{
+std::string
+make_param_string (const t8_eclass_t eclass, const sc_MPI_Comm comm, const int do_bcast, const int do_partition,
+                   const int periodic)
+{
+  std::string delimiter = std::string ("_");
+  std::string bcast = do_bcast ? std::string ("bcast") : std::string ("noBcast");
+  std::string partition = do_partition ? std::string ("partition") : std::string ("noPartition");
+  std::string periodic_string = periodic ? std::string ("periodic") : std::string ("noPeriodic");
+  std::string params
+    = delimiter + t8_eclass_to_string[eclass] + delimiter + bcast + delimiter + partition + delimiter + periodic_string;
+
+  return params;
+}
+
+std::function<std::string (const t8_eclass_t, const sc_MPI_Comm, const int, const int, const int)> param_to_string
+  = make_param_string;
+
+std::vector<t8_eclass_t> periodic_eclasses = { T8_ECLASS_VERTEX, T8_ECLASS_LINE, T8_ECLASS_QUAD, T8_ECLASS_TRIANGLE,
+                                               T8_ECLASS_HEX,    T8_ECLASS_TET,  T8_ECLASS_PRISM };
+
+std::function<t8_cmesh_t (t8_eclass_t, sc_MPI_Comm, int, int, int)> cmesh_wrapper = t8_cmesh_new_hypercube;
+
+std::vector<t8_eclass_t> nonperiodic_eclasses = { T8_ECLASS_PYRAMID };
+
+example_set *cmesh_example = (example_set *) new cmesh_cartesian_product_params<
+  decltype (periodic_eclasses.begin ()), decltype (cmesh_params::my_comms.begin ()),
+  decltype (cmesh_params::do_bcast.begin ()), decltype (cmesh_params::partition.begin ()),
+  decltype (cmesh_params::periodic.begin ())> (
+  std::make_pair (periodic_eclasses.begin (), periodic_eclasses.end ()),
+  std::make_pair (cmesh_params::my_comms.begin (), cmesh_params::my_comms.end ()),
+  std::make_pair (cmesh_params::do_bcast.begin (), cmesh_params::do_bcast.end ()),
+  std::make_pair (cmesh_params::partition.begin (), cmesh_params::partition.end ()),
+  std::make_pair (cmesh_params::periodic.begin (), cmesh_params::periodic.end ()), cmesh_wrapper, param_to_string,
+  "t8_cmesh_new_hypercube_");
+
+example_set *cmesh_example_pyra = (example_set *) new cmesh_cartesian_product_params<
+  decltype (periodic_eclasses.begin ()), decltype (cmesh_params::my_comms.begin ()),
+  decltype (cmesh_params::do_bcast.begin ()), decltype (cmesh_params::partition.begin ()),
+  decltype (cmesh_params::no_periodic.begin ())> (
+  std::make_pair (nonperiodic_eclasses.begin (), nonperiodic_eclasses.end ()),
+  std::make_pair (cmesh_params::my_comms.begin (), cmesh_params::my_comms.end ()),
+  std::make_pair (cmesh_params::do_bcast.begin (), cmesh_params::do_bcast.end ()),
+  std::make_pair (cmesh_params::partition.begin (), cmesh_params::partition.end ()),
+  std::make_pair (cmesh_params::no_periodic.begin (), cmesh_params::no_periodic.end ()), cmesh_wrapper, param_to_string,
+  "t8_cmesh_new_hypercube_");
+}  // namespace new_hypercube_cmesh
+
+#endif /* T8_CMESH_NEW_HYPERCUBE_PAD_PARAM_HXX */

--- a/test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_hypercube_param.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_hypercube_param.hxx
@@ -20,8 +20,8 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-#ifndef T8_CMESH_NEW_HYPERCUBE_PAD_PARAM_HXX
-#define T8_CMESH_NEW_HYPERCUBE_PAD_PARAM_HXX
+#ifndef T8_CMESH_NEW_HYPERCUBE_PARAM_HXX
+#define T8_CMESH_NEW_HYPERCUBE_PARAM_HXX
 
 #include <t8_eclass.h>
 #include "test/t8_cmesh_generator/t8_gtest_cmesh_cartestian_product.hxx"
@@ -77,4 +77,4 @@ example_set *cmesh_example_pyra = (example_set *) new cmesh_cartesian_product_pa
   "t8_cmesh_new_hypercube_");
 }  // namespace new_hypercube_cmesh
 
-#endif /* T8_CMESH_NEW_HYPERCUBE_PAD_PARAM_HXX */
+#endif /* T8_CMESH_NEW_HYPERCUBE_PARAM_HXX */

--- a/test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_params.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_params.hxx
@@ -63,6 +63,15 @@ std::vector<t8_eclass_t> all_eclasses
   = { T8_ECLASS_ZERO, T8_ECLASS_VERTEX, T8_ECLASS_LINE,    T8_ECLASS_QUAD,  T8_ECLASS_TRIANGLE, T8_ECLASS_HEX,
       T8_ECLASS_TET,  T8_ECLASS_PRISM,  T8_ECLASS_PYRAMID, T8_ECLASS_COUNT, T8_ECLASS_INVALID };
 
+std::vector<int> do_bcast = { 0, 1 };
+std::vector<int> partition = { 0, 1 };
+/* Currently a dummy vector for examples that have partition argument but not fully support it yet */
+std::vector<int> no_partition = { 0 };
+
+std::vector<int> periodic = { 0, 1 };
+/* Currently a dummy vector for examples that have periodic argument but not fully support it yet */
+std::vector<int> no_periodic = { 0 };
+
 std::vector<int> num_prisms = filled_vector (50, 3);
 }  // namespace cmesh_params
 


### PR DESCRIPTION
Add a new example to the parametrized tests.
Splitted the tests into two parts, because pyramids do not support a periodic hypercube (yet). 


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
