### PR TITLE
Add scheme base with empty face implementation

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
@@ -28,12 +28,13 @@
 #define T8_DEFAULT_COMMON_CXX_HXX
 
 #include <t8_element_cxx.hxx>
+#include <t8_schemes/t8_scheme_face_not_implemented_cxx.hxx>
 
 /* Macro to check whether a pointer (VAR) to a base class, comes from an
  * implementation of a child class (TYPE). */
 #define T8_COMMON_IS_TYPE(VAR, TYPE) ((dynamic_cast<TYPE> (VAR)) != NULL)
 
-class t8_default_scheme_common_c: public t8_eclass_scheme_c {
+class t8_default_scheme_common_c: public t8_scheme_face_not_implemented_c {
  public:
   /** Destructor for all default schemes */
   virtual ~t8_default_scheme_common_c ();

--- a/src/t8_schemes/t8_scheme_face_not_implemented_cxx.hxx
+++ b/src/t8_schemes/t8_scheme_face_not_implemented_cxx.hxx
@@ -1,0 +1,335 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+  Copyright (C) 2015 the developers
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_scheme_face_not_implemented_cxx.hxx
+ * We provide some functions that are useful across element classes.
+ */
+
+#ifndef T8_SCHEME_FACE_NOT_IMPLEMENTED_CXX
+#define T8_SCHEME_FACE_NOT_IMPLEMENTED_CXX
+
+#include <t8_element_cxx.hxx>
+#include <t8_element.h>
+#include <sc_functions.h>
+
+class t8_scheme_face_not_implemented_c: public t8_eclass_scheme_c {
+ public:
+  /** Destructor for all default schemes */
+  virtual ~t8_scheme_face_not_implemented_c ()
+  {
+  }
+  /** Compute the number of faces of a given element.
+   * \param [in] elem The element.
+   * \return          The number of faces of \a elem.
+   */
+  virtual int
+  t8_element_num_faces (const t8_element_t *elem) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Compute the maximum number of faces of a given element and all of its
+   *  descendants.
+   * \param [in] elem The element.
+   * \return          The maximum number of faces of \a elem and its descendants.
+   */
+  virtual int
+  t8_element_max_num_faces (const t8_element_t *elem) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Return the number of children of an element's face when the element is refined.
+   * \param [in] elem   The element whose face is considered.
+   * \param [in] face   A face of \a elem.
+   * \return            The number of children of \a face if \a elem is to be refined.
+   */
+  virtual int
+  t8_element_num_face_children (const t8_element_t *elem, int face) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Return the corner number of an element's face corner.
+   * Example quad: 2 x --- x 3
+   *                 |     |
+   *                 |     |   face 1
+   *               0 x --- x 1
+   *      Thus for face = 1 the output is: corner=0 : 1, corner=1: 3
+   *
+   * \param [in] element  The element.
+   * \param [in] face     A face index for \a element.
+   * \param [in] corner   A corner index for the face 0 <= \a corner < num_face_corners.
+   * \return              The corner number of the \a corner-th vertex of \a face.
+   *
+   * The order in which the corners must be given is determined by the eclass of \a element:
+   * LINE/QUAD/TRIANGLE:  No specific order.
+   * HEX               :  In Z-order of the face starting with the lowest corner number.
+   * TET               :  Starting with the lowest corner number counterclockwise as seen from
+   *                      'outside' of the element.
+   */
+  /* TODO: Prism order, Pyramid order. */
+  virtual int
+  t8_element_get_face_corner (const t8_element_t *element, int face, int corner) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Return the face numbers of the faces sharing an element's corner.
+   * Example quad: 2 x --- x 3
+   *                 |     |
+   *                 |     |   face 1
+   *               0 x --- x 1
+   *                  face 2
+   *      Thus for corner = 1 the output is: face=0 : 2, face=1: 1
+   * \param [in] element  The element.
+   * \param [in] corner   A corner index for the face.
+   * \param [in] face     A face index for \a corner.
+   * \return              The face number of the \a face-th face at \a corner.
+   */
+  virtual int
+  t8_element_get_corner_face (const t8_element_t *element, int corner, int face) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Compute the shape of the face of an element.
+   * \param [in] elem     The element.
+   * \param [in] face     A face of \a elem.
+   * \return              The element shape of the face.
+   * I.e. T8_ECLASS_LINE for quads, T8_ECLASS_TRIANGLE for tets
+   *      and depending on the face number either T8_ECLASS_QUAD or
+   *      T8_ECLASS_TRIANGLE for prisms.
+   */
+  virtual t8_element_shape_t
+  t8_element_face_shape (const t8_element_t *elem, int face) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Given an element and a face of the element, compute all children of
+   * the element that touch the face.
+   * \param [in] elem     The element.
+   * \param [in] face     A face of \a elem.
+   * \param [in,out] children Allocated elements, in which the children of \a elem
+   *                      that share a face with \a face are stored.
+   *                      They will be stored in order of their linear id.
+   * \param [in] num_children The number of elements in \a children. Must match
+   *                      the number of children that touch \a face.
+   *                      \ref t8_element_num_face_children
+   * \param [in,out] child_indices If not NULL, an array of num_children integers must be given,
+   *                      on output its i-th entry is the child_id of the i-th face_child.
+   * It is valid to call this function with elem = children[0].
+   */
+  virtual void
+  t8_element_children_at_face (const t8_element_t *elem, int face, t8_element_t *children[], int num_children,
+                               int *child_indices) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Given a face of an element and a child number of a child of that face, return the face number
+   * of the child of the element that matches the child face.
+   * \verbatim
+      x ---- x   x      x           x ---- x
+      |      |   |      |           |   |  | <-- f
+      |      |   |      x           |   x--x
+      |      |   |                  |      |
+      x ---- x   x                  x ---- x
+       elem    face  face_child    Returns the face number f
+     \endverbatim
+
+   * \param [in]  elem    The element.
+   * \param [in]  face    Then number of the face.
+   * \param [in]  face_child A number 0 <= \a face_child < num_face_children,
+   *                      specifying a child of \a elem that shares a face with \a face.
+   *                      These children are counted in linear order. This coincides with
+   *                      the order of children from a call to \ref t8_element_children_at_face.
+   * \return              The face number of the face of a child of \a elem
+   *                      that coincides with \a face_child.
+   */
+  virtual int
+  t8_element_face_child_face (const t8_element_t *elem, int face, int face_child) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Given a face of an element return the face number
+     * of the parent of the element that matches the element's face. Or return -1 if
+     * no face of the parent matches the face.
+
+     * \param [in]  elem    The element.
+     * \param [in]  face    Then number of the face.
+     * \return              If \a face of \a elem is also a face of \a elem's parent,
+     *                      the face number of this face. Otherwise -1.
+     * \note For the root element this function always returns \a face.
+     */
+  virtual int
+  t8_element_face_parent_face (const t8_element_t *elem, int face) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Given an element and a face of this element. If the face lies on the
+   *  tree boundary, return the face number of the tree face.
+   *  If not the return value is arbitrary.
+   *  You can call \ref t8_element_is_root_boundary to query whether the face is
+   *  at the tree boundary.
+   * \param [in] elem     The element.
+   * \param [in] face     The index of a face of \a elem.
+   * \return The index of the tree face that \a face is a subface of, if
+   *         \a face is on a tree boundary.
+   *         Any arbitrary integer if \a is not at a tree boundary.
+   * \warning The return value may look like a valid face of the tree even if 
+   *   the element does not lie on the root boundary.
+   */
+  virtual int
+  t8_element_tree_face (const t8_element_t *elem, int face) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Suppose we have two trees that share a common face f.
+   *  Given an element e that is a subface of f in one of the trees
+   *  and given the orientation of the tree connection, construct the face
+   *  element of the respective tree neighbor that logically coincides with e
+   *  but lies in the coordinate system of the neighbor tree.
+   *  \param [in] elem1     The face element.
+   *  \param [in,out] elem2 On return the face element  \a elem1 with respect
+   *                        to the coordinate system of the other tree.
+   *  \param [in] orientation The orientation of the tree-tree connection.
+   *                        \see t8_cmesh_set_join
+   *  \param [in] sign      Depending on the topological orientation of the two tree faces,
+   *                        either 0 (both faces have opposite orientation)
+   *                        or 1 (both faces have the same top. orientattion).
+   *                        \ref t8_eclass_face_orientation
+   *  \param [in] is_smaller_face Flag to declare whether \a elem1 belongs to
+   *                        the smaller face. A face f of tree T is smaller than
+   *                        f' of T' if either the eclass of T is smaller or if
+   *                        the classes are equal and f<f'. The orientation is
+   *                        defined in relation to the smaller face.
+   * \note \a elem1 and \a elem2 may point to the same element.
+   */
+  virtual void
+  t8_element_transform_face (const t8_element_t *elem1, t8_element_t *elem2, int orientation, int sign,
+                             int is_smaller_face) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Given a boundary face inside a root tree's face construct
+   *  the element inside the root tree that has the given face as a
+   *  face.
+   * \param [in] face     A face element.
+   * \param [in] face_scheme The scheme for the face element.
+   * \param [in,out] elem An allocated element. The entries will be filled with
+   *                      the data of the element that has \a face as a face and
+   *                      lies within the root tree.
+   * \param [in] root_face The index of the face of the root tree in which \a face
+   *                      lies.
+   * \return              The face number of the face of \a elem that coincides
+   *                      with \a face.
+   */
+  virtual int
+  t8_element_extrude_face (const t8_element_t *face, const t8_eclass_scheme_c *face_scheme, t8_element_t *elem,
+                           int root_face) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Construct the boundary element at a specific face.
+   * \param [in] elem     The input element.
+   * \param [in] face     The index of the face of which to construct the
+   *                      boundary element.
+   * \param [in,out] boundary An allocated element of dimension of \a element
+   *                      minus 1. The entries will be filled with the entries
+   *                      of the face of \a element.
+   * \param [in] boundary_scheme The scheme for the eclass of the boundary face.
+   * If \a elem is of class T8_ECLASS_VERTEX, then \a boundary must be NULL
+   * and will not be modified.
+   */
+  virtual void
+  t8_element_boundary_face (const t8_element_t *elem, int face, t8_element_t *boundary,
+                            const t8_eclass_scheme_c *boundary_scheme) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Construct the first descendant of an element at a given level that touches a given face.
+   * \param [in] elem      The input element.
+   * \param [in] face      A face of \a elem.
+   * \param [in, out] first_desc An allocated element. This element's data will be
+   *                       filled with the data of the first descendant of \a elem
+   *                       that shares a face with \a face.
+   * \param [in] level     The level, at which the first descendant is constructed
+   */
+  virtual void
+  t8_element_first_descendant_face (const t8_element_t *elem, int face, t8_element_t *first_desc, int level) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Construct the last descendant of an element at a given level that touches a given face.
+   * \param [in] elem      The input element.
+   * \param [in] face      A face of \a elem.
+   * \param [in, out] last_desc An allocated element. This element's data will be
+   *                       filled with the data of the last descendant of \a elem
+   *                       that shares a face with \a face.
+   * \param [in] level     The level, at which the last descendant is constructed
+   */
+  virtual void
+  t8_element_last_descendant_face (const t8_element_t *elem, int face, t8_element_t *last_desc, int level) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Compute whether a given element shares a given face with its root tree.
+   * \param [in] elem     The input element.
+   * \param [in] face     A face of \a elem.
+   * \return              True if \a face is a subface of the element's root element.
+   * \note You can compute the corresponding face number of the tree via \ref t8_element_tree_face.
+   */
+  virtual int
+  t8_element_is_root_boundary (const t8_element_t *elem, int face) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+
+  /** Construct the face neighbor of a given element if this face neighbor
+   * is inside the root tree. Return 0 otherwise.
+   * \param [in] elem The element to be considered.
+   * \param [in,out] neigh If the face neighbor of \a elem along \a face is inside
+   *                  the root tree, this element's data is filled with the
+   *                  data of the face neighbor. Otherwise the data can be modified
+   *                  arbitrarily.
+   * \param [in] face The number of the face along which the neighbor should be
+   *                  constructed.
+   * \param [out] neigh_face The number of \a face as viewed from \a neigh.
+   *                  An arbitrary value, if the neighbor is not inside the root tree.
+   * \return          True if \a neigh is inside the root tree.
+   *                  False if not. In this case \a neigh's data can be arbitrary
+   *                  on output.
+   */
+  virtual int
+  t8_element_face_neighbor_inside (const t8_element_t *elem, t8_element_t *neigh, int face, int *neigh_face) const
+  {
+    SC_ABORT ("not yet implemented");
+  }
+};
+
+#endif /* T8_SCHEME_FACE_NOT_IMPLEMENTED_CXX */


### PR DESCRIPTION
**_Describe your changes here:_**
In order to more easily create new schemes without face connectivity, this PR introduces a baseclass that implements all face related functions with `SC_ABORT`. Therefore, when implementing a new scheme, one can start with deriving from this class and only implementing element related functions.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
