### PR TITLE
Revert "Rename element ref coords integer coords"

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx
@@ -85,6 +85,20 @@ class t8_default_scheme_common_c: public t8_eclass_scheme_c {
   virtual t8_gloidx_t
   t8_element_count_leaves_from_root (int level) const;
 
+  /** Compute the integer coordinates of a given element vertex.
+   * The default scheme implements the Morton type SFCs. In these SFCs the
+   * elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and 
+   * L the maximum refinement level. 
+   * All element vertices have integer coordinates in this cube.
+   *   \param [in] elem    The element.
+   *   \param [in] vertex  The id of the vertex whose coordinates shall be computed.
+   *   \param [out] coords An array of at least as many integers as the element's dimension
+   *                      whose entries will be filled with the coordinates of \a vertex.
+   */
+  virtual void
+  t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
+    = 0;
+
   /** Convert points in the reference space of an element to points in the
    *  reference space of the tree.
    * 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -533,18 +533,21 @@ t8_default_scheme_hex_c::t8_element_anchor (const t8_element_t *elem, int coord[
   coord[2] = q->z;
 }
 
-static void
-t8_dhex_vertex_integer_coords (const p8est_quadrant_t *elem, int vertex, int coords[])
+void
+t8_default_scheme_hex_c::t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
 {
+  const p8est_quadrant_t *q1 = (const p8est_quadrant_t *) elem;
+  int len;
 
+  T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (0 <= vertex && vertex < 8);
   /* Get the length of the quadrant */
-  const int len = P8EST_QUADRANT_LEN (elem->level);
+  len = P8EST_QUADRANT_LEN (q1->level);
   /* Compute the x, y and z coordinates of the vertex depending on the
    * vertex number */
-  coords[0] = elem->x + (vertex & 1 ? 1 : 0) * len;
-  coords[1] = elem->y + (vertex & 2 ? 1 : 0) * len;
-  coords[2] = elem->z + (vertex & 4 ? 1 : 0) * len;
+  coords[0] = q1->x + (vertex & 1 ? 1 : 0) * len;
+  coords[1] = q1->y + (vertex & 2 ? 1 : 0) * len;
+  coords[2] = q1->z + (vertex & 4 ? 1 : 0) * len;
 }
 
 void
@@ -555,7 +558,7 @@ t8_default_scheme_hex_c::t8_element_vertex_reference_coords (const t8_element_t 
   T8_ASSERT (0 <= vertex && vertex < 8);
 
   int coords_int[3];
-  t8_dhex_vertex_integer_coords ((const p8est_quadrant_t *) elem, vertex, coords_int);
+  t8_element_vertex_coords (elem, vertex, coords_int);
 
   /* We divide the integer coordinates by the root length of the hex
    * to obtain the reference coordinates. */

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -511,6 +511,19 @@ struct t8_default_scheme_hex_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
+  /** Compute the integer coordinates of a given element vertex.
+   * The default scheme implements the Morton type SFCs. In these SFCs the
+   * elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and 
+   * L the maximum refinement level. 
+   * All element vertices have integer coordinates in this cube.
+   *   \param [in] elem   The element to be considered.
+   *   \param [in] vertex The id of the vertex whose coordinates shall be computed.
+   *   \param [out] coords An array of at least as many integers as the element's dimension
+   *                      whose entries will be filled with the coordinates of \a vertex.
+   */
+  virtual void
+  t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const;
+
   /** Compute the coordinates of a given element vertex inside a reference tree
    *  that is embedded into [0,1]^d (d = dimension).
    *   \param [in] elem   The element to be considered.

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx
@@ -287,6 +287,13 @@ t8_default_scheme_line_c::t8_element_last_descendant (const t8_element_t *elem, 
 }
 
 void
+t8_default_scheme_line_c::t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
+{
+  T8_ASSERT (t8_element_is_valid (elem));
+  t8_dline_vertex_coords ((const t8_dline_t *) elem, vertex, coords);
+}
+
+void
 t8_default_scheme_line_c::t8_element_vertex_reference_coords (const t8_element_t *elem, const int vertex,
                                                               double coords[]) const
 {

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx
@@ -518,6 +518,19 @@ struct t8_default_scheme_line_c: public t8_default_scheme_common_c
     return; /* suppresses compiler warning */
   }
 
