### PR TITLE
Fix geometry example

### DIFF
--- a/example/geometry/t8_example_geometries.cxx
+++ b/example/geometry/t8_example_geometries.cxx
@@ -26,11 +26,11 @@
 #include <t8_forest/t8_forest_general.h>
 #include <t8_forest/t8_forest_io.h>
 #include <t8_geometry/t8_geometry_base.hxx>
-#include <t8_geometry/t8_geometry_implementations/t8_geometry_analytic.h>
 #include <t8_geometry/t8_geometry_implementations/t8_geometry_linear.hxx>
 #include <t8_geometry/t8_geometry_implementations/t8_geometry_cad.hxx>
 #include <t8_geometry/t8_geometry_implementations/t8_geometry_analytic.hxx>
 #include <t8_geometry/t8_geometry_helpers.h>
+#include <t8_cmesh.hxx>
 #include <t8_cmesh/t8_cmesh_examples.h>
 
 #if T8_WITH_OCC
@@ -127,6 +127,13 @@ struct t8_geometry_sincos: public t8_geometry
   t8_geom_load_tree_data (t8_cmesh_t cmesh, t8_gloidx_t gtreeid)
   {
     /* Do nothing */
+  }
+
+  /** Check if  the currently active tree has a negative volume. In this case return zero. */
+  bool
+  t8_geom_tree_negative_volume () const
+  {
+    return 0;
   }
 
   /**
@@ -253,6 +260,13 @@ struct t8_geometry_cylinder: public t8_geometry
   t8_geom_load_tree_data (t8_cmesh_t cmesh, t8_gloidx_t gtreeid)
   {
     /* Do nothing */
+  }
+
+  /** Check if  the currently active tree has a negative volume. In this case return zero. */
+  bool
+  t8_geom_tree_negative_volume () const
+  {
+    return 0;
   }
 
   /**
@@ -404,6 +418,13 @@ struct t8_geometry_moving: public t8_geometry
     /* Do nothing */
   }
 
+  /** Check if  the currently active tree has a negative volume. In this case return zero. */
+  bool
+  t8_geom_tree_negative_volume () const
+  {
+    return 0;
+  }
+
   /**
    * Get the type of this geometry.
    * \return The type.
@@ -462,6 +483,13 @@ struct t8_geometry_cube_zdistorted: public t8_geometry
   t8_geom_load_tree_data (t8_cmesh_t cmesh, t8_gloidx_t gtreeid)
   {
     /* Do nothing */
+  }
+
+  /** Check if  the currently active tree has a negative volume. In this case return zero. */
+  bool
+  t8_geom_tree_negative_volume () const
+  {
+    return 0;
   }
 
   /**
@@ -535,9 +563,6 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
   t8_forest_t forest;
   t8_cmesh_t cmesh;
   char vtuname[BUFSIZ];
-  t8_geometry_c *geometry;
-  /* geometry_sincos is used for T8_GEOM_TWO_GEOMETRIES */
-  t8_geometry_c *geometry_sincos;
   int uniform_level;
   double time = 0; /* used for moving geometry */
   int sreturn;
@@ -549,7 +574,7 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
   case T8_GEOM_SINCOS:
     t8_global_productionf ("Creating uniform level %i forest with a sinus/cosinus geometry.\n", level);
     /* Sin/cos geometry. Has two quad trees. */
-    geometry = new t8_geometry_sincos;
+    t8_cmesh_register_geometry<t8_geometry_sincos> (cmesh);
     t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_QUAD);
     t8_cmesh_set_tree_class (cmesh, 1, T8_ECLASS_QUAD);
     t8_cmesh_set_join (cmesh, 0, 1, 1, 0, 0);
@@ -558,7 +583,7 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
   case T8_GEOM_CYLINDER:
     t8_global_productionf ("Creating uniform level %i forest with a cylinder geometry.\n", level);
     /* Cylinder geometry. Has one quad tree that is periodic in x direction. */
