### PR TITLE
Add doxygen generation to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ option( T8CODE_ENABLE_VTK "Enable t8code's features which rely on VTK" OFF )
 option( T8CODE_USE_SYSTEM_SC "Use system-installed sc library" OFF )
 option( T8CODE_USE_SYSTEM_P4EST "Use system-installed p4est library" OFF )
 
+option( BUILD_DOCUMENTATION "Build t8code's documentation" ON)
+
 if( NOT CMAKE_BUILD_TYPE )
     set( CMAKE_BUILD_TYPE "Release" )
 endif()
@@ -76,4 +78,8 @@ endif()
 
 if ( T8CODE_BUILD_EXAMPLES )
     add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/example )
+endif()
+
+if ( BUILD_DOCUMENTATION ) 
+    add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/doc )
 endif()

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,28 @@
+find_package(Doxygen REQUIRED)
+
+if (DOXYGEN_FOUND)
+    set(DOXYGEN_INDEX_FILE ${DOXYGEN_OUTPUT_DIR}/html/index.html)
+    set(DOXYFILE_IN ${PROJECT_SOURCE_DIR}/doc/Doxyfile.in)
+    set(DOXYFILE_OUT ${PROJECT_BINARY_DIR}/doc/Doxyfile)
+
+    #The following options are used inside the do
+    set(top_srcdir ${PROJECT_SOURCE_DIR})
+    set(top_builddir ${PROJECT_BINARY_DIR})
+
+    set(PACKAGE_NAME ${PROJECT_NAME})
+    set(VERSION ${T8_VERSION})
+
+
+    #Replace variables inside @@ with the current values
+    configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
+
+    add_custom_command( OUTPUT ${DOXYGEN_INDEX_FILE}
+                        DEPENDS ${T8_PUBLIC_HEADERS}
+                        COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYFILE_OUT} 
+                        MAIN_DEPENDENCY ${DOXYFILE_OUT} ${DOXYFILE_IN} 
+                        COMMENT "Generating documentation")
+
+    add_custom_target(Doxygen ALL DEPENDS ${DOXYGEN_INDEX_FILE})
+else (DOXYGEN_FOUND)
+    message(FATAL_ERROR "Doxygen need to be installed to generate the doxygen documentation")
+endif (DOXYGEN_FOUND)

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -44,8 +44,8 @@ PROJECT_NUMBER         = @VERSION@
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = t8code is a C library to manage a forest of adaptive \
-                         space-trees of general element classes in parallel.
+PROJECT_BRIEF          = "t8code is a C library to manage a forest of adaptive \
+                         space-trees of general element classes in parallel."
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,10 @@ execute_process( COMMAND echo ${T8CODE_VERSION}
                  OUTPUT_VARIABLE T8CODE_VERSION_POINT 
                  OUTPUT_STRIP_TRAILING_WHITESPACE )
 
+#To reuse the version in other CMakeLists
+set(T8_VERSION ${T8CODE_VERSION} CACHE INTERNAL "")
+
+
 target_compile_definitions( T8 PUBLIC T8_PACKAGE_STRING="t8 ${T8CODE_VERSION}" )
 target_compile_definitions( T8 PUBLIC T8_VERSION="${T8CODE_VERSION}" )
 target_compile_definitions( T8 PUBLIC T8_VERSION_MAJOR=${T8CODE_VERSION_MAJOR} )


### PR DESCRIPTION
Added an option to build doxygen documentation from cmake



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
