### PR TITLE
Renamed uints to the more commong uint32_t datatype.

### DIFF
--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_lagrange.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_lagrange.cxx
@@ -256,14 +256,14 @@ t8_geometry_lagrange::t8_geom_h27_basis (const double *ref_point) const
 }
 
 t8_forest_t
-t8_lagrange_element::create_uniform_forest (t8_cmesh_t cmesh, uint level) const
+t8_lagrange_element::create_uniform_forest (t8_cmesh_t cmesh, uint32_t level) const
 {
   t8_forest_t forest;
   forest = t8_forest_new_uniform (cmesh, t8_scheme_new_default_cxx (), level, 0, sc_MPI_COMM_WORLD);
   return forest;
 }
 
-t8_lagrange_element::t8_lagrange_element (t8_eclass_t eclass, uint degree, std::vector<double> &nodes)
+t8_lagrange_element::t8_lagrange_element (t8_eclass_t eclass, uint32_t degree, std::vector<double> &nodes)
   : eclass (eclass), degree (degree), nodes (nodes)
 {
   // TODO: Check if the number of nodes corresponds to the element type and degree.
@@ -279,7 +279,7 @@ t8_lagrange_element::t8_lagrange_element (t8_eclass_t eclass, uint degree, std::
   t8_cmesh_commit (cmesh, sc_MPI_COMM_WORLD);
 }
 
-const uint t8_lagrange_element::lagrange_nodes[T8_ECLASS_COUNT][2];
+const uint32_t t8_lagrange_element::lagrange_nodes[T8_ECLASS_COUNT][2];
 
 t8_eclass_t
 t8_lagrange_element::get_type () const
@@ -287,12 +287,12 @@ t8_lagrange_element::get_type () const
   return eclass;
 }
 