-    geometry = new t8_geometry_cylinder;
+    t8_cmesh_register_geometry<t8_geometry_cylinder> (cmesh);
     t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_QUAD);
     t8_cmesh_set_join (cmesh, 0, 0, 0, 1, 0);
     snprintf (vtuname, BUFSIZ, "forest_cylinder_lvl_%i", level);
@@ -569,24 +594,23 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
       /* Moebius geometry on hybrid unit square. */
       t8_cmesh_t hybrid_square = t8_cmesh_new_periodic_hybrid (sc_MPI_COMM_WORLD);
       t8_cmesh_set_derive (cmesh, hybrid_square);
-      geometry = new t8_geometry_moebius;
+      t8_cmesh_register_geometry<t8_geometry_moebius> (cmesh);
       snprintf (vtuname, BUFSIZ, "forest_moebius_lvl_%i", level);
     }
     break;
   case T8_GEOM_TWO_GEOMETRIES:
     t8_global_productionf ("Creating uniform level %i forest with a cylinder and a sine cosine geometry.\n", level);
-    /* Cylinder geometry on tree 0. Sincos geometry on tree 1. */
-    geometry = new t8_geometry_cylinder;
-    geometry_sincos = new t8_geometry_sincos;
     t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_QUAD);
     /* Tree 0 is connected to itself to form a cylinder */
     t8_cmesh_set_join (cmesh, 0, 0, 0, 1, 0);
     t8_cmesh_set_tree_class (cmesh, 1, T8_ECLASS_QUAD);
-    /* Note that we have to register both geometries to the cmesh. The cylinder geometry is
-     * stored in the "geometry" pointer and registered later, right before the cmesh is committed. */
-    t8_cmesh_set_tree_geometry (cmesh, 0, geometry);
-    t8_cmesh_set_tree_geometry (cmesh, 1, geometry_sincos);
-    t8_cmesh_register_geometry (cmesh, &geometry_sincos);
+    /* Cylinder geometry on tree 0. Sincos geometry on tree 1. */
+    {
+      t8_geometry *geometry_cylinder = t8_cmesh_register_geometry<t8_geometry_cylinder> (cmesh);
+      t8_geometry *geometry_sincos = t8_cmesh_register_geometry<t8_geometry_sincos> (cmesh);
+      t8_cmesh_set_tree_geometry (cmesh, 0, geometry_cylinder);
+      t8_cmesh_set_tree_geometry (cmesh, 1, geometry_sincos);
+    }
     snprintf (vtuname, BUFSIZ, "forest_cylinder_and_sincos_lvl_%i", level);
     break;
   case T8_GEOM_CIRCLE:
@@ -596,28 +620,28 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
       /* Circle geometry on triangulated unit square. */
       t8_cmesh_t tri_square = t8_cmesh_new_hypercube (T8_ECLASS_TRIANGLE, sc_MPI_COMM_WORLD, 0, 0, 0);
       t8_cmesh_set_derive (cmesh, tri_square);
-      geometry = new t8_geometry_circle;
+      t8_cmesh_register_geometry<t8_geometry_circle> (cmesh);
       snprintf (vtuname, BUFSIZ, "forest_circle_lvl_%i", level);
     }
     break;
   case T8_GEOM_3D:
     t8_global_productionf ("Creating uniform level %i forest with a 3D function graph geometry.\n", level);
     /* Cube geometry with sincos on top. Has one hexahedron tree. */
-    geometry = new t8_geometry_cube_zdistorted;
+    t8_cmesh_register_geometry<t8_geometry_cube_zdistorted> (cmesh);
     t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_HEX);
     snprintf (vtuname, BUFSIZ, "forest_cube_3D_lvl_%i", level);
     break;
   case T8_GEOM_MOVING:
     t8_global_productionf ("Creating uniform level %i forest with a moving geometry.\n", level);
     /* Quad geometry that rotates with time. */