+  /** Compute the integer coordinates of a given element vertex.
+   * The default scheme implements the Morton type SFCs. In these SFCs the
+   * elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and 
+   * L the maximum refinement level. 
+   * All element vertices have integer coordinates in this cube.
+   *   \param [in] elem    The element to be considered.
+   *   \param [in] vertex  The id of the vertex whose coordinates shall be computed.
+   *   \param [out] coords An array of at least as many integers as the element's dimension
+   *                       whose entries will be filled with the coordinates of \a vertex.
+   */
+  virtual void
+  t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const;
+
   /** Compute the coordinates of a given element vertex inside a reference tree
    *  that is embedded into [0,1]^d (d = dimension).
    *   \param [in] elem   The element to be considered.

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
@@ -322,7 +322,7 @@ t8_dline_last_descendant (const t8_dline_t *l, t8_dline_t *s, int level)
 }
 
 void
-t8_dline_vertex_integer_coords (const t8_dline_t *elem, const int vertex, int coords[])
+t8_dline_vertex_coords (const t8_dline_t *elem, const int vertex, int coords[])
 {
   T8_ASSERT (vertex == 0 || vertex == 1);
   if (vertex == 0) {
@@ -341,7 +341,7 @@ t8_dline_vertex_ref_coords (const t8_dline_t *elem, const int vertex, double coo
   T8_ASSERT (vertex == 0 || vertex == 1);
 
   /* Compute integer coordinates and divide by root length. */
-  t8_dline_vertex_integer_coords (elem, vertex, &coords_int);
+  t8_dline_vertex_coords (elem, vertex, &coords_int);
   coordinates[0] = coords_int / (double) T8_DLINE_ROOT_LEN;
 }
 

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
@@ -243,7 +243,7 @@ t8_dline_last_descendant (const t8_dline_t *l, t8_dline_t *s, int level);
  * \param [out] coords   The coordinates of the computed vertex
  */
 void
-t8_dline_vertex_integer_coords (const t8_dline_t *elem, const int vertex, int coords[]);
+t8_dline_vertex_coords (const t8_dline_t *elem, const int vertex, int coords[]);
 
 /** Compute the coordinates of a vertex of a line when the 
  * tree (level 0 line) is embedded in [0,1]^1.

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx
@@ -388,6 +388,13 @@ t8_default_scheme_prism_c::t8_element_anchor (const t8_element_t *elem, int anch
 }
 
 void
+t8_default_scheme_prism_c::t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
+{
+  T8_ASSERT (t8_element_is_valid (elem));
+  t8_dprism_vertex_coords ((const t8_dprism_t *) elem, vertex, coords);
+}
+
+void
 t8_default_scheme_prism_c::t8_element_vertex_reference_coords (const t8_element_t *elem, const int vertex,
                                                                double coords[]) const
 {

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.hxx
@@ -489,6 +489,17 @@ struct t8_default_scheme_prism_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
+  /** Compute the integer coordinates of a given element vertex. The default scheme implements the Morton type SFCs. 
+   * In these SFCs the elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and L the maximum 
+   * refinement level. All element vertices have integer coordinates in this cube.
+   *   \param [in] t        The element to be considered.
+   *   \param [in] vertex   The id of the vertex whose coordinates shall be computed.
+   *   \param [out] coords  An array of at least as many integers as the element's dimension whose entries will be 
+   *                        filled with the coordinates of \a vertex.
+   */
+  virtual void
+  t8_element_vertex_coords (const t8_element_t *t, int vertex, int coords[]) const;
+
   /** Compute the coordinates of a given element vertex inside a reference tree
    *  that is embedded into [0,1]^d (d = dimension).
    *   \param [in] elem   The element to be considered.
@@ -496,7 +507,7 @@ struct t8_default_scheme_prism_c: public t8_default_scheme_common_c
    *   \param [out] coords An array of at least as many doubles as the element's dimension
    *                      whose entries will be filled with the coordinates of \a vertex.
    *   \warning           coords should be zero-initialized, as only the first d coords will be set, but when used elsewhere
-   *                      all coords might be used.
+   *                      all coords might be used. 
    */
   virtual void
   t8_element_vertex_reference_coords (const t8_element_t *elem, const int vertex, double coords[]) const;

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -530,14 +530,14 @@ t8_dprism_corner_descendant (const t8_dprism_t *p, t8_dprism_t *s, int corner, i
 }
 
 void
