### PR TITLE
Add enable-fortran

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,13 +27,26 @@ T8_ARG_ENABLE([debug], [enable debug mode (assertions and extra checks)],
 T8_ARG_ENABLE([less-tests], [uses a fraction of the test cases to speed up development (WARNING: use with care)],
                  [LESS_TESTS])
 
+T8_ARG_ENABLE([fortran], [build the Fortran interfaces and programs of t8code], [FORTRAN])
+
 echo "o---------------------------------------"
 echo "| Checking MPI and related programs"
 echo "o---------------------------------------"
 
-dnl A nonempty second/third argument causes to enable F77+F90/CXX, respectively.
-SC_MPI_CONFIG([T8], [], [yes])
+dnl Check for MPI
+if test "x$T8_ENABLE_FORTRAN" = xno; then
+dnl Enable C++ 
+  SC_MPI_CONFIG([T8], [], [yes])
+else
+dnl Enable C++ and Fortran
+  SC_MPI_CONFIG([T8], [yes], [yes])
+fi
+
 SC_MPI_ENGAGE([T8])
+
+dnl Check for all Fortran related options and features
+T8_CHECK_FORTRAN
+
 # This is needed for compatibility with automake >= 1.12
 m4_ifdef([AM_PROG_AR],[AM_PROG_AR])
 dnl SC_PROG_LINT
@@ -112,6 +125,14 @@ AC_DEFINE_UNQUOTED(CC,          ["${CC}"],          [C compiler])
 AC_DEFINE_UNQUOTED(CFLAGS,      ["${CFLAGS}"],      [C compiler flags])
 AC_DEFINE_UNQUOTED(LDFLAGS,     ["${LDFLAGS}"],     [Linker flags])
 AC_DEFINE_UNQUOTED(LIBS,        ["${LIBS}"],        [Libraries])
+AC_DEFINE_UNQUOTED(CXX,         ["${CXX}"],         [C++ Compiler])
+AC_DEFINE_UNQUOTED(CXXFLAGS,    ["${CXXFLAGS}"],    [C++ Compiler Flags])
+if test "x$T8_ENABLE_FORTRAN" != xno; then
+AC_DEFINE_UNQUOTED(FC,          ["${FC}"],          [FORTRAN Compiler])
+AC_DEFINE_UNQUOTED(F77,         ["${F77}"],         [F77 Compiler])
+AC_DEFINE_UNQUOTED(FFLAGS,      ["${FFLAGS}"],      [FORTRAN Compiler Flags])
+AC_DEFINE_UNQUOTED(FCFLAGS,     ["${FCFLAGS}"],     [FORTRAN Compiler Flags])
+fi
 
 echo "o----------------------------------"
 echo "| Results for t8code are"
@@ -120,6 +141,14 @@ echo "| CPP:         $CPP"
 echo "| CPPFLAGS:    $CPPFLAGS"
 echo "| CC:          $CC"
 echo "| CFLAGS:      $CFLAGS"
+echo "| CXX:         $CXX"
+echo "| CXXFLAGS:    $CXXFLAGS"
+if test "x$T8_ENABLE_FORTRAN" != xno; then
+echo "| FC:          $FC"
+echo "| F77:         $F77"
+echo "| FFLAGS:      $FFLAGS"
+echo "| FCFLAGS:     $FCFLAGS"
+fi
 echo "| LDFLAGS:     $LDFLAGS"
 echo "| LIBS:        $LIBS"
 echo "o----------------------------------"


### PR DESCRIPTION
Add macro --enable-fortran and Fortran flags as a first step for the Fortran interface.



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