-    geometry = new t8_geometry_moving (&time);
+    t8_cmesh_register_geometry<t8_geometry_moving> (cmesh, &time);
     t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_QUAD);
     snprintf (vtuname, BUFSIZ, "forest_moving_lvl_%i", level);
     break;
   case T8_GEOM_ANALYTIC_QUAD_TO_SPHERE:
     t8_global_productionf ("Wrapping a quad around a sphere.\n");
-
-    geometry = new t8_geometry_analytic (3, "geom_quad_to_sphere", quad_to_sphere_callback, NULL, NULL, NULL);
+    t8_cmesh_register_geometry<t8_geometry_analytic> (cmesh, 3, "geom_quad_to_sphere", quad_to_sphere_callback, nullptr,
+                                                      nullptr, nullptr, nullptr);
     t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_QUAD);
     t8_cmesh_set_join (cmesh, 0, 0, 1, 0, 0);
 
@@ -643,8 +667,8 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
     /* Fill shape with bsplines so that we can create a geometry with this shape. */
     shape = BRepBuilderAPI_MakeEdge (cad_curve).Edge ();
 
-    /* Create an cad geometry. */
-    t8_geometry_cad *geometry_cad = new t8_geometry_cad (3, shape, "cad curve dim=3");
+    /* Create a cad geometry. */
+    t8_cmesh_register_geometry<t8_geometry_cad> (cmesh, 3, shape);
 
     /* The arrays indicate which face/edge carries a geometry. 
        * 0 means no geometry and any other number indicates the position of the geometry 
@@ -668,7 +692,6 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
     t8_cmesh_set_attribute (cmesh, 0, t8_get_package_id (), T8_CMESH_CAD_EDGE_PARAMETERS_ATTRIBUTE_KEY + 1,
                             parameters_edge, 2 * sizeof (double), 0);
 
-    geometry = geometry_cad;
     snprintf (vtuname, BUFSIZ, "forest_cad_triangle_lvl_%i", level);
     break;
 #else  /* !T8_WITH_OCC */
@@ -708,8 +731,8 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
     shape = BRepBuilderAPI_MakeEdge (cad_curve0).Edge ();
     shape = BRepAlgoAPI_Fuse (shape, BRepBuilderAPI_MakeEdge (cad_curve1).Edge ());
 
-    /* Create an cad geometry. */
-    t8_geometry_cad *geometry_cad = new t8_geometry_cad (3, shape, "cad curve dim=3");
+    /* Create a cad geometry. */
+    t8_cmesh_register_geometry<t8_geometry_cad> (cmesh, 3, shape);
 
     /* The arrays indicate which face/edge carries a geometry. 
      * 0 means no geometry and any other number indicates the position of the geometry 
@@ -738,7 +761,6 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
     t8_cmesh_set_attribute (cmesh, 0, t8_get_package_id (), T8_CMESH_CAD_EDGE_PARAMETERS_ATTRIBUTE_KEY + 3, parameters,
                             2 * sizeof (double), 0);
 
-    geometry = geometry_cad;
     snprintf (vtuname, BUFSIZ, "forest_cad_curve_cube_lvl_%i", level);
     break;
 #else  /* !T8_WITH_cad */
@@ -811,7 +833,7 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
     int edges[24] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
     /* Create cad geometry. */
-    t8_geometry_cad *geometry_cad = new t8_geometry_cad (3, shape, "cad surface dim=3");
+    t8_cmesh_register_geometry<t8_geometry_cad> (cmesh, 3, shape);
 
     /* Create tree 0 */
     t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_HEX);
@@ -864,7 +886,6 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
     /* Join tree 0 and tree 1 together */
     t8_cmesh_set_join (cmesh, 0, 1, 1, 0, 0);
 
-    geometry = geometry_cad;
     snprintf (vtuname, BUFSIZ, "forest_cad_surface_cubes_lvl_%i", level);
     break;
 #else  /* !T8_WITH_OCC */
@@ -908,8 +929,8 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
     int faces[6] = { 1, 2, 0, 0, 0, 0 };
     int edges[24] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
