### PR TITLE
Feature t8 element root

### DIFF
--- a/src/t8_element_c_interface.cxx
+++ b/src/t8_element_c_interface.cxx
@@ -448,3 +448,11 @@ t8_element_destroy (const t8_eclass_scheme_c *ts, int length, t8_element_t **ele
 
   ts->t8_element_destroy (length, elems);
 }
+
+void
+t8_element_root (const t8_eclass_scheme_c *ts, t8_element_t *elem)
+{
+  T8_ASSERT (ts != NULL);
+
+  ts->t8_element_root (elem);
+}

--- a/src/t8_element_c_interface.h
+++ b/src/t8_element_c_interface.h
@@ -684,6 +684,13 @@ t8_element_new (const t8_eclass_scheme_c *ts, int length, t8_element_t **elems);
 void
 t8_element_destroy (const t8_eclass_scheme_c *ts, int length, t8_element_t **elems);
 
+/** Fills an element with the root element.
+ * \param [in] ts         Implementation of a class scheme.
+ * \param [in,out] elem   The element to be filled with root.
+ */
+void
+t8_element_root (const t8_eclass_scheme_c *ts, t8_element_t *elem);
+
 T8_EXTERN_C_END ();
 
 #endif /* !T8_ELEMENT_C_INTERFACE_H */

--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -768,6 +768,13 @@ struct t8_eclass_scheme
   virtual void
   t8_element_destroy (int length, t8_element_t **elem) const
     = 0;
+
+  /** create the root element
+   * \param [in,out] elem The element that is filled with the root
+   */
+  virtual void
+  t8_element_root (t8_element_t *elem) const
+    = 0;
 };
 
 /** Destroy an implementation of a particular element class. 

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -241,7 +241,7 @@ t8_forest_min_nonempty_level (t8_cmesh_t cmesh, t8_scheme_cxx_t *scheme)
       ts = scheme->eclass_schemes[eclass];
       /* Compute the number of children of the root tree. */
       ts->t8_element_new (1, &element);
-      ts->t8_element_set_linear_id (element, 0, 0);
+      ts->t8_element_root (element);
       min_num_children = SC_MIN (min_num_children, ts->t8_element_num_children (element));
       ts->t8_element_destroy (1, &element);
       /* Compute the minimum possible maximum refinement level */
@@ -1333,7 +1333,7 @@ t8_forest_tree_shared (t8_forest_t forest, int first_or_last)
     /* we do this by first creating a level 0 child of the tree, then
      * calculating its first/last descendant */
     ts->t8_element_new (1, &element);
-    ts->t8_element_set_linear_id (element, 0, 0);
+    ts->t8_element_root (element);
     ts->t8_element_new (1, &desc);
     if (first_or_last == 0) {
       ts->t8_element_first_descendant (element, desc, forest->maxlevel);

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -661,5 +661,15 @@ t8_default_scheme_hex_c::~t8_default_scheme_hex_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
+void
+t8_default_scheme_hex_c::t8_element_root (t8_element_t *elem) const
+{
+  p8est_quadrant_t *hex = (p8est_quadrant_t *) elem;
+  hex->level = 0;
+  hex->x = 0;
+  hex->y = 0;
+  T8_QUAD_SET_TDIM (hex, 3);
+  T8_ASSERT (p8est_quadrant_is_extended (hex));
+}
 
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -665,10 +665,7 @@ void
 t8_default_scheme_hex_c::t8_element_root (t8_element_t *elem) const
 {
   p8est_quadrant_t *hex = (p8est_quadrant_t *) elem;
-  hex->level = 0;
-  hex->x = 0;
-  hex->y = 0;
-  T8_QUAD_SET_TDIM (hex, 3);
+  p8est_quadrant_set_morton (hex, 0, 0);
   T8_ASSERT (p8est_quadrant_is_extended (hex));
 }
 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -594,14 +594,7 @@ struct t8_default_scheme_hex_c: public t8_default_scheme_common_c
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
   void
-  t8_element_root (t8_element_t *elem) const
-  {
-    t8_dhex_t *hex = (t8_dhex_t *) elem;
-    hex->level = 0;
-    hex->x = 0;
-    hex->y = 0;
-    hex->z = 0;
-  }
+  t8_element_root (t8_element_t *elem) const;
 };
 
 #endif /* !T8_DEFAULT_HEX_HXX */

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -593,6 +593,10 @@ struct t8_default_scheme_hex_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+
+  /** Fills an element with the root element.
+ * \param [in,out] elem   The element to be filled with root.
+ */
   void
   t8_element_root (t8_element_t *elem) const;
 };

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -593,6 +593,15 @@ struct t8_default_scheme_hex_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+  void
+  t8_element_root (t8_element_t *elem) const
+  {
+    t8_dhex_t *hex = (t8_dhex_t *) elem;
+    hex->level = 0;
+    hex->x = 0;
+    hex->y = 0;
+    hex->z = 0;
+  }
 };
 
 #endif /* !T8_DEFAULT_HEX_HXX */

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
@@ -457,4 +457,11 @@ t8_default_scheme_line_c::~t8_default_scheme_line_c ()
    * and hence this empty function. */
 }
 
