### PR TITLE
Split cmesh commit and geometry checks

### DIFF
--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -92,6 +92,13 @@ int
 t8_cmesh_is_committed (const t8_cmesh_t cmesh);
 
 #ifdef T8_ENABLE_DEBUG
+/** Check the geometry of the mesh for validity.
+ * \param [in] cmesh            This cmesh is examined.
+ * \return                      True if the geometry of the cmesh is valid.
+ */
+bool
+t8_cmesh_validate_geometry (const t8_cmesh_t cmesh);
+
 /** After a cmesh is committed, check whether all trees in a cmesh do have positive volume.
  * Returns true if all trees have positive volume.
  * \param [in]  cmesh           This cmesh is examined. May be NULL.

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -107,8 +107,7 @@ t8_cmesh_is_committed (const t8_cmesh_t cmesh)
 
 #ifdef T8_ENABLE_DEBUG
     /* TODO: check more conditions that must always hold after commit */
-    if ((!t8_cmesh_trees_is_face_consistent (cmesh, cmesh->trees)) || (!t8_cmesh_no_negative_volume (cmesh))
-        || (!t8_cmesh_check_trees_per_eclass (cmesh))) {
+    if ((!t8_cmesh_trees_is_face_consistent (cmesh, cmesh->trees)) || (!t8_cmesh_check_trees_per_eclass (cmesh))) {
       is_checking = 0;
       return 0;
     }
@@ -121,6 +120,18 @@ t8_cmesh_is_committed (const t8_cmesh_t cmesh)
   }
   return 1;
 }
+
+#ifdef T8_ENABLE_DEBUG
+bool
+t8_cmesh_validate_geometry (const t8_cmesh_t cmesh)
+{
+  /* Geometry handler is not built yet */
+  if (cmesh->geometry_handler == NULL) {
+    return 1;
+  }
+  return t8_cmesh_no_negative_volume (cmesh);
+}
+#endif /* T8_ENABLE_DEBUG */
 
 /* Check whether a given communicator assigns the same rank and mpisize
  * as stored in a given cmesh. */

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -125,7 +125,7 @@ t8_cmesh_is_committed (const t8_cmesh_t cmesh)
 bool
 t8_cmesh_validate_geometry (const t8_cmesh_t cmesh)
 {
-  /* Geometry handler is not built yet */
+  /* Geometry handler is not constructed yet */
   if (cmesh->geometry_handler == NULL) {
     return 1;
   }

--- a/src/t8_cmesh/t8_cmesh_commit.c
+++ b/src/t8_cmesh/t8_cmesh_commit.c
@@ -612,6 +612,7 @@ t8_cmesh_commit (t8_cmesh_t cmesh, sc_MPI_Comm comm)
              (long) cmesh->num_local_trees, (long long) cmesh->num_trees, (long) cmesh->num_ghosts);
 
   T8_ASSERT (t8_cmesh_is_committed (cmesh));
+  T8_ASSERT (t8_cmesh_validate_geometry (cmesh));
   /* If profiling is enabled, we measure the runtime of  commit. */
   if (cmesh->profile != NULL) {
     cmesh->profile->commit_runtime = sc_MPI_Wtime () - cmesh->profile->commit_runtime;


### PR DESCRIPTION
**_Describe your changes here:_**
Separates the negative volume check from the cmesh is committed check as discussed.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