-    /* Create cad geometry. */
-    t8_geometry_cad *geometry_cad = new t8_geometry_cad (3, shape, "cad surface dim=3");
+    /* Create a cad geometry. */
+    t8_cmesh_register_geometry<t8_geometry_cad> (cmesh, 3, shape);
 
     /* Create corresponding trees and parameters. 
      * Here we create num trees by a coordinate transformation from cylinder to cartesian coordinates. */
@@ -970,7 +991,6 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
                               parameters + i * 8, 8 * sizeof (double), 0);
     }
 
-    geometry = geometry_cad;
     T8_FREE (vertices);
     T8_FREE (parameters);
     snprintf (vtuname, BUFSIZ, "forest_geometry_cylinder_lvl_%i", level);
@@ -982,8 +1002,6 @@ t8_analytic_geom (int level, t8_example_geom_type geom_type)
   default:
     SC_ABORT_NOT_REACHED ();
   }
-  /* Register the geometry */
-  t8_cmesh_register_geometry (cmesh, &geometry);
   /* Commit the cmesh */
   t8_cmesh_commit (cmesh, sc_MPI_COMM_WORLD);
 

--- a/src/t8_geometry/t8_geometry_base.hxx
+++ b/src/t8_geometry/t8_geometry_base.hxx
@@ -127,7 +127,7 @@ struct t8_geometry
                                       const double *points, const int num_points, int *is_inside,
                                       const double tolerance) const
   {
-    SC_ABORTF ("Function not yet implemented");
+    SC_ABORTF ("Point batch inside element function not implemented");
   };
 
   /**
@@ -137,7 +137,7 @@ struct t8_geometry
   virtual bool
   t8_geom_tree_negative_volume () const
   {
-    SC_ABORTF ("Function not implemented yet");
+    SC_ABORTF ("Tree negative volume function not implemented");
     /* To suppress compiler warnings. */
     return 0;
   };

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.cxx
@@ -24,12 +24,15 @@
 
 t8_geometry_analytic::t8_geometry_analytic (int dim, std::string name, t8_geom_analytic_fn analytical,
                                             t8_geom_analytic_jacobian_fn jacobian_in,
-                                            t8_geom_load_tree_data_fn load_tree_data_in, const void *user_data_in)
+                                            t8_geom_load_tree_data_fn load_tree_data_in,
+                                            t8_geom_tree_negative_volume_fn tree_negative_volume_in,
+                                            const void *user_data_in)
   : t8_geometry (dim, name + "_" + std::to_string (dim))
 {
   analytical_function = analytical;
   jacobian = jacobian_in;
   load_tree_data = load_tree_data_in;
+  tree_negative_volume = tree_negative_volume_in;
   user_data = user_data_in;
 }
 
@@ -39,6 +42,7 @@ t8_geometry_analytic::t8_geometry_analytic (int dim, std::string name)
   analytical_function = NULL;
   jacobian = NULL;
   load_tree_data = NULL;
+  tree_negative_volume = NULL;
   user_data = NULL;
 }
 
@@ -71,6 +75,18 @@ t8_geometry_analytic::t8_geom_load_tree_data (t8_cmesh_t cmesh, t8_gloidx_t gtre
   }
 }
 
+bool
+t8_geometry_analytic::t8_geom_tree_negative_volume () const
+{
+  if (tree_negative_volume != NULL) {
+    /* Tree negative volume if a loading function was provided. */
+    return tree_negative_volume ();
+  }
+  else {
+    return false;
+  }
+}
+
 T8_EXTERN_C_BEGIN ();
 
 void