+void
+t8_default_scheme_line_c::t8_element_root (t8_element_t *elem) const
+{
+  t8_dline_t *line = (t8_dline_t *) elem;
+  line->level = 0;
+  line->x = 0;
+}
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
@@ -604,6 +604,8 @@ struct t8_default_scheme_line_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+  void
+  t8_element_root (t8_element_t *elem) const;
 };
 
 #endif /* !T8_DEFAULT_LINE_CXX_HXX */

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
@@ -604,6 +604,9 @@ struct t8_default_scheme_line_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+  /** Fills an element with the root element.
+ * \param [in,out] elem   The element to be filled with root.
+ */
   void
   t8_element_root (t8_element_t *elem) const;
 };

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -483,7 +483,7 @@ t8_default_scheme_prism_c::t8_element_root (t8_element_t *elem) const
   prism->line.level = 0;
   prism->line.x = 0;
   prism->tri.x = 0;
-  prism->tri.x = 0;
+  prism->tri.y = 0;
   prism->tri.type = 0;
   prism->tri.level = 0;
 }

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -485,6 +485,7 @@ t8_default_scheme_prism_c::t8_element_root (t8_element_t *elem) const
   prism->tri.x = 0;
   prism->tri.x = 0;
   prism->tri.type = 0;
+  prism->tri.level = 0;
 }
 
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -476,5 +476,15 @@ t8_default_scheme_prism_c::~t8_default_scheme_prism_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
+void
+t8_default_scheme_prism_c::t8_element_root (t8_element_t *elem) const
+{
+  t8_dprism_t *prism = (t8_dprism_t *) elem;
+  prism->line.level = 0;
+  prism->line.x = 0;
+  prism->tri.x = 0;
+  prism->tri.x = 0;
+  prism->tri.type = 0;
+}
 
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
@@ -583,6 +583,9 @@ struct t8_default_scheme_prism_c: public t8_default_scheme_common_c
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
 
+  /** Fills an element with the root element.
+ * \param [in,out] elem   The element to be filled with root.
+ */
   void
   t8_element_root (t8_element_t *elem) const;
 };

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
@@ -582,6 +582,9 @@ struct t8_default_scheme_prism_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+
+  void
+  t8_element_root (t8_element_t *elem) const;
 };
 
 #endif /* !T8_DEFAULT_PRISM_CXX_HXX */

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -452,6 +452,6 @@ t8_default_scheme_pyramid_c::t8_element_root (t8_element_t *elem) const
   pyramid->pyramid.y = 0;
   pyramid->pyramid.z = 0;
   pyramid->pyramid.type = T8_DPYRAMID_ROOT_TYPE;
