### PR TITLE
Split t8_cmesh_is_committed into two funtions

### DIFF
--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -81,7 +81,6 @@ int
 t8_cmesh_is_initialized (t8_cmesh_t cmesh);
 
 /** Check whether a cmesh is not NULL, initialized and committed.
- * In addition, it asserts that the cmesh is consistent as much as possible.
  * \param [in] cmesh            This cmesh is examined.  May be NULL.
  * \return                      True if cmesh is not NULL and
  *                              \ref t8_cmesh_init has been called on it
@@ -90,6 +89,13 @@ t8_cmesh_is_initialized (t8_cmesh_t cmesh);
  */
 int
 t8_cmesh_is_committed (const t8_cmesh_t cmesh);
+
+/** Test if a cmesh is valid as much as possible.
+ * \param [in] cmesh            The cmesh to be validated.
+ * \return                      True if th cmesh is valid.
+ */
+int
+t8_cmesh_validate (const t8_cmesh_t cmesh);
 
 #ifdef T8_ENABLE_DEBUG
 /** After a cmesh is committed, check whether all trees in a cmesh do have positive volume.

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -87,6 +87,13 @@ t8_cmesh_check_trees_per_eclass (t8_cmesh_t cmesh)
 int
 t8_cmesh_is_committed (const t8_cmesh_t cmesh)
 {
+  return cmesh != NULL && t8_refcount_is_active (&cmesh->rc) && cmesh->committed;
+}
+
+int
+t8_cmesh_validate (const t8_cmesh_t cmesh)
+{
+  T8_ASSERT (t8_cmesh_is_committed (cmesh));
   static int is_checking = 0;
 
   /* We run into a stackoverflow if routines that we call here,

--- a/src/t8_cmesh/t8_cmesh_commit.c
+++ b/src/t8_cmesh/t8_cmesh_commit.c
@@ -611,7 +611,7 @@ t8_cmesh_commit (t8_cmesh_t cmesh, sc_MPI_Comm comm)
              " %li ghosts.\n",
              (long) cmesh->num_local_trees, (long long) cmesh->num_trees, (long) cmesh->num_ghosts);
 
-  T8_ASSERT (t8_cmesh_is_committed (cmesh));
+  T8_ASSERT (t8_cmesh_validate (cmesh));
   /* If profiling is enabled, we measure the runtime of  commit. */
   if (cmesh->profile != NULL) {
     cmesh->profile->commit_runtime = sc_MPI_Wtime () - cmesh->profile->commit_runtime;


### PR DESCRIPTION
**_Describe your changes here:_**
Splits the `t8_cmesh_is_commited` function into two.
The new `t8_cmesh_is_commited` now behaves exactly as its counterpart `t8_forest_is_commited`.
The additional validation checks are moved into the new function `t8_cmesh_validate`, which is called in a `t8_cmesh_commit`. Therefore, a cmesh has to be valid when committed and remains that way.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