-std::vector<std::vector<uint>>
+std::vector<std::vector<uint32_t>>
 t8_lagrange_element::get_face_nodes () const
 {
   std::ostringstream invalid_degree;
   invalid_degree << "Invalid degree " << degree << ".\n";
-  std::vector<std::vector<uint>> face_nodes;
+  std::vector<std::vector<uint32_t>> face_nodes;
   switch (eclass) {
   case T8_ECLASS_LINE:
     if (degree == 1)
@@ -370,20 +370,20 @@ t8_lagrange_element::face_classes () const
 }
 
 std::vector<double>
-t8_lagrange_element::get_node_coords (uint node) const
+t8_lagrange_element::get_node_coords (uint32_t node) const
 {
   const double *v = t8_cmesh_get_tree_vertices (cmesh, 0);
   return std::vector<double> (v + 3 * node, v + 3 * node + 3);
 }
 
 std::vector<std::vector<double>>
-t8_lagrange_element::get_node_coords (std::vector<uint> &nodes) const
+t8_lagrange_element::get_node_coords (std::vector<uint32_t> &nodes) const
 {
   const double *v = t8_cmesh_get_tree_vertices (cmesh, 0);
   size_t n_node = nodes.size ();
   std::vector<std::vector<double>> node_coords (n_node);
   for (size_t i = 0; i < n_node; ++i) {
-    uint i_node = nodes[i];
+    uint32_t i_node = nodes[i];
     node_coords[i] = std::vector<double> (v + 3 * i_node, v + 3 * i_node + 3);
   }
   return node_coords;
@@ -394,10 +394,10 @@ t8_lagrange_element::decompose () const
 {
   /* Get the node numbers of the faces */
   std::vector<t8_eclass_t> fc = face_classes ();
-  std::vector<std::vector<uint>> fn = get_face_nodes ();
+  std::vector<std::vector<uint32_t>> fn = get_face_nodes ();
   /* Create a new Lagrange element from each face */
   std::vector<t8_lagrange_element> faces;
-  const uint n_face = t8_eclass_num_faces[eclass];
+  const uint32_t n_face = t8_eclass_num_faces[eclass];
   faces.reserve (n_face);
   for (size_t i_face = 0; i_face < n_face; ++i_face) {
     auto nc = flatten<double> (get_node_coords (fn[i_face]));

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_lagrange.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_lagrange.hxx
@@ -348,7 +348,7 @@ class t8_lagrange_element {
    * \param nodes   x,y,z coordinates of the nodes, adhering to the numbering
    *                convention.
    */
-  t8_lagrange_element (t8_eclass_t eclass, uint degree, std::vector<double> &nodes);
+  t8_lagrange_element (t8_eclass_t eclass, uint32_t degree, std::vector<double> &nodes);
 
   /**
    * Destroy the t8_lagrange_element object.
@@ -385,7 +385,7 @@ class t8_lagrange_element {
    * \return      x,y,z coordinates of the node.
    */
   std::vector<double>
-  get_node_coords (uint node) const;
+  get_node_coords (uint32_t node) const;
 
   /**
    * Coordinates of the specified nodes.
@@ -394,14 +394,14 @@ class t8_lagrange_element {
    * \return       x,y,z coordinates of the nodes.
    */
   std::vector<std::vector<double>>
-  get_node_coords (std::vector<uint> &nodes) const;
+  get_node_coords (std::vector<uint32_t> &nodes) const;
 
   /**
    * Node labels on the faces of the element.
    * 
    * \return  Node labels on each face of the element.
    */
-  std::vector<std::vector<uint>>
+  std::vector<std::vector<uint32_t>>
   get_face_nodes () const;
 
   /**
@@ -434,7 +434,7 @@ class t8_lagrange_element {
    * \return         Coordinates of the points, given in x,y,z.
    */
   std::vector<std::array<double, T8_ECLASS_MAX_DIM>>
-  sample (uint n_point) const;
+  sample (uint32_t n_point) const;
 
   /**
    * Map this element on the face of a higher-dimensional element.
@@ -489,16 +489,16 @@ class t8_lagrange_element {
   /** Lagrange elements have the same element class as the linear ones. */
   t8_eclass_t eclass;
   /** Polynomial degree of the geometrical mapping. */
-  const uint degree;
+  const uint32_t degree;
   /** Points in the physical space, which span the geometry of the element. */
   const std::vector<double> nodes;
   /** Coarse mesh, wrapped by this class. */
   t8_cmesh_t cmesh;
   /** Number of nodes in the Lagrange element of a given class and degree */
-  static constexpr uint lagrange_nodes[T8_ECLASS_COUNT][2] = { { 1, 1 }, { 2, 3 }, { 4, 9 }, { 3, 6 }, { 8, 27 } };
+  static constexpr uint32_t lagrange_nodes[T8_ECLASS_COUNT][2] = { { 1, 1 }, { 2, 3 }, { 4, 9 }, { 3, 6 }, { 8, 27 } };
 
   t8_forest_t
-  create_uniform_forest (t8_cmesh_t cmesh, uint level) const;
+  create_uniform_forest (t8_cmesh_t cmesh, uint32_t level) const;
 };
 
 #endif /* !T8_GEOMETRY_LAGRANGE_HXX */

--- a/test/t8_geometry/t8_geometry_implementations/t8_gtest_geometry_lagrange.cxx
+++ b/test/t8_geometry/t8_geometry_implementations/t8_gtest_geometry_lagrange.cxx
@@ -99,7 +99,7 @@ allclose (const U &a, const V &b, double tol = T8_PRECISION_SQRT_EPS)
  * \return         Coordinates of the points, given in x,y,z.
  */
 std::vector<std::array<double, T8_ECLASS_MAX_DIM>>
-sample (t8_eclass_t eclass, uint n_point)
+sample (t8_eclass_t eclass, uint32_t n_point)
 {
   std::srand (time (NULL));
   std::vector<std::array<double, T8_ECLASS_MAX_DIM>> points (n_point);
@@ -228,7 +228,7 @@ TEST_P (LagrangeCmesh, lagrange_mapping)
   t8_lagrange_element lag = create_sample_element (eclass, degree);
   /* Compare the mappings on each boundary face of the Lagrange element */
   std::vector<t8_lagrange_element> faces = lag.decompose ();
-  uint i_face = 0;
+  uint32_t i_face = 0;
   for (const auto &face : faces) {
     auto points_on_face = sample (face.get_type (), T8_NUM_SAMPLE_POINTS);
     for (const auto &point : points_on_face) {


### PR DESCRIPTION
**_Describe your changes here:_**

`uint` is not supported by all compilers/platforms. This PR renames the few occurrences to `uint32_t`.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