-  pyramid->switch_shape_at_level = 0;
+  pyramid->switch_shape_at_level = -1;
 }
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -443,5 +443,15 @@ t8_default_scheme_pyramid_c::~t8_default_scheme_pyramid_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
-
+void
+t8_default_scheme_pyramid_c::t8_element_root (t8_element_t *elem) const
+{
+  t8_dpyramid_t *pyramid = (t8_dpyramid_t *) elem;
+  pyramid->pyramid.level = 0;
+  pyramid->pyramid.x = 0;
+  pyramid->pyramid.y = 0;
+  pyramid->pyramid.z = 0;
+  pyramid->pyramid.type = T8_DPYRAMID_ROOT_TYPE;
+  pyramid->switch_shape_at_level = 0;
+}
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
@@ -574,6 +574,8 @@ struct t8_default_scheme_pyramid_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+  void
+  t8_element_root (t8_element_t *elem) const;
 };
 
 #endif /* !T8_DEFAULT_pyramid_CXX_HXX */

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
@@ -574,6 +574,10 @@ struct t8_default_scheme_pyramid_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+
+  /** Fills an element with the root element.
+ * \param [in,out] elem   The element to be filled with root.
+ */
   void
   t8_element_root (t8_element_t *elem) const;
 };

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -792,5 +792,12 @@ t8_default_scheme_quad_c::~t8_default_scheme_quad_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
-
+void
+t8_default_scheme_quad_c::t8_element_root (t8_element_t *elem) const
+{
+  t8_dquad_t *quad = (t8_dquad_t *) elem;
+  quad->level = 0;
+  quad->x = 0;
+  quad->y = 0;
+}
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -796,10 +796,7 @@ void
 t8_default_scheme_quad_c::t8_element_root (t8_element_t *elem) const
 {
   t8_pquad_t *quad = (t8_pquad_t *) elem;
-  quad->level = 0;
-  quad->x = 0;
-  quad->y = 0;
-  T8_QUAD_SET_TDIM (quad, 2);
+  p4est_quadrant_set_morton (quad, 0, 0);
   T8_ASSERT (p4est_quadrant_is_extended (quad));
 }
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -795,9 +795,11 @@ t8_default_scheme_quad_c::~t8_default_scheme_quad_c ()
 void
 t8_default_scheme_quad_c::t8_element_root (t8_element_t *elem) const
 {
-  t8_dquad_t *quad = (t8_dquad_t *) elem;
+  t8_pquad_t *quad = (t8_pquad_t *) elem;
   quad->level = 0;
   quad->x = 0;
   quad->y = 0;
+  T8_QUAD_SET_TDIM (quad, 2);
+  T8_ASSERT (p4est_quadrant_is_extended (quad));
 }
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -624,6 +624,8 @@ struct t8_default_scheme_quad_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+  void
+  t8_element_root (t8_element_t *elem) const;
 };
 
 #endif /* !T8_DEFAULT_QUAD_CXX_HXX */

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -624,6 +624,10 @@ struct t8_default_scheme_quad_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+
+  /** Fills an element with the root element.
+ * \param [in,out] elem   The element to be filled with root.
+ */
   void
   t8_element_root (t8_element_t *elem) const;
 };

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
@@ -564,5 +564,14 @@ t8_default_scheme_tet_c::~t8_default_scheme_tet_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
-
+void
+t8_default_scheme_tet_c::t8_element_root (t8_element_t *elem) const
+{
+  t8_dtet_t *tet = (t8_dtet_t *) elem;
+  tet->level = 0;
+  tet->x = 0;
+  tet->y = 0;
+  tet->z = 0;
+  tet->type = 0;
+}
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
@@ -545,6 +545,8 @@ struct t8_default_scheme_tet_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+  void
+  t8_element_root (t8_element_t *elem) const;
 };
 
 #endif /* !T8_DEFAULT_TET_H */

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
@@ -545,6 +545,10 @@ struct t8_default_scheme_tet_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+
+  /** Fills an element with the root element.
+ * \param [in,out] elem   The element to be filled with root.
+ */
   void
   t8_element_root (t8_element_t *elem) const;
 };

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
@@ -573,5 +573,13 @@ t8_default_scheme_tri_c::~t8_default_scheme_tri_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
-
+void
+t8_default_scheme_tri_c::t8_element_root (t8_element_t *elem) const
+{
+  t8_dtri_t *tri = (t8_dtri_t *) elem;
+  tri->level = 0;
+  tri->x = 0;
+  tri->y = 0;
+  tri->type = 0;
+}
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
@@ -539,6 +539,10 @@ struct t8_default_scheme_tri_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+
+  /** Fills an element with the root element.
+ * \param [in,out] elem   The element to be filled with root.
+ */
   void
   t8_element_root (t8_element_t *elem) const;
 };

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
@@ -539,6 +539,8 @@ struct t8_default_scheme_tri_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+  void
+  t8_element_root (t8_element_t *elem) const;
 };
 
 #endif /* !T8_DEFAULT_TET_H */

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
@@ -354,5 +354,10 @@ t8_default_scheme_vertex_c::~t8_default_scheme_vertex_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
-
+void
+t8_default_scheme_vertex_c::t8_element_root (t8_element_t *elem) const
+{
+  t8_dvertex_t *vertex = (t8_dvertex_t *) elem;
+  vertex->level = 0;
+}
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
@@ -630,6 +630,10 @@ struct t8_default_scheme_vertex_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+
+  /** Fills an element with the root element.
+ * \param [in,out] elem   The element to be filled with root.
+ */
   void
   t8_element_root (t8_element_t *elem) const;
 };

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
@@ -630,6 +630,8 @@ struct t8_default_scheme_vertex_c: public t8_default_scheme_common_c
   virtual void
   t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
 #endif