@@ -85,9 +101,10 @@ t8_geometry_analytic_destroy (t8_geometry_c **geom)
 t8_geometry_c *
 t8_geometry_analytic_new (int dim, const char *name, t8_geom_analytic_fn analytical,
                           t8_geom_analytic_jacobian_fn jacobian, t8_geom_load_tree_data_fn load_tree_data,
-                          const void *user_data)
+                          t8_geom_tree_negative_volume_fn tree_negative_volume, const void *user_data)
 {
-  t8_geometry_analytic *geom = new t8_geometry_analytic (dim, name, analytical, jacobian, load_tree_data, user_data);
+  t8_geometry_analytic *geom
+    = new t8_geometry_analytic (dim, name, analytical, jacobian, load_tree_data, tree_negative_volume, user_data);
   return (t8_geometry_c *) geom;
 }
 

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.h
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.h
@@ -66,6 +66,11 @@ typedef void (*t8_geom_analytic_jacobian_fn) (t8_cmesh_t cmesh, t8_gloidx_t gtre
  */
 typedef void (*t8_geom_load_tree_data_fn) (t8_cmesh_t cmesh, t8_gloidx_t gtreeid, const void **tree_data);
 
+/**
+ * Definition for the negative volume function.
+ */
+typedef bool (*t8_geom_tree_negative_volume_fn) ();
+
 T8_EXTERN_C_BEGIN ();
 
 /** Destroy a geometry analytic object.
@@ -80,7 +85,7 @@ t8_geometry_analytic_destroy (t8_geometry_c **geom);
 t8_geometry_c *
 t8_geometry_analytic_new (int dim, const char *name, t8_geom_analytic_fn analytical,
                           t8_geom_analytic_jacobian_fn jacobian, t8_geom_load_tree_data_fn load_tree_data,
-                          const void *user_data);
+                          t8_geom_tree_negative_volume_fn tree_negative_volume, const void *user_data);
 
 /**
  * Load vertex data from given tree. 

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.hxx
@@ -49,7 +49,7 @@ struct t8_geometry_analytic: public t8_geometry
    */
   t8_geometry_analytic (int dim, std::string name, t8_geom_analytic_fn analytical,
                         t8_geom_analytic_jacobian_fn jacobian, t8_geom_load_tree_data_fn load_tree_data,
-                        const void *user_data);
+                        t8_geom_tree_negative_volume_fn tree_negative_volume_in, const void *user_data);
 
   /**
    * Constructor of the analytic geometry for testing purposes.
@@ -121,6 +121,13 @@ struct t8_geometry_analytic: public t8_geometry
     SC_ABORTF ("Function not yet implemented");
   }
 
+  /**
+   * Check if the currently active tree has a negative volume
+   * \return                True (non-zero) if the currently loaded tree has a negative volume. 0 otherwise.  
+   */
+  virtual bool
+  t8_geom_tree_negative_volume () const;
+
   /** Update a possible internal data buffer for per tree data.
    * This function is called before the first coordinates in a new tree are
    * evaluated. You can use it for example to load the vertex coordinates of the 
@@ -143,6 +150,8 @@ struct t8_geometry_analytic: public t8_geometry
   t8_geom_analytic_jacobian_fn jacobian; /**< Its jacobian. */
 
   t8_geom_load_tree_data_fn load_tree_data; /**< The function to load the tree data. */
+
+  t8_geom_tree_negative_volume_fn tree_negative_volume; /**< The function to check for negative volumes. */
 
   const void *tree_data; /** Tree data pointer that can be set in \a load_tree_data and 
                                            is passed onto \a analytical_function and \a jacobian. */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.cxx
@@ -100,7 +100,8 @@ t8_geometry_cad::t8_geom_evaluate (t8_cmesh_t cmesh, t8_gloidx_t gtreeid, const 
     t8_geometry_cad::t8_geom_evaluate_cad_hex (cmesh, gtreeid, ref_coords, 1, out_coords);
     break;
   default:
-    SC_ABORTF ("Error: Curved %s geometry not yet implemented. \n", t8_eclass_to_string[active_tree_class]);
+    SC_ABORTF ("Error: Curved cad geometry for element type %s not yet implemented. \n",
+               t8_eclass_to_string[active_tree_class]);
   }
 }
 


### PR DESCRIPTION
**_Describe your changes here:_**
Fixes the geometry example. It did not work in debug due to the missing implementations of the negative volume check.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
