### PR TITLE
Move t8_mat to installed headers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,6 +29,7 @@ libt8_installed_headers = \
   src/t8_cmesh_vtk_writer.h \
   src/t8_cmesh_vtk_reader.hxx \
   src/t8_vec.h \
+  src/t8_mat.h \
   src/t8_version.h \
   src/t8_vtk.h \
   src/t8_cmesh_netcdf.h \
@@ -102,7 +103,6 @@ libt8_internal_headers = \
   src/t8_forest/t8_forest_ghost.h \
   src/t8_forest/t8_forest_balance.h src/t8_forest/t8_forest_types.h \
   src/t8_forest/t8_forest_private.h \
-  src/t8_mat.h \
   src/t8_windows.h
 libt8_compiled_sources = \
   src/t8.c src/t8_eclass.c src/t8_mesh.c \

--- a/src/t8_mat.h
+++ b/src/t8_mat.h
@@ -104,7 +104,7 @@ t8_mat_init_zrot (double mat[3][3], const double angle)
  * \param [in,out]    b     3-vector.
  */
 static inline void
-t8_mat_mult_vec (double mat[3][3], const double a[3], double b[3])
+t8_mat_mult_vec (const double mat[3][3], const double a[3], double b[3])
 {
   b[0] = mat[0][0] * a[0] + mat[0][1] * a[1] + mat[0][2] * a[2];
   b[1] = mat[1][0] * a[0] + mat[1][1] * a[1] + mat[1][2] * a[2];
@@ -117,7 +117,7 @@ t8_mat_mult_vec (double mat[3][3], const double a[3], double b[3])
  * \param [int,out]   C     3x3-matrix.
  */
 static inline void
-t8_mat_mult_mat (double A[3][3], double B[3][3], double C[3][3])
+t8_mat_mult_mat (const double A[3][3], const double B[3][3], double C[3][3])
 {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {

--- a/src/t8_mat.h
+++ b/src/t8_mat.h
@@ -134,4 +134,4 @@ t8_mat_mult_mat (const double A[3][3], const double B[3][3], double C[3][3])
   }
 }
 
-#endif /* !T8_MAT_H! */
+#endif /* !T8_MAT_H */


### PR DESCRIPTION
**_Describe your changes here:_**
t8_vec.h is an installed header, t8_mat.h should also be


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