+  void
+  t8_element_root (t8_element_t *elem) const;
 };
 
 #endif /* !T8_DEFAULT_VERTEX_H */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -34,6 +34,7 @@ t8code_googletest_programs = \
   test/t8_schemes/t8_gtest_descendant \
   test/t8_schemes/t8_gtest_find_parent \
   test/t8_schemes/t8_gtest_equal \
+  test/t8_schemes/t8_gtest_root \
   test/t8_cmesh/t8_gtest_cmesh_face_is_boundary \
   test/t8_cmesh/t8_gtest_cmesh_partition \
   test/t8_cmesh/t8_gtest_cmesh_copy \
@@ -163,6 +164,10 @@ test_t8_schemes_t8_gtest_find_parent_SOURCES = \
 test_t8_schemes_t8_gtest_equal_SOURCES = \
   test/t8_gtest_main.cxx \
   test/t8_schemes/t8_gtest_equal.cxx
+
+test_t8_schemes_t8_gtest_root_SOURCES = \
+  test/t8_gtest_main.cxx \
+  test/t8_schemes/t8_gtest_root.cxx
 
 test_t8_cmesh_t8_gtest_cmesh_face_is_boundary_SOURCES = \
   test/t8_gtest_main.cxx \
@@ -400,6 +405,10 @@ test_t8_schemes_t8_gtest_equal_LDADD = $(t8_gtest_target_ld_add)
 test_t8_schemes_t8_gtest_equal_LDFLAGS = $(t8_gtest_target_ld_flags)
 test_t8_schemes_t8_gtest_equal_CPPFLAGS = $(t8_gtest_target_cpp_flags)
 
+test_t8_schemes_t8_gtest_root_LDADD = $(t8_gtest_target_ld_add)
+test_t8_schemes_t8_gtest_root_LDFLAGS = $(t8_gtest_target_ld_flags)
+test_t8_schemes_t8_gtest_root_CPPFLAGS = $(t8_gtest_target_cpp_flags)
+
 test_t8_cmesh_t8_gtest_cmesh_face_is_boundary_LDADD = $(t8_gtest_target_ld_add)
 test_t8_cmesh_t8_gtest_cmesh_face_is_boundary_LDFLAGS = $(t8_gtest_target_ld_flags)
 test_t8_cmesh_t8_gtest_cmesh_face_is_boundary_CPPFLAGS = $(t8_gtest_target_cpp_flags)
