### PR TITLE
Remove `bool` keyword from C header files

### DIFF
--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -96,7 +96,7 @@ t8_cmesh_is_committed (const t8_cmesh_t cmesh);
  * \param [in] cmesh            This cmesh is examined.
  * \return                      True if the geometry of the cmesh is valid.
  */
-bool
+int
 t8_cmesh_validate_geometry (const t8_cmesh_t cmesh);
 
 /** After a cmesh is committed, check whether all trees in a cmesh do have positive volume.
@@ -107,7 +107,7 @@ t8_cmesh_validate_geometry (const t8_cmesh_t cmesh);
  *                              was called, do have positive geometric volume.
  *                              False otherwise.
  */
-bool
+int
 t8_cmesh_no_negative_volume (t8_cmesh_t cmesh);
 #endif
 

--- a/src/t8_cmesh/t8_cmesh.cxx
+++ b/src/t8_cmesh/t8_cmesh.cxx
@@ -123,7 +123,7 @@ t8_cmesh_is_committed (const t8_cmesh_t cmesh)
 }
 
 #ifdef T8_ENABLE_DEBUG
-bool
+int
 t8_cmesh_validate_geometry (const t8_cmesh_t cmesh)
 {
   /* Geometry handler is not constructed yet */
@@ -532,7 +532,7 @@ t8_cmesh_tree_vertices_negative_volume (const t8_eclass_t eclass, const double *
  * Returns true if all trees have positive volume. Returns also true if no geometries are
  * registered yet, since the volume computation depends on the used geometry.
  */
-bool
+int
 t8_cmesh_no_negative_volume (t8_cmesh_t cmesh)
 {
   bool res = false;

--- a/src/t8_geometry/t8_geometry.cxx
+++ b/src/t8_geometry/t8_geometry.cxx
@@ -64,7 +64,7 @@ t8_geometry_get_type (t8_cmesh_t cmesh, t8_gloidx_t gtreeid)
   return cmesh->geometry_handler->get_tree_geometry_type (cmesh, gtreeid);
 }
 
-bool
+int
 t8_geometry_tree_negative_volume (const t8_cmesh_t cmesh, const t8_gloidx_t gtreeid)
 {
   return cmesh->geometry_handler->tree_negative_volume (cmesh, gtreeid);

--- a/src/t8_geometry/t8_geometry.h
+++ b/src/t8_geometry/t8_geometry.h
@@ -30,7 +30,6 @@
 
 #include <t8.h>
 #include <t8_refcount.h>
-#include <stdbool.h>
 
 /** This enumeration contains all possible geometries. */
 typedef enum t8_geometry_type {
@@ -109,7 +108,7 @@ t8_geometry_get_type (t8_cmesh_t cmesh, t8_gloidx_t gtreeid);
  * \param[in] gtreeid     The global id of the tree
  * \return                True if the tree with id \ref gtreeid has a negative volume. False otherwise.  
  */
-bool
+int
 t8_geometry_tree_negative_volume (const t8_cmesh_t cmesh, const t8_gloidx_t gtreeid);
 
 T8_EXTERN_C_END ();

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.h
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.h
@@ -69,7 +69,7 @@ typedef void (*t8_geom_load_tree_data_fn) (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
 /**
  * Definition for the negative volume function.
  */
-typedef bool (*t8_geom_tree_negative_volume_fn) ();
+typedef int (*t8_geom_tree_negative_volume_fn) ();
 
 T8_EXTERN_C_BEGIN ();
 

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.h
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.h
@@ -66,6 +66,11 @@ typedef void (*t8_geom_analytic_jacobian_fn) (t8_cmesh_t cmesh, t8_gloidx_t gtre
  */
 typedef void (*t8_geom_load_tree_data_fn) (t8_cmesh_t cmesh, t8_gloidx_t gtreeid, const void **tree_data);
 
+/**
+ * Definition for the negative volume function.
+ */
+typedef int (*t8_geom_tree_negative_volume_fn) ();
+
 T8_EXTERN_C_BEGIN ();
 
 /** Destroy a geometry analytic object.

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.h
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.h
@@ -66,11 +66,6 @@ typedef void (*t8_geom_analytic_jacobian_fn) (t8_cmesh_t cmesh, t8_gloidx_t gtre
  */
 typedef void (*t8_geom_load_tree_data_fn) (t8_cmesh_t cmesh, t8_gloidx_t gtreeid, const void **tree_data);
 
-/**
- * Definition for the negative volume function.
- */
-typedef int (*t8_geom_tree_negative_volume_fn) ();
-
 T8_EXTERN_C_BEGIN ();
 
 /** Destroy a geometry analytic object.


### PR DESCRIPTION
**_Describe your changes here:_**

`bool` keyword in C header files creates trouble for the `Clang.jl` Julia package. The latter is needed for creating the Julia wrapper `T8code.jl`. This PR replaces `bool` with `int` in C header files.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
