### PR TITLE
fix orientation

### DIFF
--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -1420,7 +1420,7 @@ t8_cmesh_new_hypercube_pad (const t8_eclass_t eclass, sc_MPI_Comm comm, const do
         if (eclass == T8_ECLASS_HEX) {
           const t8_locidx_t tree_id_0 = poly_id_0;
           const t8_locidx_t tree_id_1 = poly_id_0 + polygons_y * polygons_x;
-          t8_cmesh_set_join (cmesh, tree_id_0, tree_id_1, 5, 4, 4);
+          t8_cmesh_set_join (cmesh, tree_id_0, tree_id_1, 5, 4, 0);
         }
         else if (eclass == T8_ECLASS_TET) {
           t8_locidx_t tree_id_0 = poly_id_0 * 6 + 5;


### PR DESCRIPTION
Discovered a bug in the hypercube_pad example, where the orientation between two quad-faces was set to 4 (which is impossible if, a quad has 4 corners, we start with corner 0). This PR fixes it. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
