### PR TITLE
Feature: Optionally compute face orientation when calling leaf_face_neighbor routine.

### DIFF
--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1689,16 +1689,17 @@ t8_forest_element_half_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid, 
   return neighbor_tree;
 }
 
-int 
-t8_forest_leaf_face_orientation (t8_forest_t forest, const t8_locidx_t ltreeid, const t8_eclass_scheme_c *ts, const t8_element_t *leaf, int face)
+int
+t8_forest_leaf_face_orientation (t8_forest_t forest, const t8_locidx_t ltreeid, const t8_eclass_scheme_c *ts,
+                                 const t8_element_t *leaf, int face)
 {
   int orientation = 0;
 
-  if (t8_element_is_root_boundary(ts, leaf, face)) {
-    t8_cmesh_t cmesh = t8_forest_get_cmesh(forest);
-    t8_locidx_t ltreeid_in_cmesh = t8_forest_ltreeid_to_cmesh_ltreeid(forest, ltreeid);
-    int iface_in_tree = t8_element_tree_face(ts, leaf, face);
-    t8_cmesh_get_face_neighbor(cmesh, ltreeid_in_cmesh, iface_in_tree, NULL, &orientation);
+  if (t8_element_is_root_boundary (ts, leaf, face)) {
+    t8_cmesh_t cmesh = t8_forest_get_cmesh (forest);
+    t8_locidx_t ltreeid_in_cmesh = t8_forest_ltreeid_to_cmesh_ltreeid (forest, ltreeid);
+    int iface_in_tree = t8_element_tree_face (ts, leaf, face);
+    t8_cmesh_get_face_neighbor (cmesh, ltreeid_in_cmesh, iface_in_tree, NULL, &orientation);
   }
 
   return orientation;
@@ -1737,7 +1738,7 @@ t8_forest_leaf_face_neighbors_ext (t8_forest_t forest, t8_locidx_t ltreeid, cons
     ts = t8_forest_get_eclass_scheme (forest, eclass);
 
     if (orientation) {
-      *orientation = t8_forest_leaf_face_orientation(forest, ltreeid, ts, leaf, face);
+      *orientation = t8_forest_leaf_face_orientation (forest, ltreeid, ts, leaf, face);
     }
 
     /* At first we compute these children of the face neighbor elements of leaf. For this, we need the

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1689,11 +1689,26 @@ t8_forest_element_half_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid, 
   return neighbor_tree;
 }
 
+int 
+t8_forest_leaf_face_orientation (t8_forest_t forest, const t8_locidx_t ltreeid, const t8_eclass_scheme_c *ts, const t8_element_t *leaf, int face)
+{
+  int orientation = 0;
+
+  if (t8_element_is_root_boundary(ts, leaf, face)) {
+    t8_cmesh_t cmesh = t8_forest_get_cmesh(forest);
+    t8_locidx_t ltreeid_in_cmesh = t8_forest_ltreeid_to_cmesh_ltreeid(forest, ltreeid);
+    int iface_in_tree = t8_element_tree_face(ts, leaf, face);
+    t8_cmesh_get_face_neighbor(cmesh, ltreeid_in_cmesh, iface_in_tree, NULL, &orientation);
+  }
+
+  return orientation;
+}
+
 void
 t8_forest_leaf_face_neighbors_ext (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *leaf,
                                    t8_element_t **pneighbor_leaves[], int face, int *dual_faces[], int *num_neighbors,
                                    t8_locidx_t **pelement_indices, t8_eclass_scheme_c **pneigh_scheme,
-                                   int forest_is_balanced, t8_gloidx_t *gneigh_tree)
+                                   int forest_is_balanced, t8_gloidx_t *gneigh_tree, int *orientation)
 {
   t8_eclass_t neigh_class, eclass;
   t8_gloidx_t gneigh_treeid;
@@ -1720,6 +1735,11 @@ t8_forest_leaf_face_neighbors_ext (t8_forest_t forest, t8_locidx_t ltreeid, cons
      * its parent or its children at the face. */
     eclass = t8_forest_get_tree_class (forest, ltreeid);
     ts = t8_forest_get_eclass_scheme (forest, eclass);
+
+    if (orientation) {
+      *orientation = t8_forest_leaf_face_orientation(forest, ltreeid, ts, leaf, face);
+    }
+
     /* At first we compute these children of the face neighbor elements of leaf. For this, we need the
      * neighbor tree's eclass, scheme, and tree id */
     neigh_class = t8_forest_element_neighbor_eclass (forest, ltreeid, leaf, face);
@@ -1931,7 +1951,7 @@ t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid, const t8
                                int forest_is_balanced)
 {
   t8_forest_leaf_face_neighbors_ext (forest, ltreeid, leaf, pneighbor_leaves, face, dual_faces, num_neighbors,
-                                     pelement_indices, pneigh_scheme, forest_is_balanced, NULL);
+                                     pelement_indices, pneigh_scheme, forest_is_balanced, NULL, NULL);
 }
 
 void

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -504,8 +504,9 @@ t8_forest_get_coarse_tree (t8_forest_t forest, t8_locidx_t ltreeid);
  *
  * For more information about the encoding of face orientation refer to \ref t8_cmesh_get_face_neighbor.
  */
-int 
-t8_forest_leaf_face_orientation (t8_forest_t forest, const t8_locidx_t ltreeid, const t8_eclass_scheme_c *ts, const t8_element_t *leaf, int face);
+int
+t8_forest_leaf_face_orientation (t8_forest_t forest, const t8_locidx_t ltreeid, const t8_eclass_scheme_c *ts,
+                                 const t8_element_t *leaf, int face);
 
 /** Compute the leaf face neighbors of a forest.
  * \param [in]    forest  The forest. Must have a valid ghost layer.

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -493,6 +493,20 @@ t8_forest_cmesh_ltreeid_to_ltreeid (t8_forest_t forest, t8_locidx_t lctreeid);
 t8_ctree_t
 t8_forest_get_coarse_tree (t8_forest_t forest, t8_locidx_t ltreeid);
 
+/** Compute the leaf face orientation at given face in a forest.
+ * \param [in]    forest  The forest. Must have a valid ghost layer.
+ * \param [in]    ltreeid A local tree id.
+ * \param [in]    ts      The eclass scheme of the element.
+ * \param [in]    leaf    A leaf in tree \a ltreeid of \a forest.
+ * \param [in]    face    The index of the face across which the face neighbors
+ *                        are searched.
+ * \return                Face orientation encoded as integer.
+ *
+ * For more information about the encoding of face orientation refer to \ref t8_cmesh_get_face_neighbor.
+ */
+int 
+t8_forest_leaf_face_orientation (t8_forest_t forest, const t8_locidx_t ltreeid, const t8_eclass_scheme_c *ts, const t8_element_t *leaf, int face);
+
 /** Compute the leaf face neighbors of a forest.
  * \param [in]    forest  The forest. Must have a valid ghost layer.
  * \param [in]    ltreeid A local tree id.
@@ -510,6 +524,7 @@ t8_forest_get_coarse_tree (t8_forest_t forest, t8_locidx_t ltreeid);
  * \param [out]   pneigh_scheme On output the eclass scheme of the neighbor elements.
  * \param [in]    forest_is_balanced True if we know that \a forest is balanced, false
  *                        otherwise.
+ * \param [out]   orientation If a pointer to an integer variable is given the face orientation is computed and stored there.
  * \note If there are no face neighbors, then *neighbor_leaves = NULL, num_neighbors = 0,
  * and *pelement_indices = NULL on output.
  * \note Currently \a forest must be balanced.
@@ -525,7 +540,7 @@ void
 t8_forest_leaf_face_neighbors_ext (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *leaf,
                                    t8_element_t **pneighbor_leaves[], int face, int *dual_faces[], int *num_neighbors,
                                    t8_locidx_t **pelement_indices, t8_eclass_scheme_c **pneigh_scheme,
-                                   int forest_is_balanced, t8_gloidx_t *gneigh_tree);
+                                   int forest_is_balanced, t8_gloidx_t *gneigh_tree, int *orientation);
 
 /** Exchange ghost information of user defined element data.
  * \param[in] forest       The forest. Must be committed.

--- a/test/t8_forest/t8_gtest_forest_face_normal.cxx
+++ b/test/t8_forest/t8_gtest_forest_face_normal.cxx
@@ -88,7 +88,7 @@ TEST_P (class_forest_face_normal, back_and_forth)
 
         t8_gloidx_t gneightree;
         t8_forest_leaf_face_neighbors_ext (forest, itree, element, &neighbors, iface, &dual_faces, &num_neighbors,
-                                           &neigh_ids, &neigh_scheme, forest_is_balanced, &gneightree);
+                                           &neigh_ids, &neigh_scheme, forest_is_balanced, &gneightree, NULL);
 
         /* Iterate and compute their facenormal */
         for (int ineigh = 0; ineigh < num_neighbors; ineigh++) {


### PR DESCRIPTION
**_Describe your changes here:_**

Title says it all. This is a convenience argument for the user base of t8code.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
