### PR TITLE
Add header for subelements

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,6 +18,7 @@ defaulthexincludedir = $(schemesdefaultincludedir)/t8_default_hex
 defaulttetincludedir = $(schemesdefaultincludedir)/t8_default_tet
 defaultprismincludedir = $(schemesdefaultincludedir)/t8_default_prism
 defaultpyramidincludedir = $(schemesdefaultincludedir)/t8_default_pyramid
+schemessubelementsincludedir = $(includedir)/t8_schemes/t8_subelements
 
 libt8_generated_headers = src/t8_config.h
 libt8_installed_headers = \
@@ -55,7 +56,8 @@ libt8_installed_headers_forest = \
   src/t8_forest/t8_forest_adapt.h \
   src/t8_forest/t8_forest_vtk.h \
   src/t8_forest/t8_forest_to_vtkUnstructured.hxx \
-  src/t8_forest/t8_forest_iterate.h src/t8_forest/t8_forest_partition.h
+  src/t8_forest/t8_forest_iterate.h src/t8_forest/t8_forest_partition.h \
+  src/t8_forest/t8_forest_subpatch.hxx
 libt8_installed_headers_geometry = \
   src/t8_geometry/t8_geometry.h \
   src/t8_geometry/t8_geometry_handler.hxx \
@@ -92,6 +94,9 @@ libt8_installed_headers_default_hex =
 libt8_installed_headers_default_tet =
 libt8_installed_headers_default_prism =
 libt8_installed_headers_default_pyramid =
+libt8_installed_headers_schemes_subelements = \
+  src/t8_schemes/t8_subelements/t8_subelements_cxx.hxx \
+  src/t8_schemes/t8_subelements/t8_subelements.hxx
 libt8_internal_headers = \
   src/t8_cmesh/t8_cmesh_trees.h src/t8_cmesh/t8_cmesh_partition.h \
   src/t8_cmesh/t8_cmesh_copy.h \
@@ -139,6 +144,7 @@ libt8_compiled_sources = \
   src/t8_forest/t8_forest_partition.cxx src/t8_forest/t8_forest_cxx.cxx \
   src/t8_forest/t8_forest_private.c src/t8_forest/t8_forest_vtk.cxx \
   src/t8_forest/t8_forest_ghost.cxx src/t8_forest/t8_forest_iterate.cxx \
+  src/t8_forest/t8_forest_subpatch.cxx \
   src/t8_version.c \
   src/t8_vtk.c src/t8_forest/t8_forest_balance.cxx \
   src/t8_forest/t8_forest_netcdf.cxx \
@@ -147,7 +153,8 @@ libt8_compiled_sources = \
   src/t8_vtk/t8_vtk_polydata.cxx \
   src/t8_vtk/t8_vtk_unstructured.cxx \
   src/t8_vtk/t8_vtk_parallel.cxx \
-  src/t8_vtk/t8_vtk_reader.cxx
+  src/t8_vtk/t8_vtk_reader.cxx \
+  src/t8_schemes/t8_subelements/t8_subelements_cxx.cxx 
 
 
 # this variable is used for headers that are not publicly installed
@@ -188,5 +195,6 @@ dist_defaulthexinclude_HEADERS = $(libt8_installed_headers_default_hex)
 dist_defaulttetinclude_HEADERS = $(libt8_installed_headers_default_tet)
 dist_defaultprisminclude_HEADERS = $(libt8_installed_headers_default_prism)
 dist_defaultpyramidinclude_HEADERS = $(libt8_installed_headers_default_pyramid)
+dist_schemessubelementsinclude_HEADERS = $(libt8_installed_headers_schemes_subelements)
 
 AM_CPPFLAGS += -I@top_srcdir@/src @T8_SC_CPPFLAGS@ @T8_P4EST_CPPFLAGS@

