### PR TITLE
Disable tests instead of skipping them

### DIFF
--- a/scripts/find_disabled_tests.scp
+++ b/scripts/find_disabled_tests.scp
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+
+#This file is part of t8code.
+#t8code is a C library to manage a collection (a forest) of multiple
+#connected adaptive space-trees of general element classes in parallel.
+
+#Copyright (C) 2024 the developers
+
+#t8code is free software; you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation; either version 2 of the License, or
+#(at your option) any later version.
+
+#t8code is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+
+#You should have received a copy of the GNU General Public License
+#along with t8code; if not, write to the Free Software Foundation, Inc.,
+#51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+
+find test -type f -name "*.log" -exec grep -E "YOU HAVE [0-9]+ DISABLED TEST" -m 1 -H {} \;

--- a/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
@@ -38,6 +38,7 @@
  * See: https://github.com/DLR-AMR/t8code/issues/920
  */
 
+/* Remove `DISABLED_` from the name of the Test(suite) or use `--gtest_also_run_disabled_tests` when you start working on the issue. */
 class DISABLED_t8_cmesh_copy: public testing::TestWithParam<cmesh_example_base *> {
  protected:
   void

--- a/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_copy.cxx
@@ -38,13 +38,13 @@
  * See: https://github.com/DLR-AMR/t8code/issues/920
  */
 
-class t8_cmesh_copy: public testing::TestWithParam<cmesh_example_base *> {
+class DISABLED_t8_cmesh_copy: public testing::TestWithParam<cmesh_example_base *> {
  protected:
   void
   SetUp () override
   {
     /* Skip test since cmesh copy is not yet working. See https://github.com/DLR-AMR/t8code/issues/920 */
-    GTEST_SKIP ();
+
     cmesh_original = GetParam ()->cmesh_create ();
 
     /* Initialized test cmesh that we derive in the test */
@@ -55,7 +55,7 @@ class t8_cmesh_copy: public testing::TestWithParam<cmesh_example_base *> {
   TearDown () override
   {
     /* Skip test since cmesh copy is not yet working. See https://github.com/DLR-AMR/t8code/issues/920 */
-    GTEST_SKIP ();
+
     /* Unref both cmeshes */
     t8_cmesh_unref (&cmesh);
   }
@@ -71,7 +71,7 @@ test_cmesh_committed (t8_cmesh_t cmesh)
   ASSERT_TRUE (t8_cmesh_trees_is_face_consistent (cmesh, cmesh->trees)) << "Cmesh face consistency failed.";
 }
 
-TEST_P (t8_cmesh_copy, test_cmesh_copy)
+TEST_P (DISABLED_t8_cmesh_copy, test_cmesh_copy)
 {
   t8_cmesh_set_derive (cmesh, cmesh_original);
   t8_cmesh_commit (cmesh, sc_MPI_COMM_WORLD);
@@ -82,4 +82,4 @@ TEST_P (t8_cmesh_copy, test_cmesh_copy)
 }
 
 /* Test all cmeshes over all different inputs*/
-INSTANTIATE_TEST_SUITE_P (t8_gtest_cmesh_copy, t8_cmesh_copy, AllCmeshsParam, pretty_print_base_example);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_cmesh_copy, DISABLED_t8_cmesh_copy, AllCmeshsParam, pretty_print_base_example);

--- a/test/t8_forest/t8_gtest_ghost_delete.cxx
+++ b/test/t8_forest/t8_gtest_ghost_delete.cxx
@@ -106,7 +106,6 @@ class DISABLED_forest_ghost_exchange_holes: public testing::Test {
 TEST_F (DISABLED_forest_ghost_exchange_holes, errorTest)
 {
   /* This test tests the functionality described in Issue: https://github.com/DLR-AMR/t8code/issues/825
-  * Remove the DISABLED_ macros when you start working on the issue or us --gtest_also_run_disabled_tests
   */
   if (comm != sc_MPI_COMM_NULL) {
     const int level = 1;

--- a/test/t8_forest/t8_gtest_ghost_delete.cxx
+++ b/test/t8_forest/t8_gtest_ghost_delete.cxx
@@ -54,7 +54,7 @@ test_adapt_holes (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which
   return 0;
 }
 
-class forest_ghost_exchange_holes: public testing::Test {
+class DISABLED_forest_ghost_exchange_holes: public testing::Test {
  protected:
   void
   SetUp () override
@@ -103,12 +103,11 @@ class forest_ghost_exchange_holes: public testing::Test {
   t8_cmesh_t cmesh;
 };
 
-TEST_F (forest_ghost_exchange_holes, errorTest)
+TEST_F (DISABLED_forest_ghost_exchange_holes, errorTest)
 {
   /* This test tests the functionality described in Issue: https://github.com/DLR-AMR/t8code/issues/825
-  * Remove the GTEST_SKIP() macros when you start working on the issue.
+  * Remove the DISABLED_ macros when you start working on the issue or us --gtest_also_run_disabled_tests
   */
-  GTEST_SKIP ();
   if (comm != sc_MPI_COMM_NULL) {
     const int level = 1;
     const int execute_ghost = 1;

--- a/test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
@@ -37,7 +37,10 @@
  * The two resulting forests must be equal.
  * */
 
-class global_tree: public testing::TestWithParam<std::tuple<t8_eclass, int>> {
+/* 
+ * Remove `DISABLED_` from the name of the Test(suite) or use `--gtest_also_run_disabled_tests` when you start working on the issue. 
+ */
+class DISABLED_global_tree: public testing::TestWithParam<std::tuple<t8_eclass, int>> {
  protected:
   void
   SetUp () override
@@ -46,8 +49,6 @@ class global_tree: public testing::TestWithParam<std::tuple<t8_eclass, int>> {
     testcase = std::get<1> (GetParam ());
     forest = t8_forest_new_uniform (t8_cmesh_new_bigmesh (eclass, 3, sc_MPI_COMM_WORLD), t8_scheme_new_default_cxx (),
                                     0, 0, sc_MPI_COMM_WORLD);
-    /* Remove if partitioning empty trees from processes with no elements works */
-    GTEST_SKIP ();
   }
   void
   TearDown () override
@@ -128,7 +129,7 @@ t8_adapt_forest (t8_forest_t forest_from, t8_forest_adapt_t adapt_fn, int do_ada
   return forest_new;
 }
 
-TEST_P (global_tree, test_empty_global_tree)
+TEST_P (DISABLED_global_tree, test_empty_global_tree)
 {
   ASSERT_TRUE (!forest->incomplete_trees);
 
@@ -168,5 +169,5 @@ TEST_P (global_tree, test_empty_global_tree)
   t8_forest_unref (&forest_adapt_b);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_empty_global_tree, global_tree,
+INSTANTIATE_TEST_SUITE_P (t8_gtest_empty_global_tree, DISABLED_global_tree,
                           testing::Combine (AllEclasses, testing::Range (0, 6)));

--- a/test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
@@ -37,9 +37,7 @@
  * The two resulting forests must be equal.
  * */
 
-/* 
- * Remove `DISABLED_` from the name of the Test(suite) or use `--gtest_also_run_disabled_tests` when you start working on the issue. 
- */
+/* Remove `DISABLED_` from the name of the Test(suite) or use `--gtest_also_run_disabled_tests` when you start working on the issue. */
 class DISABLED_global_tree: public testing::TestWithParam<std::tuple<t8_eclass, int>> {
  protected:
   void


### PR DESCRIPTION
Updated our testsuite to match the updated guideline for test-driven development. 
Also added a script that finds all disabled tests. 




**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