-t8_dprism_vertex_integer_coords (const t8_dprism_t *elem, const int vertex, int coords[3])
+t8_dprism_vertex_coords (const t8_dprism_t *elem, const int vertex, int coords[3])
 {
   T8_ASSERT (vertex >= 0 && vertex < 6);
   T8_ASSERT (elem->line.level == elem->tri.level);
   /*Compute x and y coordinate */
-  t8_dtri_compute_integer_coords (&elem->tri, vertex % 3, coords);
+  t8_dtri_compute_coords (&elem->tri, vertex % 3, coords);
   /* Compute z coordinate coords[0] *= T8_DPRISM_ROOT_BY_DTRI_ROOT; */
-  t8_dline_vertex_integer_coords (&elem->line, vertex / 3, &coords[2]);
+  t8_dline_vertex_coords (&elem->line, vertex / 3, &coords[2]);
   coords[0] /= T8_DPRISM_ROOT_BY_DTRI_ROOT;
   coords[1] /= T8_DPRISM_ROOT_BY_DTRI_ROOT;
   coords[2] /= T8_DPRISM_ROOT_BY_DLINE_ROOT;
@@ -551,7 +551,7 @@ t8_dprism_vertex_ref_coords (const t8_dprism_t *elem, const int vertex, double c
   T8_ASSERT (vertex >= 0 && vertex < 6);
 
   /* Compute the integer coordinates in [0, root_len]^3 */
-  t8_dprism_vertex_integer_coords (elem, vertex, coords_int);
+  t8_dprism_vertex_coords (elem, vertex, coords_int);
 
   /* Divide by the root length. */
   coords[0] = coords_int[0] / (double) T8_DPRISM_ROOT_LEN;

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
@@ -284,7 +284,7 @@ t8_dprism_corner_descendant (const t8_dprism_t *p, t8_dprism_t *s, int corner, i
  * \param [out] coordinates An array of 3 t8_dprism_coord_t that will be filled with the coordinates of the vertex.
  */
 void
-t8_dprism_vertex_integer_coords (const t8_dprism_t *elem, int vertex, int coords[3]);
+t8_dprism_vertex_coords (const t8_dprism_t *elem, int vertex, int coords[3]);
 
 /** Compute the reference coordinates of a vertex of a prism when the 
  * tree (level 0) is embedded in \f$ [0,1]^3 \f$.

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -352,6 +352,13 @@ t8_default_scheme_pyramid_c::t8_element_anchor (const t8_element_t *elem, int an
 }
 
 void
+t8_default_scheme_pyramid_c::t8_element_vertex_coords (const t8_element_t *t, int vertex, int coords[]) const
+{
+  T8_ASSERT (t8_element_is_valid (t));
+  t8_dpyramid_compute_coords ((const t8_dpyramid_t *) t, vertex, coords);
+}
+
+void
 t8_default_scheme_pyramid_c::t8_element_nca (const t8_element_t *elem1, const t8_element_t *elem2,
                                              t8_element_t *nca) const
 {

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
@@ -481,6 +481,17 @@ struct t8_default_scheme_pyramid_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
+  /** Compute the integer coordinates of a given element vertex. The default scheme implements the Morton type SFCs. 
+   * In these SFCs the elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and  L the maximum 
+   * refinement level. All element vertices have integer coordinates in this cube.
+   *   \param [in] t      The element to be considered.
+   *   \param [in] vertex The id of the vertex whose coordinates shall be computed.
+   *   \param [out] coords An array of at least as many integers as the element's dimension
+   *                      whose entries will be filled with the coordinates of \a vertex.
+   */
+  virtual void
+  t8_element_vertex_coords (const t8_element_t *t, int vertex, int coords[]) const;
+
   /** Compute the coordinates of a given element vertex inside a reference tree
    *  that is embedded into [0,1]^d (d = dimension).
    *   \param [in] elem   The element to be considered.

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -1500,7 +1500,7 @@ t8_dpyramid_successor (const t8_dpyramid_t *elem, t8_dpyramid_t *succ, const int
 }
 
 void
-t8_dpyramid_compute_integer_coords (const t8_dpyramid_t *elem, const int vertex, int coords[])
+t8_dpyramid_compute_coords (const t8_dpyramid_t *elem, const int vertex, int coords[])
 {
   T8_ASSERT (0 <= vertex && vertex < T8_DPYRAMID_CORNERS);
 
@@ -1541,7 +1541,7 @@ t8_dpyramid_compute_integer_coords (const t8_dpyramid_t *elem, const int vertex,
   }
   else {
     T8_ASSERT (0 <= vertex && vertex < T8_DTET_CORNERS);
-    t8_dtet_compute_integer_coords (&(elem->pyramid), vertex, coords);
+    t8_dtet_compute_coords (&(elem->pyramid), vertex, coords);
   }
 }
 
@@ -1550,7 +1550,7 @@ t8_dpyramid_vertex_reference_coords (const t8_dpyramid_t *elem, const int vertex
 {
   int coords_int[3];
   T8_ASSERT (0 <= vertex && vertex < T8_DPYRAMID_CORNERS);
-  t8_dpyramid_compute_integer_coords (elem, vertex, coords_int);
+  t8_dpyramid_compute_coords (elem, vertex, coords_int);
   /*scale the coordinates onto the reference cube */
   coords[0] = coords_int[0] / (double) T8_DPYRAMID_ROOT_LEN;
   coords[1] = coords_int[1] / (double) T8_DPYRAMID_ROOT_LEN;

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
@@ -253,7 +253,7 @@ t8_dpyramid_last_descendant_face (const t8_dpyramid_t *p, const int face, t8_dpy
  * \param [out] coords An array of 3 t8_dpyramid_coord_t that will be filled with the coordinates of the vertex.
  */
 void
-t8_dpyramid_compute_integer_coords (const t8_dpyramid_t *elem, const int vertex, int coords[]);
+t8_dpyramid_compute_coords (const t8_dpyramid_t *elem, const int vertex, int coords[]);
 
 /** Compute the parent of a given pyramid
  * \param [in] p        Input pyramid.

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -665,16 +665,19 @@ t8_default_scheme_quad_c::t8_element_anchor (const t8_element_t *elem, int coord
 }
 
 void
-t8_dquad_vertex_integer_coords (const p4est_quadrant_t *elem, int vertex, int coords[])
+t8_default_scheme_quad_c::t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
 {
+  const p4est_quadrant_t *q1 = (const p4est_quadrant_t *) elem;
+  int len;
 
+  T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (0 <= vertex && vertex < 4);
   /* Get the length of the quadrant */
-  const int len = P4EST_QUADRANT_LEN (elem->level);
+  len = P4EST_QUADRANT_LEN (q1->level);
   /* Compute the x and y coordinates of the vertex depending on the
    * vertex number */
-  coords[0] = elem->x + (vertex & 1 ? 1 : 0) * len;
-  coords[1] = elem->y + (vertex & 2 ? 1 : 0) * len;
+  coords[0] = q1->x + (vertex & 1 ? 1 : 0) * len;
+  coords[1] = q1->y + (vertex & 2 ? 1 : 0) * len;
 }
 
 void
@@ -685,7 +688,7 @@ t8_default_scheme_quad_c::t8_element_vertex_reference_coords (const t8_element_t
   T8_ASSERT (0 <= vertex && vertex < 4);
 
   int coords_int[2];
-  t8_dquad_vertex_integer_coords ((const p4est_quadrant_t *) elem, vertex, coords_int);
+  t8_element_vertex_coords (elem, vertex, coords_int);
 
   /* We divide the integer coordinates by the root length of the quad
    * to obtain the reference coordinates. */

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -542,6 +542,19 @@ struct t8_default_scheme_quad_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
+  /** Compute the integer coordinates of a given element vertex.
+   * The default scheme implements the Morton type SFCs. In these SFCs the
+   * elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and 
+   * L the maximum refinement level. 
+   * All element vertices have integer coordinates in this cube.
+   *   \param [in] elem    The element to be considered.
+   *   \param [in] vertex  The id of the vertex whose coordinates shall be computed.
+   *   \param [out] coords An array of at least as many integers as the element's dimension
+   *                      whose entries will be filled with the coordinates of \a vertex.
+   */
+  virtual void
+  t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const;
+
   /** Compute the coordinates of a given element vertex inside a reference tree
    *  that is embedded into [0,1]^d (d = dimension).
    *   \param [in] elem   The element to be considered.

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx
@@ -451,6 +451,13 @@ t8_default_scheme_tet_c::t8_element_anchor (const t8_element_t *elem, int anchor
 }
 
 void
+t8_default_scheme_tet_c::t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
+{
+  T8_ASSERT (t8_element_is_valid (elem));
+  t8_dtet_compute_coords ((const t8_default_tet_t *) elem, vertex, coords);
+}
+
+void
 t8_default_scheme_tet_c::t8_element_vertex_reference_coords (const t8_element_t *elem, const int vertex,
                                                              double coords[]) const
 {

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.hxx
@@ -452,6 +452,17 @@ struct t8_default_scheme_tet_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
+  /** Compute the integer coordinates of a given element vertex. The default scheme implements the Morton type SFCs. 
+   * In these SFCs the elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and L the maximum 
+   * refinement level. All element vertices have integer coordinates in this cube.
+   *   \param [in] elem    The element to be considered.
+   *   \param [in] vertex  The id of the vertex whose coordinates shall be computed.
+   *   \param [out] coords An array of at least as many integers as the element's dimension
+   *                      whose entries will be filled with the coordinates of \a vertex.
+   */
+  virtual void
+  t8_element_vertex_coords (const t8_element_t *elem, const int vertex, int coords[]) const;
+
   /** Compute the coordinates of a given element vertex inside a reference tree
    *  that is embedded into [0,1]^d (d = dimension).
    *   \param [in] elem   The element to be considered.

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
@@ -41,7 +41,7 @@ T8_EXTERN_C_BEGIN ();
  * \param [out] coordinates An array of 3 t8_dtet_coord_t that will be filled with the coordinates of the vertex.
  */
 void
-t8_dtet_compute_integer_coords (const t8_dtet_t *elem, int vertex, t8_dtet_coord_t coordinates[3]);
+t8_dtet_compute_coords (const t8_dtet_t *elem, int vertex, t8_dtet_coord_t coordinates[3]);
 
 /** Compute the coordinates of a vertex of a tetrahedron when the 
  * tree (level 0 tetrahedron) is embedded in \f$ [0,1]^3 \f$.

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_dtri_to_dtet.h
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_dtri_to_dtet.h
@@ -72,7 +72,7 @@ T8_EXTERN_C_BEGIN ();
 #define t8_dtri_parent t8_dtet_parent
 #define t8_dtri_ancestor t8_dtet_ancestor
 #define t8_dtri_compute_all_coords t8_dtet_compute_all_coords
-#define t8_dtri_compute_integer_coords t8_dtet_compute_integer_coords
+#define t8_dtri_compute_coords t8_dtet_compute_coords
 #define t8_dtri_compute_vertex_ref_coords t8_dtet_compute_vertex_ref_coords
 #define t8_dtri_compute_reference_coords t8_dtet_compute_reference_coords
 #define t8_dtri_child t8_dtet_child

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.cxx
@@ -468,6 +468,13 @@ t8_default_scheme_tri_c::t8_element_anchor (const t8_element_t *elem, int anchor
 }
 
 void
+t8_default_scheme_tri_c::t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
+{
+  T8_ASSERT (t8_element_is_valid (elem));
+  t8_dtri_compute_coords ((const t8_dtri_t *) elem, vertex, coords);
+}
+
+void
 t8_default_scheme_tri_c::t8_element_vertex_reference_coords (const t8_element_t *elem, const int vertex,
                                                              double coords[]) const
 {

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx
@@ -446,6 +446,17 @@ struct t8_default_scheme_tri_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
+  /** Compute the integer coordinates of a given element vertex. The default scheme implements the Morton type SFCs. 
+   * In these SFCs the elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and L the maximum 
+   * refinement level. All element vertices have integer coordinates in this cube.
+   *   \param [in] elem      The element to be considered.
+   *   \param [in] vertex The id of the vertex whose coordinates shall be computed.
+   *   \param [out] coords An array of at least as many integers as the element's dimension whose entries will be 
+   *                          filled with the coordinates of \a vertex.
+   */
+  virtual void
+  t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const;
+
   /** Compute the coordinates of a given element vertex inside a reference tree
    *  that is embedded into [0,1]^d (d = dimension).
    *   \param [in] elem      The element to be considered.

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
@@ -286,7 +286,7 @@ t8_dtri_ancestor (const t8_dtri_t *t, int level, t8_dtri_t *ancestor)
 
 /* Compute the coordinates of a given vertex of a triangle/tet */
 void
-t8_dtri_compute_integer_coords (const t8_dtri_t *elem, const int vertex, t8_dtri_coord_t coordinates[T8_DTRI_DIM])
+t8_dtri_compute_coords (const t8_dtri_t *elem, const int vertex, t8_dtri_coord_t coordinates[T8_DTRI_DIM])
 {
   /* Calculate the vertex coordinates of a triangle/tetrahedron in relation to its orientation. Orientations are 
    * described here: https://doi.org/10.1137/15M1040049
@@ -359,7 +359,7 @@ t8_dtri_compute_vertex_ref_coords (const t8_dtri_t *elem, const int vertex, doub
   int coords_int[T8_DTRI_DIM];
   T8_ASSERT (0 <= vertex && vertex < T8_DTRI_CORNERS);
 
-  t8_dtri_compute_integer_coords (elem, vertex, coords_int);
+  t8_dtri_compute_coords (elem, vertex, coords_int);
   /* Since the integer coordinates are coordinates w.r.t to
    * the embedding into [0,T8_DTRI_ROOT_LEN]^d, we just need
    * to divide them by the root length. */
@@ -512,13 +512,13 @@ t8_dtri_compute_all_coords (const t8_dtri_t *elem, t8_dtri_coord_t coordinates[T
 #endif
 #ifdef T8_ENABLE_DEBUG
   /* We check whether the results are the same as with the
-   * t8_dtri_compute_integer_coords function.
+   * t8_dtri_compute_coords function.
    */
   {
     int ivertex;
     t8_dtri_coord_t coords[T8_DTRI_DIM];
     for (ivertex = 0; ivertex < T8_DTRI_FACES; ivertex++) {
-      t8_dtri_compute_integer_coords (elem, ivertex, coords);
+      t8_dtri_compute_coords (elem, ivertex, coords);
       T8_ASSERT (coords[0] == coordinates[ivertex][0]);
       T8_ASSERT (coords[1] == coordinates[ivertex][1]);
 #ifdef T8_DTRI_TO_DTET
@@ -560,7 +560,7 @@ t8_dtri_child (const t8_dtri_t *t, int childid, t8_dtri_t *child)
     vertex = t8_dtri_beyid_to_vertex[Bey_cid];
     /* i-th anchor coordinate of child is (X_(0,i)+X_(vertex,i))/2
      * where X_(i,j) is the j-th coordinate of t's ith node */
-    t8_dtri_compute_integer_coords (t, vertex, t_coordinates);
+    t8_dtri_compute_coords (t, vertex, t_coordinates);
     c->x = (t->x + t_coordinates[0]) >> 1;
     c->y = (t->y + t_coordinates[1]) >> 1;
 #ifdef T8_DTRI_TO_DTET

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
@@ -80,7 +80,7 @@ t8_dtri_ancestor (const t8_dtri_t *t, int level, t8_dtri_t *ancestor);
  * \param [out] coordinates An array of 2 t8_dtri_coord_t that will be filled with the coordinates of the vertex.
  */
 void
-t8_dtri_compute_integer_coords (const t8_dtri_t *elem, const int vertex, t8_dtri_coord_t coordinates[2]);
+t8_dtri_compute_coords (const t8_dtri_t *elem, const int vertex, t8_dtri_coord_t coordinates[2]);
 
 /** Compute the reference coordinates of a vertex of a triangle when the 
  * tree (level 0 triangle) is embedded in \f$ [0,1]^2 \f$.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.cxx
@@ -242,6 +242,13 @@ t8_default_scheme_vertex_c::t8_element_anchor (const t8_element_t *elem, int anc
 }
 
 void
+t8_default_scheme_vertex_c::t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const
+{
+  T8_ASSERT (t8_element_is_valid (elem));
+  t8_dvertex_vertex_coords ((const t8_dvertex_t *) elem, vertex, coords);
+}
+
+void
 t8_default_scheme_vertex_c::t8_element_vertex_reference_coords (const t8_element_t *elem, const int vertex,
                                                                 double coords[]) const
 {

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex_cxx.hxx
@@ -548,6 +548,19 @@ struct t8_default_scheme_vertex_c: public t8_default_scheme_common_c
   virtual void
   t8_element_anchor (const t8_element_t *elem, int anchor[3]) const;
 
+  /** Compute the integer coordinates of a given element vertex.
+   * The default scheme implements the Morton type SFCs. In these SFCs the
+   * elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and 
+   * L the maximum refinement level. 
+   * All element vertices have integer coordinates in this cube.
+   *   \param [in] elem    The element.
+   *   \param [in] vertex  The id of the vertex whose coordinates shall be computed.
+   *   \param [out] coords An array of at least as many integers as the element's dimension
+   *                      whose entries will be filled with the coordinates of \a vertex.
+   */
+  virtual void
+  t8_element_vertex_coords (const t8_element_t *elem, int vertex, int coords[]) const;
+
   /** Compute the coordinates of a given element vertex inside a reference tree
    *  that is embedded into [0,1]^d (d = dimension).
    *   \param [in] elem   The element to be considered.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.c
@@ -159,7 +159,7 @@ t8_dvertex_last_descendant (const t8_dvertex_t *v, t8_dvertex_t *s, int level)
 }
 
 void
-t8_dvertex_vertex_integer_coords (const t8_dvertex_t *elem, const int vertex, int coords[])
+t8_dvertex_vertex_coords (const t8_dvertex_t *elem, const int vertex, int coords[])
 {
   T8_ASSERT (vertex == 0);
 

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.h
@@ -194,7 +194,7 @@ t8_dvertex_last_descendant (const t8_dvertex_t *v, t8_dvertex_t *s, int level);
  * \param [out] coords   The coordinates of the computed vertex
  */
 void
-t8_dvertex_vertex_integer_coords (const t8_dvertex_t *elem, int vertex, int coords[]);
+t8_dvertex_vertex_coords (const t8_dvertex_t *elem, int vertex, int coords[]);
 
 /** Compute the coordinates of a vertex (always 0) inside the [0,1]^0 reference space.
  * \param [in] elem     vertex whose vertex is computed.


### PR DESCRIPTION
Reverts DLR-AMR/t8code#832
`t8_element_vertex_coords` wasn't needed in the past but in order to enable transitioning it's  a necessary function.