### PR TITLE
Correct orientation parameter in tutorial

### DIFF
--- a/tutorials/general/t8_tutorial_build_cmesh.cxx
+++ b/tutorials/general/t8_tutorial_build_cmesh.cxx
@@ -276,7 +276,7 @@ t8_cmesh_new_hybrid_gate_3d (sc_MPI_Comm comm)
    * t8_cmesh_set_join (cmesh, 1, 3, 0, 4, 0);
    * t8_cmesh_set_join (cmesh, 2, 5, 0, 0, 0);
    * t8_cmesh_set_join (cmesh, 3, 5, 1, 1, 0);
-   * t8_cmesh_set_join (cmesh, 4, 5, 4, 2, 0);
+   * t8_cmesh_set_join (cmesh, 4, 5, 4, 2, 2);
    *
    * // 7. Commit the mesh
    * t8_cmesh_commit (cmesh, comm);
@@ -316,7 +316,7 @@ t8_cmesh_new_hybrid_gate_3d (sc_MPI_Comm comm)
   t8_cmesh_set_join (cmesh, 1, 3, 0, 4, 0);
   t8_cmesh_set_join (cmesh, 2, 5, 0, 0, 0);
   t8_cmesh_set_join (cmesh, 3, 5, 1, 1, 0);
-  t8_cmesh_set_join (cmesh, 4, 5, 4, 2, 0);
+  t8_cmesh_set_join (cmesh, 4, 5, 4, 2, 2);
 
   /*
    * Definition of the first tree


### PR DESCRIPTION
Corrected the orientation parameter in the 3D example between element 4 and 5 from 0 to 2.
The parameter in the wiki article was already changed.



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
