### PR TITLE
Rename occ test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,7 @@ add_t8_test( NAME t8_gtest_eclass            SOURCES t8_gtest_main.cxx t8_gtest_
 add_t8_test( NAME t8_gtest_vec               SOURCES t8_gtest_main.cxx t8_gtest_vec.cxx )
 add_t8_test( NAME t8_gtest_mat               SOURCES t8_gtest_main.cxx t8_gtest_mat.cxx )
 add_t8_test( NAME t8_gtest_refcount          SOURCES t8_gtest_main.cxx t8_gtest_refcount.cxx )
-add_t8_test( NAME t8_gtest_cad_linkage       SOURCES t8_gtest_main.cxx t8_gtest_cad_linkage.cxx )
+add_t8_test( NAME t8_gtest_occ_linkage       SOURCES t8_gtest_main.cxx t8_gtest_occ_linkage.cxx )
 add_t8_test( NAME t8_gtest_version           SOURCES t8_gtest_main.cxx t8_gtest_version.cxx )
 add_t8_test( NAME t8_gtest_basics            SOURCES t8_gtest_main.cxx t8_gtest_basics.cxx )
 add_t8_test( NAME t8_gtest_netcdf_linkage    SOURCES t8_gtest_main.cxx t8_gtest_netcdf_linkage.cxx )

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -24,7 +24,7 @@ t8code_googletest_programs = \
   test/t8_gtest_vec \
   test/t8_gtest_mat \
   test/t8_gtest_refcount \
-  test/t8_gtest_cad_linkage \
+  test/t8_gtest_occ_linkage \
   test/t8_gtest_version \
   test/t8_schemes/t8_gtest_init_linear_id \
   test/t8_gtest_basics \
@@ -123,9 +123,9 @@ test_t8_gtest_refcount_SOURCES = \
   test/t8_gtest_main.cxx \
   test/t8_gtest_refcount.cxx
 
-test_t8_gtest_cad_linkage_SOURCES = \
+test_t8_gtest_occ_linkage_SOURCES = \
   test/t8_gtest_main.cxx \
-  test/t8_gtest_cad_linkage.cxx
+  test/t8_gtest_occ_linkage.cxx
 
 test_t8_gtest_version_SOURCES = \
   test/t8_gtest_main.cxx \
@@ -371,9 +371,9 @@ test_t8_gtest_refcount_LDADD = $(t8_gtest_target_ld_add)
 test_t8_gtest_refcount_LDFLAGS = $(t8_gtest_target_ld_flags)
 test_t8_gtest_refcount_CPPFLAGS = $(t8_gtest_target_cpp_flags)
 
-test_t8_gtest_cad_linkage_LDADD = $(t8_gtest_target_ld_add)
-test_t8_gtest_cad_linkage_LDFLAGS = $(t8_gtest_target_ld_flags)
-test_t8_gtest_cad_linkage_CPPFLAGS = $(t8_gtest_target_cpp_flags)
+test_t8_gtest_occ_linkage_LDADD = $(t8_gtest_target_ld_add)
+test_t8_gtest_occ_linkage_LDFLAGS = $(t8_gtest_target_ld_flags)
+test_t8_gtest_occ_linkage_CPPFLAGS = $(t8_gtest_target_cpp_flags)
 
 test_t8_gtest_version_LDADD = $(t8_gtest_target_ld_add)
 test_t8_gtest_version_LDFLAGS = $(t8_gtest_target_ld_flags)
@@ -584,7 +584,7 @@ test_t8_gtest_eclass_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_gtest_vec_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_gtest_mat_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_gtest_refcount_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
-test_t8_gtest_cad_linkage_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
+test_t8_gtest_occ_linkage_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_gtest_version_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_schemes_t8_gtest_init_linear_id_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)
 test_t8_gtest_basics_CPPFLAGS += $(t8_gtest_target_mpi_cpp_flags)

--- a/test/t8_gtest_occ_linkage.cxx
+++ b/test/t8_gtest_occ_linkage.cxx
@@ -20,10 +20,10 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-/* In this test we create an cad gp_Pnt object.
+/* In this test we create an occ gp_Pnt object.
  * The purpose of this test is to check whether t8code successfully links
- * against cad.
- * If t8code was not configured with --with-cad then this test
+ * against occ.
+ * If t8code was not configured with --with-occ then this test
  * does nothing and is always passed.
  */
 
@@ -34,13 +34,13 @@
 #endif
 
 /* Check whether we can successfully execute VTK code */
-TEST (t8_test_cad_linkage, test_gp_Pnt)
+TEST (t8_test_occ_linkage, test_gp_Pnt)
 {
 #if T8_WITH_OCC
 
   EXPECT_NO_THROW (gp_Pnt pnt = gp_Pnt (); pnt.SetX (1););
-  t8_global_productionf ("Successfully created cad gp_Pnt object.\n");
+  t8_global_productionf ("Successfully created occ gp_Pnt object.\n");
 #else
-  t8_global_productionf ("This version of t8code is not compiled with cad support.\n");
+  t8_global_productionf ("This version of t8code is not compiled with occ support.\n");
 #endif
 }


### PR DESCRIPTION
**_Describe your changes here:_**
The occ linkage test was accidentally renamed to cad


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
