### PR TITLE
Set join by stash

### DIFF
--- a/src/t8_cmesh/t8_cmesh_helpers.h
+++ b/src/t8_cmesh/t8_cmesh_helpers.h
@@ -35,25 +35,48 @@
 T8_EXTERN_C_BEGIN ();
 
 /** Sets the face connectivity information of an un-committed \cmesh based on a list of tree vertices.
- * \param[in,out]   cmesh         Pointer to a t8code cmesh object. If set to NULL this argument is ignored.
- * \param[in]       ntrees        Number of coarse mesh elements resp. trees.
- * \param[in]       vertices      List of per element vertices with dimensions [ntrees,T8_ECLASS_MAX_CORNERS,T8_ECLASS_MAX_DIM].
- * \param[in]       eclasses      List of element classes of length [ntrees].
- * \param[in,out]   connectivity  If connectivity is not NULL the variable is filled with a pointer to an allocated
-                                  face connectivity array. The ownership of this
-                                  array goes to the caller. This argument is mainly used for debugging and
-                                  testing purposes. The dimension of \a connectivity are [ntrees,T8_ECLASS_MAX_FACES,3].
-                                  For each element and each face the following is stored:
-                                      neighbor_tree_id, neighbor_dual_face_id, orientation
- * \param[in]       do_both_directions Compute the connectivity from both neighboring sides. Takes much longer to compute.
-
-  \warning This routine might be too expensive for very large meshes. In this case, consider to use a fully featured mesh generator.
-
-  \note This routine does not detect periodic boundaries.
+ * \param[in,out]   cmesh               Pointer to a t8code cmesh object. If set to NULL this argument is ignored.
+ * \param[in]       ntrees              Number of coarse mesh elements resp. trees.
+ * \param[in]       vertices            List of per element vertices with dimensions
+ *                                      [ntrees,T8_ECLASS_MAX_CORNERS,T8_ECLASS_MAX_DIM].
+ * \param[in]       eclasses            List of element classes of length [ntrees].
+ * \param[in,out]   connectivity        If connectivity is not NULL the variable is filled with a pointer to an
+ *                                      allocated face connectivity array. The ownership of this
+ *                                      array goes to the caller. This argument is mainly used for debugging and
+ *                                      testing purposes. The dimension of \a connectivity are
+ *                                      [ntrees,T8_ECLASS_MAX_FACES,3].
+ *                                      For each element and each face the following is stored:
+ *                                      neighbor_tree_id, neighbor_dual_face_id, orientation
+ * \param[in]       do_both_directions  Compute the connectivity from both neighboring sides.
+ *                                      Takes much longer to compute.
+ *
+ * \warning  This routine might be too expensive for very large meshes. In this case, 
+ *           consider to use a fully featured mesh generator.
+ *
+ * \note This routine does not detect periodic boundaries.
  */
 void
-t8_cmesh_set_join_by_vertices (t8_cmesh_t cmesh, const int ntrees, const t8_eclass_t *eclasses, const double *vertices,
-                               int **connectivity, const int do_both_directions);
+t8_cmesh_set_join_by_vertices (t8_cmesh_t cmesh, const t8_gloidx_t ntrees, const t8_eclass_t *eclasses,
+                               const double *vertices, int **connectivity, const int do_both_directions);
+
+/** Sets the face connectivity information of an un-committed \cmesh based on the cmesh stash.
+ * \param[in,out]   cmesh               An uncommitted cmesh. The trees eclasses and vertices do need to be set.
+ * \param[in,out]   connectivity        If connectivity is not NULL the variable is filled with a pointer to an
+ *                                      allocated face connectivity array. The ownership of this
+ *                                      array goes to the caller. This argument is mainly used for debugging and
+ *                                      testing purposes. The dimension of \a connectivity are 
+ *                                      [ntrees,T8_ECLASS_MAX_FACES,3].
+ *                                      For each element and each face the following is stored:
+ *                                      neighbor_tree_id, neighbor_dual_face_id, orientation
+ * \param[in]       do_both_directions  Compute the connectivity from both neighboring sides. Takes much longer to compute.
+ *
+ * \warning This routine might be too expensive for very large meshes. In this case,
+ *          consider to use a fully featured mesh generator.
+ *
+ * \note This routine does not detect periodic boundaries.
+ */
+void
+t8_cmesh_set_join_by_stash (t8_cmesh_t cmesh, int **connectivity, const int do_both_directions);
 
 T8_EXTERN_C_END ();
 


### PR DESCRIPTION
**_Describe your changes here:_**
Allows calling set join by vertices without the need of the eclasses and vertices array. The information is extracted from the cmesh stash instead


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