@@ -569,6 +578,7 @@ test_t8_geometry_t8_gtest_geometry_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_schemes_t8_gtest_descendant_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_schemes_t8_gtest_find_parent_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_schemes_t8_gtest_equal_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
+test_t8_schemes_t8_gtest_root_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_cmesh_t8_gtest_cmesh_face_is_boundary_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_cmesh_t8_gtest_cmesh_partition_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_cmesh_t8_gtest_cmesh_set_partition_offsets_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)

--- a/test/t8_forest/t8_gtest_find_owner.cxx
+++ b/test/t8_forest/t8_gtest_find_owner.cxx
@@ -86,7 +86,7 @@ TEST_P (forest_find_owner, find_owner)
   t8_eclass_scheme_c  ts = scheme->eclass_schemes[eclass];
   ts->t8_element_new (1, &element);
   /* Compute the number of elements per tree */
-  ts->t8_element_set_linear_id (element, 0, 0);
+  ts->t8_element_root (element);
   /* TODO: This computation fails with pyramids */
   t8_gloidx_t         elements_per_tree =
     pow (ts->t8_element_num_children (element), level);

--- a/test/t8_schemes/t8_gtest_descendant.cxx
+++ b/test/t8_schemes/t8_gtest_descendant.cxx
@@ -41,7 +41,7 @@ class class_schemes_descendant: public testing::TestWithParam<t8_eclass_t> {
     ts->t8_element_new (1, &elem);
     ts->t8_element_new (1, &desc);
     ts->t8_element_new (1, &test);
-    ts->t8_element_set_linear_id (elem, 0, 0);
+    ts->t8_element_root (elem);
   }
   void
   TearDown () override

--- a/test/t8_schemes/t8_gtest_dfs_base.hxx
+++ b/test/t8_schemes/t8_gtest_dfs_base.hxx
@@ -63,7 +63,7 @@ class TestDFS: public testing::TestWithParam<t8_eclass_t> {
     eclass = GetParam ();
     ts = scheme->eclass_schemes[eclass];
     ts->t8_element_new (1, &element);
-    ts->t8_element_set_linear_id (element, 0, 0);
+    ts->t8_element_root (element);
   }
   void
   dfs_test_teardown ()

--- a/test/t8_schemes/t8_gtest_face_neigh.cxx
+++ b/test/t8_schemes/t8_gtest_face_neigh.cxx
@@ -42,7 +42,7 @@ class face_neigh: public testing::TestWithParam<t8_eclass_t> {
     ts->t8_element_new (1, &element);
     ts->t8_element_new (1, &child);
     ts->t8_element_new (1, &neigh);
-    ts->t8_element_set_linear_id (element, 0, 0);
+    ts->t8_element_root (element);
   }
 
   void

--- a/test/t8_schemes/t8_gtest_init_linear_id.cxx
+++ b/test/t8_schemes/t8_gtest_init_linear_id.cxx
@@ -39,7 +39,7 @@ class linear_id: public testing::TestWithParam<t8_eclass> {
     ts->t8_element_new (1, &element);
     ts->t8_element_new (1, &child);
     ts->t8_element_new (1, &test);
-    ts->t8_element_set_linear_id (element, 0, 0);
+    ts->t8_element_root (element);
   }
   void
   TearDown () override

--- a/test/t8_schemes/t8_gtest_root.cxx
+++ b/test/t8_schemes/t8_gtest_root.cxx
@@ -58,4 +58,12 @@ TEST_P (root, has_level_zero)
   EXPECT_EQ (ts->t8_element_level (element), 0);
 }
 
