### PR TITLE
cmake: Add option to use system sc and p4est

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required( VERSION 3.16 )
 project( T8CODE DESCRIPTION "Parallel algorithms and data structures for tree-based AMR with arbitrary element shapes." LANGUAGES C CXX )
 include( CTest )
 
-
 option( T8CODE_BUILD_AS_SHARED_LIBRARY "Whether t8code should be built as a shared or a static library" ON )
 option( T8CODE_BUILD_TESTS "Build t8code's automated tests" ON )
 option( T8CODE_BUILD_TUTORIALS "Build t8code's tutorials" ON )
@@ -11,6 +10,8 @@ option( T8CODE_BUILD_EXAMPLES "Build t8code's examples" ON )
 option( T8CODE_ENABLE_MPI "Enable t8code's features which rely on MPI" ON )
 option( T8CODE_ENABLE_VTK "Enable t8code's features which rely on VTK" OFF )
 
+option( T8CODE_USE_SYSTEM_SC "Use system-installed sc library" OFF )
+option( T8CODE_USE_SYSTEM_P4EST "Use system-installed p4est library" OFF )
 
 if( NOT CMAKE_BUILD_TYPE )
     set( CMAKE_BUILD_TYPE "Release" )
@@ -51,8 +52,18 @@ set(CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
 
-add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/sc )
-add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/p4est )
+if (T8CODE_USE_SYSTEM_SC)
+    find_package(SC REQUIRED PATHS /path/to/system/sc)
+else()
+    add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/sc )
+endif()
+
+if (T8CODE_USE_SYSTEM_P4EST)
+    find_package(P4EST REQUIRED PATHS /path/to/system/p4est)
+else()
+    add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/p4est )
+endif()
+
 add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/src )
 
 if ( T8CODE_BUILD_TESTS )


### PR DESCRIPTION
**_Describe your changes here:_**
Adds the option to use the system sc and p4est rather than the submodules


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