--- a/src/t8_schemes/t8_subelements/t8_subelements_cxx.hxx
+++ b/src/t8_schemes/t8_subelements/t8_subelements_cxx.hxx
@@ -1,0 +1,848 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#ifndef T8_SUBELEMENT_CXX_HXX
+#define T8_SUBELEMENT_CXX_HXX
+
+#include <t8_element.h>
+#include <t8_element_cxx.hxx>
+#include <t8_eclass.h>
+#include <sc_functions.h>
+
+typedef struct 
+{
+  t8_element_t *elem;
+  /* stores transition cell information (default for non-subelements is 0 and for subelements it is != 0 - is therefore used as a is_subelement check)
+     what type of subelement is stored here? Removing hanging nodes, subpatches, which parent cell type? */
+  int                 subelement_type; // TODO: enum?
+  /* For subelements number of type, for subpatches dimension (default for non-subelements is 0) */ //TODO: make pair out of cell_type and transition_type?
+  int                 transition_type;
+  /* stores subelement information (default for non-subelements is 0) */
+  int                 subelement_id;
+} t8_element_with_subelements;
+
+struct t8_subelement_scheme_c: public t8_eclass_scheme_c
+{
+ public:
+  t8_eclass_scheme_c *scheme;
+  /** The table for a particular implementation of an element class. */
+
+  /** Constructor. */
+  t8_subelement_scheme_c (t8_eclass_scheme_c *scheme);
+
+  ~t8_subelement_scheme_c ();
+
+  /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
+   * Returns false otherwise.
+   * \return                    non-zero if there is one element in the tree that does not refine into 2^dim children.
+   */
+  virtual int
+  t8_element_refines_irregular (void) const;
+
+  /** Return the maximum allowed level for any element of a given class.
+   * \return                      The maximum allowed level for elements of class \b ts.
+   */
+  virtual int
+  t8_element_maxlevel (void) const;
+
+  /** Return the level of a particular element.
+   * \param [in] elem    The element whose level should be returned.
+   * \return             The level of \b elem.
+   */
+  virtual int
+  t8_element_level (const t8_element_t *elem) const;
+
+  /** Copy all entries of \b source to \b dest. \b dest must be an existing
+   *  element. No memory is allocated by this function.
+   * \param [in] source The element whose entries will be copied to \b dest.
+   * \param [in,out] dest This element's entries will be overwrite with the
+   *                    entries of \b source.
+   * \note \a source and \a dest may point to the same element.
+   */
+  virtual void
+  t8_element_copy (const t8_element_t *source, t8_element_t *dest) const;
+
+  /** Compare two elements.
+   * \param [in] elem1  The first element.
+   * \param [in] elem2  The second element.
+   * \return       negative if elem1 < elem2, zero if elem1 equals elem2
+   *               and positive if elem1 > elem2.
+   *  If elem2 is a copy of elem1 then the elements are equal.
+   */
+  virtual int
+  t8_element_compare (const t8_element_t *elem1, const t8_element_t *elem2) const;
+
+  /** Check if two elements are equal.
+  * \param [in] ts     Implementation of a class scheme.
+  * \param [in] elem1  The first element.
+  * \param [in] elem2  The second element.
+  * \return            1 if the elements are equal, 0 if they are not equal
+  */
+  virtual int
+  t8_element_equal (const t8_element_t *elem1, const t8_element_t *elem2) const;
+
+  /** Compute the parent of a given element \b elem and store it in \b parent.
+   *  \b parent needs to be an existing element. No memory is allocated by this function.
+   *  \b elem and \b parent can point to the same element, then the entries of
+   *  \b elem are overwritten by the ones of its parent.
+   * \param [in] elem   The element whose parent will be computed.
+   * \param [in,out] parent This element's entries will be overwritten by those
+   *                    of \b elem's parent.
+   *                    The storage for this element must exist
+   *                    and match the element class of the parent.
+   *                    For a pyramid, for example, it may be either a
+   *                    tetrahedron or a pyramid depending on \b elem's childid.
+   */
+  virtual void
+  t8_element_parent (const t8_element_t *elem, t8_element_t *parent) const;
+
+  /** Compute the number of siblings of an element. That is the number of 
+   * Children of its parent.
+   * \param [in] elem The element.
+   * \return          The number of siblings of \a element.
+   * Note that this number is >= 1, since we count the element itself as a sibling.
+   */
+  virtual int
+  t8_element_num_siblings (const t8_element_t *elem) const;
+
+  /** Compute a specific sibling of a given element \b elem and store it in \b sibling.
+   *  \b sibling needs to be an existing element. No memory is allocated by this function.
+   *  \b elem and \b sibling can point to the same element, then the entries of
+   *  \b elem are overwritten by the ones of its sibid-th sibling.
+   * \param [in] elem   The element whose sibling will be computed.
+   * \param [in] sibid  The id of the sibling computed.
+   * \param [in,out] sibling This element's entries will be overwritten by those
+   *                    of \b elem's sibid-th sibling.
+   *                    The storage for this element must exist
+   *                    and match the element class of the sibling.
+   */
+  virtual void
+  t8_element_sibling (const t8_element_t *elem, int sibid, t8_element_t *sibling) const;
+
+  /** Compute the number of corners of a given element.
+   * \param [in] elem The element.
+   * \return          The number of corners of \a elem.
+   */
+  virtual int
+  t8_element_num_corners (const t8_element_t *elem) const;
+
+  /** Compute the number of faces of a given element.
+   * \param [in] elem The element.
+   * \return          The number of faces of \a elem.
+   */
+  virtual int
+  t8_element_num_faces (const t8_element_t *elem) const;
+
+  /** Compute the maximum number of faces of a given element and all of its
+   *  descendants.
+   * \param [in] elem The element.
+   * \return          The maximum number of faces of \a elem and its descendants.
+   */
+  virtual int
+  t8_element_max_num_faces (const t8_element_t *elem) const;
+
+  /** Return the number of children of an element when it is refined.
+   * \param [in] elem   The element whose number of children is returned.
+   * \return            The number of children of \a elem if it is to be refined.
+   */
+  virtual int
+  t8_element_num_children (const t8_element_t *elem) const;
+
+  /** Return the number of children of an element's face when the element is refined.
+   * \param [in] elem   The element whose face is considered.
+   * \param [in] face   A face of \a elem.
+   * \return            The number of children of \a face if \a elem is to be refined.
+   */
+  virtual int
+  t8_element_num_face_children (const t8_element_t *elem, int face) const;
+
+  /** Return the corner number of an element's face corner.
+   * Example quad: 2 x --- x 3
+   *                 |     |
+   *                 |     |   face 1
+   *               0 x --- x 1
+   *      Thus for face = 1 the output is: corner=0 : 1, corner=1: 3
+   *
+   * \param [in] element  The element.
+   * \param [in] face     A face index for \a element.
+   * \param [in] corner   A corner index for the face 0 <= \a corner < num_face_corners.
+   * \return              The corner number of the \a corner-th vertex of \a face.
+   *
+   * The order in which the corners must be given is determined by the eclass of \a element:
+   * LINE/QUAD/TRIANGLE:  No specific order.
+   * HEX               :  In Z-order of the face starting with the lowest corner number.
+   * TET               :  Starting with the lowest corner number counterclockwise as seen from
+   *                      'outside' of the element.
+   */
+  virtual int
+  t8_element_get_face_corner (const t8_element_t *element, int face, int corner) const;
+
+  /** Return the face numbers of the faces sharing an element's corner.
+   * Example quad: 2 x --- x 3
+   *                 |     |
+   *                 |     |   face 1
+   *               0 x --- x 1
+   *                  face 2
+   *      Thus for corner = 1 the output is: face=0 : 2, face=1: 1
+   * \param [in] element  The element.
+   * \param [in] corner   A corner index for the face.
+   * \param [in] face     A face index for \a corner.
+   * \return              The face number of the \a face-th face at \a corner.
+   */
+  virtual int
+  t8_element_get_corner_face (const t8_element_t *element, int corner, int face) const;
+
+  /** Construct the child element of a given number.
+   * \param [in] elem     This must be a valid element, bigger than maxlevel.
+   * \param [in] childid  The number of the child to construct.
+   * \param [in,out] child        The storage for this element must exist
+   *                              and match the element class of the child.
+   *                              For a pyramid, for example, it may be either a
+   *                              tetrahedron or a pyramid depending on \a childid.
+   *                              This can be checked by \a t8_element_child_eclass.
+   *                              On output, a valid element.
+   * It is valid to call this function with elem = child.
+   * \see t8_element_child_eclass
+   */
+  virtual void
+  t8_element_child (const t8_element_t *elem, int childid, t8_element_t *child) const;
+
+  /** Construct all children of a given element.
+   * \param [in] elem     This must be a valid element, bigger than maxlevel.
+   * \param [in] length   The length of the output array \a c must match
+   *                      the number of children.
+   * \param [in,out] c    The storage for these \a length elements must exist
+   *                      and match the element class in the children's ordering.
+   *                      On output, all children are valid.
+   * It is valid to call this function with elem = c[0].
+   * \see t8_element_num_children
+   * \see t8_element_child_eclass
+   */
+  virtual void
+  t8_element_children (const t8_element_t *elem, int length, t8_element_t *c[]) const;
+
+  /** Compute the child id of an element.
+   * \param [in] elem     This must be a valid element.
+   * \return              The child id of elem.
+   */
+  virtual int
+  t8_element_child_id (const t8_element_t *elem) const;
+
+  /** Compute the ancestor id of an element, that is the child id
+   * at a given level.
+   * \param [in] elem     This must be a valid element.
+   * \param [in] level    A refinement level. Must satisfy \a level < elem.level
+   * \return              The child_id of \a elem in regard to its \a level ancestor.
+   */
+  virtual int
+  t8_element_ancestor_id (const t8_element_t *elem, int level) const;
+
+  /** Query whether a given set of elements is a family or not.
+   * \param [in] fam      An array of as many elements as an element of class
+   *                      \b ts has siblings.
+   * \return              Zero if \b fam is not a family, nonzero if it is.
+   * \note level 0 elements do not form a family.
+   */
+  virtual int
+  t8_element_is_family (t8_element_t *const *fam) const;
+
+  /** Compute the nearest common ancestor of two elements. That is,
+   * the element with highest level that still has both given elements as
+   * descendants.
+   * \param [in] elem1    The first of the two input elements.
+   * \param [in] elem2    The second of the two input elements.
+   * \param [in,out] nca  The storage for this element must exist
+   *                      and match the element class of the child.
+   *                      On output the unique nearest common ancestor of
+   *                      \b elem1 and \b elem2.
+   */
+  virtual void
+  t8_element_nca (const t8_element_t *elem1, const t8_element_t *elem2, t8_element_t *nca) const;
+
+  /** Compute the shape of the face of an element.
+   * \param [in] elem     The element.
+   * \param [in] face     A face of \a elem.
+   * \return              The element shape of the face.
+   * I.e. T8_ECLASS_LINE for quads, T8_ECLASS_TRIANGLE for tets
+   *      and depending on the face number either T8_ECLASS_QUAD or
+   *      T8_ECLASS_TRIANGLE for prisms.
+   */
+  virtual t8_element_shape_t
+  t8_element_face_shape (const t8_element_t *elem, int face) const;
+
+  /** Given an element and a face of the element, compute all children of
+   * the element that touch the face.
+   * \param [in] elem     The element.
+   * \param [in] face     A face of \a elem.
+   * \param [in,out] children Allocated elements, in which the children of \a elem
+   *                      that share a face with \a face are stored.
+   *                      They will be stored in order of their linear id.
+   * \param [in] num_children The number of elements in \a children. Must match
+   *                      the number of children that touch \a face.
+   *                      \ref t8_element_num_face_children
+   * \param [in,out] child_indices If not NULL, an array of num_children integers must be given,
+   *                      on output its i-th entry is the child_id of the i-th face_child.
+   * It is valid to call this function with elem = children[0].
+   */
+  virtual void
+  t8_element_children_at_face (const t8_element_t *elem, int face, t8_element_t *children[], int num_children,
+                               int *child_indices) const;
+
+  /** Given a face of an element and a child number of a child of that face, return the face number
+   * of the child of the element that matches the child face.
+   * \verbatim
+      x ---- x   x      x           x ---- x
+      |      |   |      |           |   |  | <-- f
+      |      |   |      x           |   x--x
+      |      |   |                  |      |
+      x ---- x   x                  x ---- x
+       elem    face  face_child    Returns the face number f
+     \endverbatim
+
+   * \param [in]  elem    The element.
+   * \param [in]  face    Then number of the face.
+   * \param [in]  face_child A number 0 <= \a face_child < num_face_children,
+   *                      specifying a child of \a elem that shares a face with \a face.
+   *                      These children are counted in linear order. This coincides with
+   *                      the order of children from a call to \ref t8_element_children_at_face.
+   * \return              The face number of the face of a child of \a elem
+   *                      that coincides with \a face_child.
+   */
+  virtual int
+  t8_element_face_child_face (const t8_element_t *elem, int face, int face_child) const;
+
+  /** Given a face of an element return the face number
+     * of the parent of the element that matches the element's face. Or return -1 if
+     * no face of the parent matches the face.
+
+     * \param [in]  elem    The element.
+     * \param [in]  face    Then number of the face.
+     * \return              If \a face of \a elem is also a face of \a elem's parent,
+     *                      the face number of this face. Otherwise -1.
+     * \note For the root element this function always returns \a face.
+     */
+  virtual int
+  t8_element_face_parent_face (const t8_element_t *elem, int face) const;
+
+  /** Given an element and a face of this element. If the face lies on the
+   *  tree boundary, return the face number of the tree face.
+   *  If not the return value is arbitrary.
+   *  You can call \ref t8_element_is_root_boundary to query whether the face is
+   *  at the tree boundary.
+   * \param [in] elem     The element.
+   * \param [in] face     The index of a face of \a elem.
+   * \return The index of the tree face that \a face is a subface of, if
+   *         \a face is on a tree boundary.
+   *         Any arbitrary integer if \a is not at a tree boundary.
+   * \warning The return value may look like a valid face of the tree even if 
+   *   the element does not lie on the root boundary.
+   */
+  virtual int
+  t8_element_tree_face (const t8_element_t *elem, int face) const;
+
+  /** Suppose we have two trees that share a common face f.
+   *  Given an element e that is a subface of f in one of the trees
+   *  and given the orientation of the tree connection, construct the face
+   *  element of the respective tree neighbor that logically coincides with e
+   *  but lies in the coordinate system of the neighbor tree.
+   *  \param [in] elem1     The face element.
+   *  \param [in,out] elem2 On return the face element \a elem1 with respective
+   *                        to the coordinate system of the other tree.
+   *  \param [in] orientation The orientation of the tree-tree connection.
+   *                        \see t8_cmesh_set_join
+   *  \param [in] sign      Depending on the topological orientation of the two tree faces,
+   *                        either 0 (both faces have opposite orientation)
+   *                        or 1 (both faces have the same top. orientattion).
+   *                        \ref t8_eclass_face_orientation
+   *  \param [in] is_smaller_face Flag to declare whether \a elem1 belongs to
+   *                        the smaller face. A face f of tree T is smaller than
+   *                        f' of T' if either the eclass of T is smaller or if
+   *                        the classes are equal and f<f'. The orientation is
+   *                        defined in relation to the smaller face.
+   * \note \a elem1 and \a elem2 may point to the same element.
+   */
+  virtual void
+  t8_element_transform_face (const t8_element_t *elem1, t8_element_t *elem2, int orientation, int sign,
+                             int is_smaller_face) const;
+
+  /** Given a boundary face inside a root tree's face construct
+   *  the element inside the root tree that has the given face as a
+   *  face.
+   * \param [in] face     A face element.
+   * \param [in] face_scheme The scheme for the face element.
+   * \param [in,out] elem An allocated element. The entries will be filled with
+   *                      the data of the element that has \a face as a face and
+   *                      lies within the root tree.
+   * \param [in] root_face The index of the face of the root tree in which \a face
+   *                      lies.
+   * \return              The face number of the face of \a elem that coincides
+   *                      with \a face.
+   */
+  virtual int
+  t8_element_extrude_face (const t8_element_t *face, const t8_eclass_scheme_c *face_scheme, t8_element_t *elem,
+                           int root_face) const;
+
+  /** Construct the boundary element at a specific face.
+   * \param [in] elem     The input element.
+   * \param [in] face     The index of the face of which to construct the
+   *                      boundary element.
+   * \param [in,out] boundary An allocated element of dimension of \a element
+   *                      minus 1. The entries will be filled with the entries
+   *                      of the face of \a element.
+   * \param [in] boundary_scheme The scheme for the eclass of the boundary face.
+   * If \a elem is of class T8_ECLASS_VERTEX, then \a boundary must be NULL
+   * and will not be modified.
+   */
+  virtual void
+  t8_element_boundary_face (const t8_element_t *elem, int face, t8_element_t *boundary,
+                            const t8_eclass_scheme_c *boundary_scheme) const;
+
+  /** Construct the first descendant of an element at a given level that touches a given face.
+   * \param [in] elem      The input element.
+   * \param [in] face      A face of \a elem.
+   * \param [in, out] first_desc An allocated element. This element's data will be
+   *                       filled with the data of the first descendant of \a elem
+   *                       that shares a face with \a face.
+   * \param [in] level     The level, at which the first descendant is constructed
+   */
+  virtual void
+  t8_element_first_descendant_face (const t8_element_t *elem, int face, t8_element_t *first_desc, int level) const;
+
+  /** Construct the last descendant of an element at a given level that touches a given face.
+   * \param [in] elem      The input element.
+   * \param [in] face      A face of \a elem.
+   * \param [in, out] last_desc An allocated element. This element's data will be
+   *                       filled with the data of the last descendant of \a elem
+   *                       that shares a face with \a face.
+   * \param [in] level     The level, at which the last descendant is constructed
+   */
+  virtual void
+  t8_element_last_descendant_face (const t8_element_t *elem, int face, t8_element_t *last_desc, int level) const;
+
+  /** Compute whether a given element shares a given face with its root tree.
+   * \param [in] elem     The input element.
+   * \param [in] face     A face of \a elem.
+   * \return              True if \a face is a subface of the element's root element.
+   * \note You can compute the corresponding face number of the tree via \ref t8_element_tree_face.
+   */
+  virtual int
+  t8_element_is_root_boundary (const t8_element_t *elem, int face) const;
+
+  /** Construct the face neighbor of a given element if this face neighbor
+   * is inside the root tree. Return 0 otherwise.
+   * \param [in] elem The element to be considered.
+   * \param [in,out] neigh If the face neighbor of \a elem along \a face is inside
+   *                  the root tree, this element's data is filled with the
+   *                  data of the face neighbor. Otherwise the data can be modified
+   *                  arbitrarily.
+   * \param [in] face The number of the face along which the neighbor should be
+   *                  constructed.
+   * \param [out] neigh_face The number of \a face as viewed from \a neigh.
+   *                  An arbitrary value, if the neighbor is not inside the root tree.
+   * \return          True if \a neigh is inside the root tree.
+   *                  False if not. In this case \a neigh's data can be arbitrary
+   *                  on output.
+   */
+  virtual int
+  t8_element_face_neighbor_inside (const t8_element_t *elem, t8_element_t *neigh, int face, int *neigh_face) const;
+
+  /** Return the shape of an allocated element according its type.
+    *  For example, a child of an element can be an element of a different shape
+    *  and has to be handled differently - according to its shape.
+    *  \param [in] elem     The element to be considered
+    *  \return              The shape of the element as an eclass
+   */
+  virtual t8_element_shape_t
+  t8_element_shape (const t8_element_t *elem) const;
+
+  /** Initialize the entries of an allocated element according to a
+   *  given linear id in a uniform refinement.
+   * \param [in,out] elem The element whose entries will be set.
+   * \param [in] level    The level of the uniform refinement to consider.
+   * \param [in] id       The linear id.
+   *                      id must fulfil 0 <= id < 'number of feaves in the uniform refinement'
+   */
+  virtual void
+  t8_element_set_linear_id (t8_element_t *elem, int level, t8_linearidx_t id) const;
+
+  /** Compute the linear id of a given element in a hypothetical uniform
+   * refinement of a given level.
+   * \param [in] elem     The element whose id we compute.
+   * \param [in] level    The level of the uniform refinement to consider.
+   * \return              The linear id of the element.
+   */
+  virtual t8_linearidx_t
+  t8_element_get_linear_id (const t8_element_t *elem, int level) const;
+
+  /** Compute the first descendant of a given element.
+   * \param [in] elem     The element whose descendant is computed.
+   * \param [out] desc    The first element in a uniform refinement of \a elem
+   *                      of the given level.
+   * \param [in] level    The level, at which the descendant is computed.
+   */
+  virtual void
+  t8_element_first_descendant (const t8_element_t *elem, t8_element_t *desc, int level) const;
+
+  /** Compute the last descendant of a given element.
+   * \param [in] elem     The element whose descendant is computed.
+   * \param [out] desc    The last element in a uniform refinement of \a elem
+   *                      of the given level.
+   * \param [in] level    The level, at which the descendant is computed.
+   */
+  virtual void
+  t8_element_last_descendant (const t8_element_t *elem, t8_element_t *desc, int level) const;
+
+  /** Construct the successor in a uniform refinement of a given element.
+   * \param [in] elem1    The element whose successor should be constructed.
+   * \param [in,out] elem2  The element whose entries will be set.
+   * \param [in] level    The level of the uniform refinement to consider.
+   */
+  virtual void
+  t8_element_successor (const t8_element_t *t, t8_element_t *s) const;
+
+  /** Compute the coordinates of a given element vertex inside a reference tree
+   *  that is embedded into [0,1]^d (d = dimension).
+   *   \param [in] t      The element to be considered.
+   *   \param [in] vertex The id of the vertex whose coordinates shall be computed.
+   *   \param [out] coords An array of at least as many doubles as the element's dimension
+   *                      whose entries will be filled with the coordinates of \a vertex.
+   */
+  virtual void
+  t8_element_vertex_reference_coords (const t8_element_t *t, const int vertex, double coords[]) const;
+
+  /** Convert a point in the reference space of an element to a point in the
+   *  reference space of the tree.
+   * 
+   * \param [in] elem         The element.
+   * \param [in] coords_input The coordinates of the point in the reference space of the element.
+   * \param [in] user_data    User data.
+   * \param [out] out_coords  The coordinates of the point in the reference space of the tree.
+   */
+  virtual void
+  t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords, const size_t num_coords,
+                               double *out_coords) const;
+
+  /** Count how many leaf descendants of a given uniform level an element would produce.
+   * \param [in] t     The element to be checked.
+   * \param [in] level A refinement level.
+   * \return Suppose \a t is uniformly refined up to level \a level. The return value
+   * is the resulting number of elements (of the given level).
+   * If \a level < t8_element_level(t), the return value should be 0.
+   *
+   * Example: If \a t is a line element that refines into 2 line elements on each level,
+   *  then the return value is max(0, 2^{\a level - level(\a t)}).
+   *  Thus, if \a t's level is 0, and \a level = 3, the return value is 2^3 = 8.
+   */
+  virtual t8_gloidx_t
+  t8_element_count_leaves (const t8_element_t *t, int level) const;
+
+  /** Count how many leaf descendants of a given uniform level the root element will produce.
+   * \param [in] level A refinement level.
+   * \return The value of \ref t8_element_count_feaves if the input element
+   *      is the root (level 0) element.
+   *
+   * This is a convenience function, and can be implemented via
+   * \ref t8_element_count_feaves.
+   */
+  virtual t8_gloidx_t
+  t8_element_count_leaves_from_root (int level) const;
+
+#ifdef T8_ENABLE_DEBUG
+  /** Query whether a given element can be considered as 'valid' and it is
+   *  safe to perform any of the above algorithms on it.
+   *  For example this could mean that all coordinates are in valid ranges
+   *  and other membervariables do have meaningful values.
+   * \param [in]      elem  The element to be checked.
+   * \return          True if \a elem is safe to use. False otherwise.
+   * \note            An element that is constructed with \ref t8_element_new
+   *                  must pass this test.
+   * \note            An element for which \ref t8_element_init was called must pass
+   *                  this test.
+   * \note            This function is used for debugging to catch certain errors.
+   *                  These can for example occur when an element points to a region
+   *                  of memory which should not be interpreted as an element.
+   * \note            We recommend to use the assertion T8_ASSERT (t8_element_is_valid (elem))
+   *                  in the implementation of each of the functions in this file.
+   */
+  virtual int
+  t8_element_is_valid (const t8_element_t *elem) const;
+
+  /**
+ * Print a given element. For a example for a triangle print the coordinates
+ * and the level of the triangle. This function is only available in the
+ * debugging configuration. 
+ * 
+ * \param [in]        elem  The element to print
+ */
+  virtual void
+  t8_element_debug_print (const t8_element_t *elem) const;
+
+  /**
+ * \brief Fill a string with readable information about the element
+ * 
+ * \param[in] elem The element to translate into human-readable information
+ * \param[in, out] debug_string The string to fill. 
+ */
+  virtual void
+  t8_element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
+
+#endif
+
+  /** Allocate memory for an array of elements of a given class and initialize them.
+   * \param [in] length   The number of elements to be allocated.
+   * \param [in,out] elems On input an array of \b length many unallocated
+   *                      element pointers.
+   *                      On output all these pointers will point to an allocated
+   *                      and initialized element.
+   * \note Not every element that is created in t8code will be created by a call
+   * to this function. However, if an element is not created using \ref t8_element_new,
+   * then it is guaranteed that \ref t8_element_init is called on it.
+   * \note In debugging mode, an element that was created with \ref t8_element_new
+   * must pass \ref t8_element_is_valid.
+   * \note If an element was created by \ref t8_element_new then \ref t8_element_init
+   * may not be called for it. Thus, \ref t8_element_new should initialize an element
+   * in the same way as a call to \ref t8_element_init would.
+   * \see t8_element_init
+   * \see t8_element_is_valid
+   */
+  /* TODO: would it be better to directly allocate an array of elements,
+   *       not element pointers? */
+  virtual void
+  t8_element_new (int length, t8_element_t **elem) const;
+
+  /** Initialize an array of allocated elements.
+   * \param [in] length   The number of elements to be initialized.
+   * \param [in,out] elems On input an array of \b length many allocated
+   *                       elements.
+   * \param [in] called_new True if the elements in \a elem were created by a call
+   *                       to \ref t8_element_new. False if no element in \a elem
+   *                       was created in this way. The case that only some elements
+   *                       were created by \ref t8_element_new should never occur.
+   * \note In debugging mode, an element that was passed to \ref t8_element_init
+   * must pass \ref t8_element_is_valid.
+   * \note If an element was created by \ref t8_element_new then \ref t8_element_init
+   * may not be called for it. Thus, \ref t8_element_new should initialize an element
+   * in the same way as a call to \ref t8_element_init would.
+   * Thus, if \a called_new is true this function should usually do nothing.
+   * \see t8_element_new
+   * \see t8_element_is_valid
+   */
+  virtual void
+  t8_element_init (int length, t8_element_t *elem) const;
+
+  /** Deinitialize an array of allocated elements.
+   * \param [in] length   The number of elements to be deinitialized.
+   * \param [in,out] elems On input an array of \b length many allocated
+   *                       and initialized elements, on output an array of
+   *                       \b length many allocated, but not initialized elements.
+   * \note Call this function if you called t8_element_init on the element pointers.
+   * \see t8_element_init
+   */
+  virtual void
+  t8_element_deinit (int length, t8_element_t *elem) const;
+
+  /** Deallocate an array of elements.
+   * \param [in] length   The number of elements in the array.
+   * \param [in,out] elem On input an array of \b length many allocated
+   *                      element pointers.
+   *                      On output all these pointers will be freed.
+   *                      \b elem itself will not be freed by this function.
+   * \see t8_element_new
+   */
+  virtual void
+  t8_element_destroy (int length, t8_element_t **elem) const;
+
+  /** create the root element
+   * \param [in,out] elem The element that is filled with the root
+   */
+  virtual void
+  t8_element_root (t8_element_t *elem) const;
+
+  /** Pack multiple elements into contiguous memory, so they can be sent via MPI.
+   * \param [in] elements Array of elements that are to be packed
+   * \param [in] count Number of elements to pack
+   * \param [in,out] send_buffer Buffer in which to pack the elements
+   * \param [in] buffer_size size of the buffer (in order to check that we don't access out of range)
+   * \param [in, out] position the position of the first byte that is not already packed
+   * \param [in] comm MPI Communicator
+  */
+  virtual void
+  t8_element_MPI_Pack (t8_element_t **const elements, const unsigned int count, void *send_buffer, int buffer_size,
+                       int *position, sc_MPI_Comm comm) const;
+
+  /** Determine an upper bound for the size of the packed message of \b count elements
+   * \param [in] count Number of elements to pack
+   * \param [in] comm MPI Communicator
+   * \param [out] pack_size upper bound on the message size
+  */
+  virtual void
+  t8_element_MPI_Pack_size (const unsigned int count, sc_MPI_Comm comm, int *pack_size) const;
+
+  /** Unpack multiple elements from contiguous memory that was received via MPI.
+   * \param [in] recvbuf Buffer from which to unpack the elements
+   * \param [in] buffer_size size of the buffer (in order to check that we don't access out of range)
+   * \param [in, out] position the position of the first byte that is not already packed
+   * \param [in] elements Array of initialised elements that is to be filled from the message
+   * \param [in] count Number of elements to unpack
+   * \param [in] comm MPI Communicator
+  */
+  virtual void
+  t8_element_MPI_Unpack (void *recvbuf, const int buffer_size, int *position, t8_element_t **elements,
+                         const unsigned int count, sc_MPI_Comm comm) const;
+
+/*------------------------Subelement specific----------------------------------*/
+
+  /** This function refines a parent element into subelements.
+   *  Depending on the subelement type, the number of subelements 
+   *  to fill the parent element, can differ.
+   *  \param [in] elem A valid element
+   *  \param [in] type The subelement type
+   *  \param [out] subelements An array of all subelements of the parent quad element elem
+   */
+  virtual void
+  t8_element_to_transition_cell (const t8_element_t *elem,
+                                                     int type,
+                                                     t8_element_t
+                                                     *subelements[]);
+
+  /** Test wheter a given element is a subelement or not
+   * \param [in] source The element whose entries will be copied to \b dest.
+   * \param [out] zero if no subelement, one if subelement
+   */
+  virtual int
+  t8_element_is_subelement(const t8_element *elem) const;
+
+   /** This function resets the subelement values of an element to the default value -1.
+   * \param [in,out] elem A valid element, whose subelement values have been resetted. 
+   */
+  virtual void
+  t8_element_reset_subelement_values (t8_element *elem) const;
+ 
+  /** This function will determine the location of a specific subelement in the parent element.
+   *  Since different subelement types are possible, it is a priori not known where for example the
+   *  subelement with id 3 is located. 
+   *  \param [in] elem A valid subelement
+   *  \param [out] An array, whose entries are face_number, split and sub_face_id
+   *                      face_number: the face number (clockwise enumeration), the given subelement is adjacent to (value between 0 and 3)
+   *                                   It can be translated to the quad enumeration via subelement_location_to_parent_dual_face[location[0]]
+   *                      split: whether there is a hanging node at the face, the subelement is adjacent to 
+   *                             (value 0 if there is not hanging node and 1 if there is one)
+   *                      sub_face_id: if there is a hanging node at the face, it is important to know if the given 
+   *                                   subelement is the first or the second subelement at this face
+   *                                   (value 0 if it is the first and 1 if it is the second)
+   *  The information in the location can be used to automatically determine the verticies of any subelement.
+   *  Since this function is only used to determine the vertices of subelements, it can be declared as a private/protected function.
+   */
+  virtual void
+  t8_element_get_location_of_subelement (const t8_element_t *elem, int location []) const;
+
+  /** This function copies the subelement values from source to dest.
+   *  \param [in] source A valid element 
+   *  \param [in,out] dest A valid element, whose subelement values are equal to those of source
+   */
+  virtual void
+  t8_element_copy_subelement_values (const t8_element * source, t8_element * dest) const;
+
+#ifdef T8_ENABLE_DEBUG
+  /** Query whether an elements subelement values are valid
+   *  \param [in] source A element
+   *  \return true, if the subelement values are valid
+   */
+  virtual int
+  t8_element_subelement_values_are_valid (const t8_element_t *elem) const;
+#endif
+
+  /** Check whether the neighbors of an element at a specic face are siblings
+   *  \param [in] elem A valid element 
+   *  \param [in] elem_face A valid face 
+   *  \return true if the neighbor of elem at face elem_face is a sibling.
+   */
+  virtual int
+  t8_element_neighbor_is_sibling (const t8_element * elem,
+                                                      const int elem_face) const;
+
+    /** Return zero refine value for schemes that do not have a transition implementation.
+   *  \param [in] elem A valid element 
+   *  \return Integer, used as the refine value during transition adaptation.
+   */
+  virtual int
+  t8_element_get_transition_refine_identifier (void) const;
+
+  /** Construct all sibling neighbors of elem at face. */
+  virtual void
+   t8_element_get_sibling_neighbor_in_transition_cell (const t8_element_t
+                                                         *elem,
+                                                         const int face,
+                                                         const int
+                                                         num_neighbors,
+                                                         t8_element_t
+                                                         *neighbor_at_face[],
+                                                         int *neigh_face[]) const;
+
+  /** Return the number of subelements in a transition cell of type transition_type
+   *  \param [in] transition_type The subelement type as an integer
+   *  \return the number of subelements, this transition cell consists of
+   */
+  virtual int
+  t8_element_get_number_of_subelements (int transition_type) const;
+
+  /** Return the transition type of an element
+   *  \param [in] elem A valid element 
+   *  \return the transition type of elem (0 if elem is no subelement) 
+   */
+  virtual int
+  t8_element_get_transition_type (const t8_element * elem) const;
+
+  /** Return the subelement id of a given element. 
+   *  \param [in] elem A valid element 
+   *  \return the subelement id of elem (0 if elem is no subelement)
+   */
+  virtual int
+  t8_element_get_subelement_id (const t8_element * elem) const;
+
+  /** Return 1 if the eclass scheme has an implementation for subelements. Return 0 otherwise. */
+  virtual int
+  t8_element_scheme_supports_transitioning (void) const;
+
+  /** Return 1 if the eclass scheme has an implementation for subelements, which is conformal. */
+  virtual int
+  t8_element_transition_scheme_is_conformal (void) const;
+
+  /** Return the subelement id of the neighbor subelement of elem (possibly not subelement) at face elem_face
+  *   that is a sibling of the subelement neigh. 
+  *  \param [in] elem a given element (possibly subelement)
+  *  \param [in] neigh a random subelement (pseudoneighbor) in a transition cell from which we assume that it owns the real neighbor of elem
+  *  \param [in] elem_face a given face number of element elem
+  *  \return the subelement id of the real subelement neighbor of element elem, which is a sibling of neigh.
+  */
+  virtual int
+  t8_element_find_neighbor_in_transition_cell (const
+                                                                   t8_element_t
+                                                                   *elem,
+                                                                   const
+                                                                   t8_element_t
+                                                                   *neigh,
+                                                                   int
+                                                                   elem_face) const;
+};
+
+#endif /* T8_SUBELEMENT_CXX_HXX */


### PR DESCRIPTION
Add a header file for the subelement scheme.
Each subelement scheme is based on a element scheme which is used for all non subelement-specific operations.



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