+TEST_P (root, has_level_zero)
+{
+  t8_element_t *root_compare;
+  ts->t8_element_new (1, &root_compare);
+  ts->t8_element_set_linear_id (root_compare, 0, 0);
+  EXPECT_ELEM_EQ (ts, element, root_compare);
+}
+
 INSTANTIATE_TEST_SUITE_P (t8_gtest_root, root, testing::Values (T8_ECLASS_PYRAMID));

--- a/test/t8_schemes/t8_gtest_root.cxx
+++ b/test/t8_schemes/t8_gtest_root.cxx
@@ -58,12 +58,13 @@ TEST_P (root, has_level_zero)
   EXPECT_EQ (ts->t8_element_level (element), 0);
 }
 
-TEST_P (root, has_level_zero)
+TEST_P (root, equals_linear_id_0_0)
 {
   t8_element_t *root_compare;
   ts->t8_element_new (1, &root_compare);
   ts->t8_element_set_linear_id (root_compare, 0, 0);
   EXPECT_ELEM_EQ (ts, element, root_compare);
+  ts->t8_element_destroy (1, &root_compare);
 }
 
 INSTANTIATE_TEST_SUITE_P (t8_gtest_root, root, testing::Values (T8_ECLASS_PYRAMID));

--- a/test/t8_schemes/t8_gtest_root.cxx
+++ b/test/t8_schemes/t8_gtest_root.cxx
@@ -3,7 +3,7 @@ This file is part of t8code.
 t8code is a C library to manage a collection (a forest) of multiple
 connected adaptive space-trees of general element classes in parallel.
 
-Copyright (C) 2015 the developers
+Copyright (C) 2024 the developers
 
 t8code is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/test/t8_schemes/t8_gtest_root.cxx
+++ b/test/t8_schemes/t8_gtest_root.cxx
@@ -1,0 +1,61 @@
+/*
+This file is part of t8code.
+t8code is a C library to manage a collection (a forest) of multiple
+connected adaptive space-trees of general element classes in parallel.
+
+Copyright (C) 2015 the developers
+
+t8code is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+t8code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with t8code; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_gtest_root.cxx
+*/
+
+#include <gtest/gtest.h>
+#include <test/t8_gtest_custom_assertion.hxx>
+#include <t8_eclass.h>
+#include <t8_schemes/t8_default/t8_default_cxx.hxx>
+
+class root: public testing::TestWithParam<t8_eclass> {
+ protected:
+  void
+  SetUp () override
+  {
+    eclass = GetParam ();
+    scheme = t8_scheme_new_default_cxx ();
+    ts = scheme->eclass_schemes[eclass];
+    ts->t8_element_new (1, &element);
+    ts->t8_element_root (element);
+  }
+  void
+  TearDown () override
+  {
+    ts->t8_element_destroy (1, &element);
+    t8_scheme_cxx_unref (&scheme);
+  }
+  t8_element_t *element;
+  t8_scheme_cxx *scheme;
+  t8_eclass_scheme_c *ts;
+  t8_eclass_t eclass;
+};
+
+/*Test root*/
+
+TEST_P (root, has_level_zero)
+{
+  EXPECT_EQ (ts->t8_element_level (element), 0);
+}
+
+INSTANTIATE_TEST_SUITE_P (t8_gtest_root, root, testing::Values (T8_ECLASS_PYRAMID));

--- a/test/t8_schemes/t8_gtest_successor.cxx
+++ b/test/t8_schemes/t8_gtest_successor.cxx
@@ -41,7 +41,7 @@ class class_successor: public testing::TestWithParam<t8_eclass_t> {
     ts->t8_element_new (1, &child);
     ts->t8_element_new (1, &last);
 
-    ts->t8_element_set_linear_id (element, 0, 0);
+    ts->t8_element_root (element);
   }
   void
   TearDown () override


### PR DESCRIPTION
**_Describe your changes here:_**
Introduce an element function that fills an element with the root element. 
Also replaces all occurences of `t8_element_set_linear_id (elem, 0, 0)` by `t8_element_root`.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
