### PR TITLE
Introduce Makro to controll the number of points used for testing

### DIFF
--- a/test/t8_geometry/t8_geometry_implementations/t8_gtest_geometry_lagrange.cxx
+++ b/test/t8_geometry/t8_geometry_implementations/t8_gtest_geometry_lagrange.cxx
@@ -215,11 +215,6 @@ class LagrangeCmesh: public testing::TestWithParam<std::tuple<t8_eclass_t, int>>
 
   t8_eclass_t eclass;
   int degree;
-  #ifdef T8_ENABLE_LESS_TESTS
-  const int num_points = 1000;
-  #else
-  const int num_points = 10000;
-  #endif
 };
 
 /**
@@ -238,7 +233,7 @@ TEST_P (LagrangeCmesh, lagrange_mapping)
   std::vector<t8_lagrange_element> faces = lag.decompose ();
   uint i_face = 0;
   for (const auto &face : faces) {
-    auto points_on_face = sample (face.get_type (), num_points);
+    auto points_on_face = sample (face.get_type (), T8_NUM_SAMPLE_POINTS);
     for (const auto &point : points_on_face) {
       auto mapped1 = face.evaluate (point);
       auto mapped2 = lag.evaluate (face.map_on_face (lag.get_type (), i_face, point));

--- a/test/t8_geometry/t8_geometry_implementations/t8_gtest_geometry_linear.cxx
+++ b/test/t8_geometry/t8_geometry_implementations/t8_gtest_geometry_linear.cxx
@@ -94,11 +94,6 @@ class geometry_test: public testing::TestWithParam<std::tuple<int, t8_eclass>> {
   t8_eclass_t eclass;
   t8_geometry_with_vertices *geom;
   t8_cmesh_t cmesh;
-#ifdef T8_ENABLE_LESS_TESTS
-  const int num_points = 1000;
-#else
-  const int num_points = 10000;
-#endif
 };
 
 int geometry_test::seed;
@@ -123,7 +118,7 @@ TEST_P (geometry_test, cmesh_geometry)
     << "cmesh's geometry is not the expected geometry.";
 
   srand (seed);
-  for (int ipoint = 0; ipoint < num_points; ++ipoint) {
+  for (int ipoint = 0; ipoint < T8_NUM_SAMPLE_POINTS; ++ipoint) {
     double point[3] = { 0 };
     /* Compute random coordinates in [0,1].
      * These are seen as reference coordinates in the single

--- a/test/t8_gtest_macros.hxx
+++ b/test/t8_gtest_macros.hxx
@@ -36,6 +36,16 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
  */
 auto print_eclass = [] (const testing::TestParamInfo<t8_eclass> &info) { return t8_eclass_to_string[info.param]; };
 
+/**
+ * Number of points to use in tests
+ * 
+ */
+#ifdef T8_ENABLE_LESS_TESTS
+#define T8_NUM_SAMPLE_POINTS 1000
+#else
+#define T8_NUM_SAMPLE_POINTS 10000
+#endif
+
 #define AllEclasses testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT)
 #define AllEclasses2D testing::Values (T8_ECLASS_QUAD, T8_ECLASS_TRIANGLE)
 


### PR DESCRIPTION
Use a Makro to avoid redefining the variable num_points over and over again. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
