### PR TITLE
More const parameter for our element array class [1/3].

### DIFF
--- a/src/t8_data/t8_containers.cxx
+++ b/src/t8_data/t8_containers.cxx
@@ -180,14 +180,14 @@ t8_element_array_resize (t8_element_array_t *element_array, size_t new_count)
     sc_array_resize (&element_array->array, new_count);
     t8_element_t *first_new_elem;
     /* Get the first newly allocated element */
-    first_new_elem = t8_element_array_index_locidx (element_array, old_count);
+    first_new_elem = t8_element_array_index_locidx_mutable (element_array, old_count);
     /* Call t8_element_init on all new elements */
     element_array->scheme->t8_element_init (new_count - old_count, first_new_elem);
   }
   else if (old_count > new_count) {
     t8_element_t *first_old_elem;
     /* Get the first element to deinit */
-    first_old_elem = t8_element_array_index_locidx (element_array, new_count);
+    first_old_elem = t8_element_array_index_locidx_mutable (element_array, new_count);
     element_array->scheme->t8_element_deinit (old_count - new_count, first_old_elem);
     sc_array_resize (&element_array->array, new_count);
   }
@@ -199,12 +199,12 @@ t8_element_array_resize (t8_element_array_t *element_array, size_t new_count)
 }
 
 void
-t8_element_array_copy (t8_element_array_t *dest, t8_element_array_t *src)
+t8_element_array_copy (t8_element_array_t *dest, const t8_element_array_t *src)
 {
   T8_ASSERT (t8_element_array_is_valid (dest));
   T8_ASSERT (t8_element_array_is_valid (src));
   T8_ASSERT (dest->scheme == src->scheme);
-  sc_array_copy (&dest->array, &src->array);
+  sc_array_copy (&dest->array, (sc_array_t *) &src->array); /* need to convert src->array to non-const */
 }
 
 t8_element_t *
@@ -229,22 +229,34 @@ t8_element_array_push_count (t8_element_array_t *element_array, size_t count)
   return new_elements;
 }
 
-t8_element_t *
-t8_element_array_index_locidx (t8_element_array_t *element_array, t8_locidx_t index)
+const t8_element_t *
+t8_element_array_index_locidx (const t8_element_array_t *element_array, t8_locidx_t index)
 {
   T8_ASSERT (t8_element_array_is_valid (element_array));
-  return (t8_element_t *) t8_sc_array_index_locidx (&element_array->array, index);
+  return (const t8_element_t *) t8_sc_array_index_locidx (&element_array->array, index);
+}
+
+const t8_element_t *
+t8_element_array_index_int (const t8_element_array_t *element_array, int index)
+{
+  T8_ASSERT (t8_element_array_is_valid (element_array));
+  return (const t8_element_t *) sc_array_index_int ((sc_array_t*) &element_array->array, index); /* Need to convert element_array->array to non-const */
 }
 
 t8_element_t *
-t8_element_array_index_int (t8_element_array_t *element_array, int index)
+t8_element_array_index_locidx_mutable (t8_element_array_t *element_array, t8_locidx_t index)
 {
-  T8_ASSERT (t8_element_array_is_valid (element_array));
-  return (t8_element_t *) sc_array_index_int (&element_array->array, index);
+  return (t8_element_t *) t8_element_array_index_locidx (element_array, index);
 }
 
-t8_eclass_scheme_c *
-t8_element_array_get_scheme (t8_element_array_t *element_array)
+t8_element_t *
+t8_element_array_index_int_mutable (t8_element_array_t *element_array, int index)
+{
+  return (t8_element_t *) t8_element_array_index_int (element_array, index);
+}
+
+const t8_eclass_scheme_c *
+t8_element_array_get_scheme (const t8_element_array_t *element_array)
 {
   T8_ASSERT (t8_element_array_is_valid (element_array));
   return element_array->scheme;
@@ -258,14 +270,14 @@ t8_element_array_get_count (const t8_element_array_t *element_array)
 }
 
 size_t
-t8_element_array_get_size (t8_element_array_t *element_array)
+t8_element_array_get_size (const t8_element_array_t *element_array)
 {
   T8_ASSERT (t8_element_array_is_valid (element_array));
   return element_array->scheme->t8_element_size ();
 }
 
 t8_element_t *
-t8_element_array_get_data (t8_element_array_t *element_array)
+t8_element_array_get_data (const t8_element_array_t *element_array)
 {
   T8_ASSERT (t8_element_array_is_valid (element_array));
 
@@ -277,8 +289,16 @@ t8_element_array_get_data (t8_element_array_t *element_array)
   }
 }
 
+const sc_array_t *
+t8_element_array_get_array (const t8_element_array_t *element_array)
+{
+  T8_ASSERT (t8_element_array_is_valid (element_array));
+
+  return &element_array->array;
+}
+
 sc_array_t *
-t8_element_array_get_array (t8_element_array_t *element_array)
+t8_element_array_get_array_mutable (t8_element_array_t *element_array)
 {
   T8_ASSERT (t8_element_array_is_valid (element_array));
 
@@ -289,7 +309,7 @@ void
 t8_element_array_reset (t8_element_array_t *element_array)
 {
   T8_ASSERT (t8_element_array_is_valid (element_array));
-  t8_element_t *first_elem = t8_element_array_index_locidx (element_array, 0);
+  t8_element_t *first_elem = t8_element_array_index_locidx_mutable (element_array, 0);
   size_t count = t8_element_array_get_count (element_array);
   element_array->scheme->t8_element_deinit (count, first_elem);
   sc_array_reset (&element_array->array);
@@ -299,7 +319,7 @@ void
 t8_element_array_truncate (t8_element_array_t *element_array)
 {
   T8_ASSERT (t8_element_array_is_valid (element_array));
-  t8_element_t *first_elem = t8_element_array_index_locidx (element_array, 0);
+  t8_element_t *first_elem = t8_element_array_index_locidx_mutable (element_array, 0);
   size_t count = t8_element_array_get_count (element_array);
   element_array->scheme->t8_element_deinit (count, first_elem);
   sc_array_truncate (&element_array->array);

--- a/src/t8_data/t8_containers.cxx
+++ b/src/t8_data/t8_containers.cxx
@@ -277,7 +277,7 @@ t8_element_array_get_size (const t8_element_array_t *element_array)
   return element_array->scheme->t8_element_size ();
 }
 
-t8_element_t *
+const t8_element_t *
 t8_element_array_get_data (const t8_element_array_t *element_array)
 {
   T8_ASSERT (t8_element_array_is_valid (element_array));
@@ -288,6 +288,14 @@ t8_element_array_get_data (const t8_element_array_t *element_array)
   else {
     return NULL;
   }
+}
+
+t8_element_t *
+t8_element_array_get_data_mutable (t8_element_array_t *element_array)
+{
+  T8_ASSERT (t8_element_array_is_valid (element_array));
+
+  return (t8_element_t *) t8_element_array_get_data (element_array);
 }
 
 const sc_array_t *

--- a/src/t8_data/t8_containers.cxx
+++ b/src/t8_data/t8_containers.cxx
@@ -240,7 +240,8 @@ const t8_element_t *
 t8_element_array_index_int (const t8_element_array_t *element_array, int index)
 {
   T8_ASSERT (t8_element_array_is_valid (element_array));
-  return (const t8_element_t *) sc_array_index_int ((sc_array_t*) &element_array->array, index); /* Need to convert element_array->array to non-const */
+  return (const t8_element_t *) sc_array_index_int ((sc_array_t *) &element_array->array,
+                                                    index); /* Need to convert element_array->array to non-const */
 }
 
 t8_element_t *

--- a/src/t8_data/t8_containers.h
+++ b/src/t8_data/t8_containers.h
@@ -218,8 +218,17 @@ t8_element_array_get_size (const t8_element_array_t *element_array);
  * \return                     A pointer to the stored data. If the number of stored
  *                             elements is 0, then NULL is returned.
  */
-t8_element_t *
+const t8_element_t *
 t8_element_array_get_data (const t8_element_array_t *element_array);
+
+
+/** Return a pointer to the real data array stored in a t8_element_array.
+ * \param [in]  element_array  Array structure.
+ * \return                     A pointer to the stored data. If the number of stored
+ *                             elements is 0, then NULL is returned.
+ */
+t8_element_t *
+t8_element_array_get_data_mutable (t8_element_array_t *element_array);
 
 /** Return a const pointer to the sc_array stored in a t8_element_array.
  * \param [in]  element_array  Array structure.

--- a/src/t8_data/t8_containers.h
+++ b/src/t8_data/t8_containers.h
@@ -221,7 +221,6 @@ t8_element_array_get_size (const t8_element_array_t *element_array);
 const t8_element_t *
 t8_element_array_get_data (const t8_element_array_t *element_array);
 
-
 /** Return a pointer to the real data array stored in a t8_element_array.
  * \param [in]  element_array  Array structure.
  * \return                     A pointer to the stored data. If the number of stored

--- a/src/t8_data/t8_containers.h
+++ b/src/t8_data/t8_containers.h
@@ -138,7 +138,7 @@ t8_element_array_resize (t8_element_array_t *element_array, size_t new_count);
  * \param [in] src  Array used as source of new data, will not be changed.
  */
 void
-t8_element_array_copy (t8_element_array_t *dest, t8_element_array_t *src);
+t8_element_array_copy (t8_element_array_t *dest, const t8_element_array_t *src);
 
 /** Enlarge an array by one element.
  * \param [in, ou] element_array Array structure to be modified.
@@ -157,30 +157,48 @@ t8_element_array_push (t8_element_array_t *element_array);
 t8_element_t *
 t8_element_array_push_count (t8_element_array_t *element_array, size_t count);
 
-/** Return a given element in an array.
+/** Return a given element in an array. Const version.
  * \param [in]  element_array Array of elements.
  * \param [in]  index The index of an element within the array.
  * \return            A pointer to the element stored at position \a index in
  *                    \a element_array.
  */
-t8_element_t *
-t8_element_array_index_locidx (t8_element_array_t *element_array, t8_locidx_t index);
+const t8_element_t *
+t8_element_array_index_locidx (const t8_element_array_t *element_array, t8_locidx_t index);
 
-/** Return a given element in an array.
+/** Return a given element in an array. Const version.
+ * \param [in]  element_array Array of elements.
+ * \param [in]  index The index of an element within the array.
+ * \return            A pointer to the element stored at position \a index in
+ *                    \a element_array.
+ */
+const t8_element_t *
+t8_element_array_index_int (const t8_element_array_t *element_array, int index);
+
+/** Return a given element in an array. Mutable version.
  * \param [in]  element_array Array of elements.
  * \param [in]  index The index of an element within the array.
  * \return            A pointer to the element stored at position \a index in
  *                    \a element_array.
  */
 t8_element_t *
-t8_element_array_index_int (t8_element_array_t *element_array, int index);
+t8_element_array_index_locidx_mutable (t8_element_array_t *element_array, t8_locidx_t index);
+
+/** Return a given element in an array. Mutable version.
+ * \param [in]  element_array Array of elements.
+ * \param [in]  index The index of an element within the array.
+ * \return            A pointer to the element stored at position \a index in
+ *                    \a element_array.
+ */
+t8_element_t *
+t8_element_array_index_int_mutable (t8_element_array_t *element_array, int index);
 
 /** Return the eclass scheme associated to a t8_element_array.
  * \param [in]  element_array Array of elements.
  * \return      The eclass scheme stored at \a element_array.
  */
-t8_eclass_scheme_c *
-t8_element_array_get_scheme (t8_element_array_t *element_array);
+const t8_eclass_scheme_c *
+t8_element_array_get_scheme (const t8_element_array_t *element_array);
 
 /** Return the number of elements stored in a t8_element_array_t.
  * \param [in]  element_array  Array structure.
@@ -193,22 +211,31 @@ t8_element_array_get_count (const t8_element_array_t *element_array);
  * \return                     The size (in bytes) of a single element in \a element_array.
  */
 size_t
-t8_element_array_get_size (t8_element_array_t *element_array);
+t8_element_array_get_size (const t8_element_array_t *element_array);
 
-/** Return a pointer to the real data array stored in a t8_element_array.
+/** Return a const pointer to the real data array stored in a t8_element_array.
  * \param [in]  element_array  Array structure.
  * \return                     A pointer to the stored data. If the number of stored
  *                             elements is 0, then NULL is returned.
  */
 t8_element_t *
-t8_element_array_get_data (t8_element_array_t *element_array);
+t8_element_array_get_data (const t8_element_array_t *element_array);
 
-/** Return a pointer to the sc_array stored in a t8_element_array.
+/** Return a const pointer to the sc_array stored in a t8_element_array.
+ * \param [in]  element_array  Array structure.
+ * \return                     A const pointer to the sc_array storing the data.
+ * \note The data cannot be modified.
+ */
+const sc_array_t *
+t8_element_array_get_array (const t8_element_array_t *element_array);
+
+/** Return a mutable pointer to the sc_array stored in a t8_element_array.
  * \param [in]  element_array  Array structure.
  * \return                     A pointer to the sc_array storing the data.
+ * \note The data can be modified.
  */
 sc_array_t *
-t8_element_array_get_array (t8_element_array_t *element_array);
+t8_element_array_get_array_mutable (t8_element_array_t *element_array);
 
 /** Sets the array count to zero and frees all elements.
  * \param [in,out]  element_array  Array structure to be reset.

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -929,7 +929,7 @@ t8_forest_get_element (t8_forest_t forest, t8_locidx_t lelement_id, t8_locidx_t 
   tree = t8_forest_get_tree (forest, ltree);
   if (tree->elements_offset <= lelement_id
       && lelement_id < tree->elements_offset + (t8_locidx_t) t8_element_array_get_count (&tree->elements)) {
-    return t8_element_array_index_locidx (&tree->elements, lelement_id - tree->elements_offset);
+    return t8_element_array_index_locidx_mutable (&tree->elements, lelement_id - tree->elements_offset);
   }
   /* The element was not found.
    * This case is covered by the first if and should therefore never happen. */

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -143,7 +143,7 @@ t8_forest_pos (t8_forest_t forest, t8_eclass_scheme_c *ts, t8_element_array_t *t
    * maximum number of member. */
   t8_locidx_t el_iter; /* Loop running variable */
   t8_locidx_t pos = -1;
-  t8_element_t *element_compare;
+  const t8_element_t *element_compare;
   for (el_iter = 1; el_iter < (t8_locidx_t) num_siblings && el_iter < elements_in_array; el_iter++) {
     pos = telements_pos - el_iter;
     T8_ASSERT (0 <= pos && pos < elements_in_array);
@@ -242,7 +242,8 @@ t8_forest_adapt_coarsen_recursive (t8_forest_t forest, t8_locidx_t ltreeid, t8_l
     }
 #endif
     for (ielement = 0; ielement < (t8_locidx_t) num_siblings && pos + ielement < elements_in_array; ielement++) {
-      fam[ielement] = t8_element_array_index_locidx (telements, pos + ielement);
+      /* TODO: In a future version, fam[ielement] should be const and we should call t8_element_array_index_locidx (the const version). */
+      fam[ielement] = t8_element_array_index_locidx_mutable (telements, pos + ielement);
     }
 
     int num_elements_to_adapt_callback;
@@ -473,7 +474,8 @@ t8_forest_adapt (t8_forest_t forest)
         }
 #endif
         for (zz = 0; zz < num_siblings && el_considered + (t8_locidx_t) zz < num_el_from; zz++) {
-          elements_from[zz] = t8_element_array_index_locidx (telements_from, el_considered + (t8_locidx_t) zz);
+          /* TODO: In a future version elements_from[zz] should be const and we should call t8_element_array_index_locidx (the const version). */
+          elements_from[zz] = t8_element_array_index_locidx_mutable (telements_from, el_considered + (t8_locidx_t) zz);
           /* This is a quick check whether we build up a family here and could
            * abort early if not.
            * If the child id of the current element is not zz, then it cannot
@@ -553,7 +555,8 @@ t8_forest_adapt (t8_forest_t forest)
           else {
             (void) t8_element_array_push_count (telements, num_children);
             for (zz = 0; zz < num_children; zz++) {
-              elements[zz] = t8_element_array_index_locidx (telements, el_inserted + zz);
+              /* TODO: In a future version elements_from[zz] should be const and we should call t8_element_array_index_locidx (the const version). */
+              elements[zz] = t8_element_array_index_locidx_mutable (telements, el_inserted + zz);
             }
             tscheme->t8_element_children (elements_from[0], num_children, elements);
             el_inserted += (t8_locidx_t) num_children;

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1108,7 +1108,6 @@ t8_forest_compute_desc (t8_forest_t forest)
   t8_locidx_t itree_id, num_trees, num_elements;
   t8_tree_t itree;
   t8_eclass_scheme_c *ts;
-  t8_element_t *element;
 
   T8_ASSERT (forest != NULL);
   /* Iterate over all trees */
@@ -1126,18 +1125,18 @@ t8_forest_compute_desc (t8_forest_t forest)
     /* get the eclass scheme associated to tree */
     ts = forest->scheme_cxx->eclass_schemes[itree->eclass];
     /* get a pointer to the first element of itree */
-    element = t8_element_array_index_locidx (&itree->elements, 0);
+    const t8_element_t * first_element = t8_element_array_index_locidx (&itree->elements, 0);
     /* get memory for the trees first descendant */
     ts->t8_element_new (1, &itree->first_desc);
     /* calculate the first descendant of the first element */
-    ts->t8_element_first_descendant (element, itree->first_desc, forest->maxlevel);
+    ts->t8_element_first_descendant (first_element, itree->first_desc, forest->maxlevel);
     /* get a pointer to the last element of itree */
     num_elements = t8_element_array_get_count (&itree->elements);
-    element = t8_element_array_index_locidx (&itree->elements, num_elements - 1);
+    const t8_element_t * last_element = t8_element_array_index_locidx (&itree->elements, num_elements - 1);
     /* get memory for the trees first descendant */
     ts->t8_element_new (1, &itree->last_desc);
     /* calculate the last descendant of the first element */
-    ts->t8_element_last_descendant (element, itree->last_desc, forest->maxlevel);
+    ts->t8_element_last_descendant (last_element, itree->last_desc, forest->maxlevel);
   }
 }
 
@@ -1208,11 +1207,11 @@ t8_forest_populate (t8_forest_t forest)
       T8_ASSERT (num_tree_elements > 0);
       /* Allocate elements for this processor. */
       t8_element_array_init_size (telements, eclass_scheme, num_tree_elements);
-      element = t8_element_array_index_locidx (telements, 0);
+      element = t8_element_array_index_locidx_mutable (telements, 0);
       eclass_scheme->t8_element_set_linear_id (element, forest->set_level, start);
       count_elements++;
       for (et = start + 1; et < end; et++, count_elements++) {
-        element_succ = t8_element_array_index_locidx (telements, et - start);
+        element_succ = t8_element_array_index_locidx_mutable (telements, et - start);
         T8_ASSERT (eclass_scheme->t8_element_level (element) == forest->set_level);
         eclass_scheme->t8_element_successor (element, element_succ);
         /* TODO: process elements here */
@@ -1423,24 +1422,22 @@ t8_forest_copy_trees (t8_forest_t forest, t8_forest_t from, int copy_elements)
   }
 }
 
-/* Search for a lineasr element id (at forest->maxlevel) in a sorted array of
+/* Search for a linear element id (at forest->maxlevel) in a sorted array of
  * elements. If the element does not exist, return the largest index i
  * such that the element at position i has a smaller id than the given one.
  * If no such i exists, return -1.
  */
 /* TODO: should return t8_locidx_t */
 static t8_locidx_t
-t8_forest_bin_search_lower (t8_element_array_t *elements, t8_linearidx_t element_id, int maxlevel)
+t8_forest_bin_search_lower (const t8_element_array_t *elements, const t8_linearidx_t element_id, const int maxlevel)
 {
-  t8_element_t *query;
   t8_linearidx_t query_id;
   t8_locidx_t low, high, guess;
-  t8_eclass_scheme_c *ts;
 
-  ts = t8_element_array_get_scheme (elements);
+  const t8_eclass_scheme_c *ts = t8_element_array_get_scheme (elements);
   /* At first, we check whether any element has smaller id than the
    * given one. */
-  query = t8_element_array_index_int (elements, 0);
+  const t8_element_t * query = t8_element_array_index_int (elements, 0);
   query_id = ts->t8_element_get_linear_id (query, maxlevel);
   if (query_id > element_id) {
     /* No element has id smaller than the given one */
@@ -1720,8 +1717,8 @@ t8_forest_leaf_face_neighbors_ext (t8_forest_t forest, t8_locidx_t ltreeid, cons
   t8_locidx_t lneigh_treeid = -1;
   t8_locidx_t lghost_treeid = -1, *element_indices, element_index;
   t8_eclass_scheme_c *ts, *neigh_scheme;
-  t8_element_array_t *element_array;
-  t8_element_t *ancestor, **neighbor_leaves;
+  const t8_element_t *ancestor;
+  t8_element_t **neighbor_leaves;
   t8_linearidx_t neigh_id;
   int num_children_at_face, at_maxlevel;
   int ineigh, *owners, different_owners, have_ghosts;
@@ -1826,7 +1823,7 @@ t8_forest_leaf_face_neighbors_ext (t8_forest_t forest, t8_locidx_t ltreeid, cons
       neigh_id = neigh_scheme->t8_element_get_linear_id (neighbor_leaves[0], forest->maxlevel);
       if (owners[0] != forest->mpirank) {
         /* The elements are ghost elements of the same owner */
-        element_array = t8_forest_ghost_get_tree_elements (forest, lghost_treeid);
+        const t8_element_array_t *element_array = t8_forest_ghost_get_tree_elements (forest, lghost_treeid);
         /* Find the index in element_array of the leaf ancestor of the first neighbor.
          * This is either the neighbor itself or its parent, or its grandparent */
         element_index = t8_forest_bin_search_lower (element_array, neigh_id, forest->maxlevel);
@@ -1842,7 +1839,7 @@ t8_forest_leaf_face_neighbors_ext (t8_forest_t forest, t8_locidx_t ltreeid, cons
       }
       else {
         /* the elements are local elements */
-        element_array = t8_forest_get_tree_element_array (forest, lneigh_treeid);
+        const t8_element_array_t *element_array = t8_forest_get_tree_element_array (forest, lneigh_treeid);
         /* Find the index in element_array of the leaf ancestor of the first neighbor.
          * This is either the neighbor itself or its parent, or its grandparent */
         element_index = t8_forest_bin_search_lower (element_array, neigh_id, forest->maxlevel);
@@ -1905,7 +1902,7 @@ t8_forest_leaf_face_neighbors_ext (t8_forest_t forest, t8_locidx_t ltreeid, cons
        * This is either the local leaf array of the local tree or the corresponding leaf array in the ghost structure */
       if (owners[ineigh] == forest->mpirank) {
         /* The neighbor is a local leaf */
-        element_array = t8_forest_get_tree_element_array (forest, lneigh_treeid);
+        const t8_element_array_t * element_array = t8_forest_get_tree_element_array (forest, lneigh_treeid);
         /* Find the index of the neighbor in the array */
         element_indices[ineigh] = t8_forest_bin_search_lower (element_array, neigh_id, forest->maxlevel);
         T8_ASSERT (element_indices[ineigh] >= 0);
@@ -1923,7 +1920,7 @@ t8_forest_leaf_face_neighbors_ext (t8_forest_t forest, t8_locidx_t ltreeid, cons
       }
       else {
         /* The neighbor is a ghost */
-        element_array = t8_forest_ghost_get_tree_elements (forest, lghost_treeid);
+        const t8_element_array_t* element_array = t8_forest_ghost_get_tree_elements (forest, lghost_treeid);
         /* Find the index of the neighbor in the array */
         element_indices[ineigh] = t8_forest_bin_search_lower (element_array, neigh_id, forest->maxlevel);
 
@@ -2653,8 +2650,7 @@ t8_forest_element_has_leaf_desc (t8_forest_t forest, t8_gloidx_t gtreeid, const 
                                  t8_eclass_scheme_c *ts)
 {
   t8_locidx_t ltreeid;
-  t8_element_array_t *elements;
-  t8_element_t *last_desc, *elem_found;
+  t8_element_t *last_desc;
   t8_locidx_t ghost_treeid;
   t8_linearidx_t last_desc_id, elem_id;
   int index, level, level_found;
@@ -2677,13 +2673,13 @@ t8_forest_element_has_leaf_desc (t8_forest_t forest, t8_gloidx_t gtreeid, const 
   if (ltreeid >= 0) {
     /* The tree is a local tree */
     /* Get the elements */
-    elements = t8_forest_get_tree_element_array (forest, ltreeid);
+    const t8_element_array_t *elements = t8_forest_get_tree_element_array (forest, ltreeid);
 
     index = t8_forest_bin_search_lower (elements, last_desc_id, forest->maxlevel);
     if (index >= 0) {
       /* There exists an element in the array with id <= last_desc_id,
        * If also elem_id < id, then we found a true decsendant of element */
-      elem_found = t8_element_array_index_locidx (elements, index);
+      const t8_element_t * elem_found = t8_element_array_index_locidx (elements, index);
       elem_id = ts->t8_element_get_linear_id (elem_found, forest->maxlevel);
       level_found = ts->t8_element_level (elem_found);
       if (ts->t8_element_get_linear_id (element, forest->maxlevel) <= elem_id && level < level_found) {
@@ -2700,12 +2696,12 @@ t8_forest_element_has_leaf_desc (t8_forest_t forest, t8_gloidx_t gtreeid, const 
     ghost_treeid = t8_forest_ghost_get_ghost_treeid (forest, gtreeid);
     if (ghost_treeid >= 0) {
       /* The tree is a ghost tree */
-      elements = t8_forest_ghost_get_tree_elements (forest, ghost_treeid);
+      const t8_element_array_t *elements  = t8_forest_ghost_get_tree_elements (forest, ghost_treeid);
       index = t8_forest_bin_search_lower (elements, last_desc_id, forest->maxlevel);
       if (index >= 0) {
         /* There exists an element in the array with id <= last_desc_id,
          * If also elem_id < id, then we found a true decsendant of element */
-        elem_found = t8_element_array_index_int (elements, index);
+        const t8_element_t * elem_found = t8_element_array_index_int (elements, index);
         elem_id = ts->t8_element_get_linear_id (elem_found, forest->maxlevel);
         level_found = ts->t8_element_level (elem_found);
         if (ts->t8_element_get_linear_id (element, forest->maxlevel) <= elem_id && level < level_found) {

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1125,14 +1125,14 @@ t8_forest_compute_desc (t8_forest_t forest)
     /* get the eclass scheme associated to tree */
     ts = forest->scheme_cxx->eclass_schemes[itree->eclass];
     /* get a pointer to the first element of itree */
-    const t8_element_t * first_element = t8_element_array_index_locidx (&itree->elements, 0);
+    const t8_element_t *first_element = t8_element_array_index_locidx (&itree->elements, 0);
     /* get memory for the trees first descendant */
     ts->t8_element_new (1, &itree->first_desc);
     /* calculate the first descendant of the first element */
     ts->t8_element_first_descendant (first_element, itree->first_desc, forest->maxlevel);
     /* get a pointer to the last element of itree */
     num_elements = t8_element_array_get_count (&itree->elements);
-    const t8_element_t * last_element = t8_element_array_index_locidx (&itree->elements, num_elements - 1);
+    const t8_element_t *last_element = t8_element_array_index_locidx (&itree->elements, num_elements - 1);
     /* get memory for the trees first descendant */
     ts->t8_element_new (1, &itree->last_desc);
     /* calculate the last descendant of the first element */
@@ -1437,7 +1437,7 @@ t8_forest_bin_search_lower (const t8_element_array_t *elements, const t8_lineari
   const t8_eclass_scheme_c *ts = t8_element_array_get_scheme (elements);
   /* At first, we check whether any element has smaller id than the
    * given one. */
-  const t8_element_t * query = t8_element_array_index_int (elements, 0);
+  const t8_element_t *query = t8_element_array_index_int (elements, 0);
   query_id = ts->t8_element_get_linear_id (query, maxlevel);
   if (query_id > element_id) {
     /* No element has id smaller than the given one */
@@ -1902,7 +1902,7 @@ t8_forest_leaf_face_neighbors_ext (t8_forest_t forest, t8_locidx_t ltreeid, cons
        * This is either the local leaf array of the local tree or the corresponding leaf array in the ghost structure */
       if (owners[ineigh] == forest->mpirank) {
         /* The neighbor is a local leaf */
-        const t8_element_array_t * element_array = t8_forest_get_tree_element_array (forest, lneigh_treeid);
+        const t8_element_array_t *element_array = t8_forest_get_tree_element_array (forest, lneigh_treeid);
         /* Find the index of the neighbor in the array */
         element_indices[ineigh] = t8_forest_bin_search_lower (element_array, neigh_id, forest->maxlevel);
         T8_ASSERT (element_indices[ineigh] >= 0);
@@ -1920,7 +1920,7 @@ t8_forest_leaf_face_neighbors_ext (t8_forest_t forest, t8_locidx_t ltreeid, cons
       }
       else {
         /* The neighbor is a ghost */
-        const t8_element_array_t* element_array = t8_forest_ghost_get_tree_elements (forest, lghost_treeid);
+        const t8_element_array_t *element_array = t8_forest_ghost_get_tree_elements (forest, lghost_treeid);
         /* Find the index of the neighbor in the array */
         element_indices[ineigh] = t8_forest_bin_search_lower (element_array, neigh_id, forest->maxlevel);
 
@@ -2679,7 +2679,7 @@ t8_forest_element_has_leaf_desc (t8_forest_t forest, t8_gloidx_t gtreeid, const 
     if (index >= 0) {
       /* There exists an element in the array with id <= last_desc_id,
        * If also elem_id < id, then we found a true decsendant of element */
-      const t8_element_t * elem_found = t8_element_array_index_locidx (elements, index);
+      const t8_element_t *elem_found = t8_element_array_index_locidx (elements, index);
       elem_id = ts->t8_element_get_linear_id (elem_found, forest->maxlevel);
       level_found = ts->t8_element_level (elem_found);
       if (ts->t8_element_get_linear_id (element, forest->maxlevel) <= elem_id && level < level_found) {
@@ -2696,12 +2696,12 @@ t8_forest_element_has_leaf_desc (t8_forest_t forest, t8_gloidx_t gtreeid, const 
     ghost_treeid = t8_forest_ghost_get_ghost_treeid (forest, gtreeid);
     if (ghost_treeid >= 0) {
       /* The tree is a ghost tree */
-      const t8_element_array_t *elements  = t8_forest_ghost_get_tree_elements (forest, ghost_treeid);
+      const t8_element_array_t *elements = t8_forest_ghost_get_tree_elements (forest, ghost_treeid);
       index = t8_forest_bin_search_lower (elements, last_desc_id, forest->maxlevel);
       if (index >= 0) {
         /* There exists an element in the array with id <= last_desc_id,
          * If also elem_id < id, then we found a true decsendant of element */
-        const t8_element_t * elem_found = t8_element_array_index_int (elements, index);
+        const t8_element_t *elem_found = t8_element_array_index_int (elements, index);
         elem_id = ts->t8_element_get_linear_id (elem_found, forest->maxlevel);
         level_found = ts->t8_element_level (elem_found);
         if (ts->t8_element_get_linear_id (element, forest->maxlevel) <= elem_id && level < level_found) {

--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -1084,7 +1084,7 @@ t8_forest_ghost_parse_received_message (t8_forest_t forest, t8_forest_ghost_t gh
       /* Initialize the element array */
       t8_element_array_init_size (&ghost_tree->elements, ts, num_elements);
       /* pointer to where the elements are to be inserted */
-      element_insert = t8_element_array_get_data (&ghost_tree->elements);
+      element_insert = t8_element_array_get_data_mutable (&ghost_tree->elements);
       /* Compute the element offset of this new tree by adding the offset
        * of the previous tree to the element count of the previous tree. */
       ghost_tree->element_offset = *current_element_offset;

--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -457,7 +457,7 @@ t8_ghost_add_remote (t8_forest_t forest, t8_forest_ghost_t ghost, int remote_ran
     int ielem;
     int elem_count = t8_element_array_get_count (&remote_tree->elements);
     for (ielem = 0; ielem < elem_count - 1; ielem++) {
-      const t8_element_t * test_el = t8_element_array_index_int (&remote_tree->elements, ielem);
+      const t8_element_t *test_el = t8_element_array_index_int (&remote_tree->elements, ielem);
       SC_CHECK_ABORTF (!ts->t8_element_equal (test_el, elem), "Local element %i already in remote ghosts at pos %i\n",
                        element_index, ielem);
     }

--- a/src/t8_forest/t8_forest_iterate.cxx
+++ b/src/t8_forest/t8_forest_iterate.cxx
@@ -30,7 +30,7 @@ T8_EXTERN_C_BEGIN ();
 
 typedef struct
 {
-  t8_eclass_scheme_c *ts;
+  const t8_eclass_scheme_c *ts;
   int level;
   int num_children;
 } t8_forest_child_type_query_t;
@@ -54,17 +54,16 @@ void
 t8_forest_split_array (const t8_element_t *element, t8_element_array_t *leaf_elements, size_t *offsets)
 {
   sc_array_t offset_view;
-  sc_array_t *element_array;
   t8_forest_child_type_query_t query_data;
-  t8_eclass_scheme_c *ts;
+  
 
-  ts = t8_element_array_get_scheme (leaf_elements);
+  const t8_eclass_scheme_c * ts = t8_element_array_get_scheme (leaf_elements);
   /* Store the number of children and the level of element */
   query_data.num_children = ts->t8_element_num_children (element);
   query_data.level = ts->t8_element_level (element);
   query_data.ts = ts;
 
-  element_array = t8_element_array_get_array (leaf_elements);
+  sc_array_t *element_array = t8_element_array_get_array_mutable (leaf_elements);
   /* Split the elements array according to the elements' ancestor id at
    * the given level. In other words for each child C of element, find
    * the indices i, j such that all descendants of C are
@@ -82,7 +81,7 @@ t8_forest_iterate_faces (t8_forest_t forest, t8_locidx_t ltreeid, const t8_eleme
 {
   t8_eclass_scheme_c *ts;
   t8_eclass_t eclass;
-  t8_element_t *leaf, **face_children;
+  t8_element_t **face_children;
   int child_face, num_face_children, iface;
   int *child_indices;
   size_t *split_offsets, indexa, indexb, elem_count;
@@ -102,7 +101,7 @@ t8_forest_iterate_faces (t8_forest_t forest, t8_locidx_t ltreeid, const t8_eleme
   if (elem_count == 1) {
     /* There is only one leaf left, we check whether it is the same as element
      * and if so call the callback function */
-    leaf = t8_element_array_index_locidx (leaf_elements, 0);
+    const t8_element_t * leaf = t8_element_array_index_locidx (leaf_elements, 0);
     if (ts->t8_element_equal (element, leaf)) {
       /* The element is the leaf, we are at the last stage of the recursion
        * and can call the callback. */
@@ -112,7 +111,7 @@ t8_forest_iterate_faces (t8_forest_t forest, t8_locidx_t ltreeid, const t8_eleme
   }
 #ifdef T8_ENABLE_DEBUG
   /* Check whether element has greater level than the first leaf */
-  leaf = t8_element_array_index_locidx (leaf_elements, 0);
+  const t8_element_t * leaf = t8_element_array_index_locidx (leaf_elements, 0);
   T8_ASSERT (ts->t8_element_level (element) < ts->t8_element_level (leaf));
 #endif
 

--- a/src/t8_forest/t8_forest_iterate.cxx
+++ b/src/t8_forest/t8_forest_iterate.cxx
@@ -55,9 +55,8 @@ t8_forest_split_array (const t8_element_t *element, t8_element_array_t *leaf_ele
 {
   sc_array_t offset_view;
   t8_forest_child_type_query_t query_data;
-  
 
-  const t8_eclass_scheme_c * ts = t8_element_array_get_scheme (leaf_elements);
+  const t8_eclass_scheme_c *ts = t8_element_array_get_scheme (leaf_elements);
   /* Store the number of children and the level of element */
   query_data.num_children = ts->t8_element_num_children (element);
   query_data.level = ts->t8_element_level (element);
@@ -101,7 +100,7 @@ t8_forest_iterate_faces (t8_forest_t forest, t8_locidx_t ltreeid, const t8_eleme
   if (elem_count == 1) {
     /* There is only one leaf left, we check whether it is the same as element
      * and if so call the callback function */
-    const t8_element_t * leaf = t8_element_array_index_locidx (leaf_elements, 0);
+    const t8_element_t *leaf = t8_element_array_index_locidx (leaf_elements, 0);
     if (ts->t8_element_equal (element, leaf)) {
       /* The element is the leaf, we are at the last stage of the recursion
        * and can call the callback. */
@@ -111,7 +110,7 @@ t8_forest_iterate_faces (t8_forest_t forest, t8_locidx_t ltreeid, const t8_eleme
   }
 #ifdef T8_ENABLE_DEBUG
   /* Check whether element has greater level than the first leaf */
-  const t8_element_t * leaf = t8_element_array_index_locidx (leaf_elements, 0);
+  const t8_element_t *leaf = t8_element_array_index_locidx (leaf_elements, 0);
   T8_ASSERT (ts->t8_element_level (element) < ts->t8_element_level (leaf));
 #endif
 

--- a/src/t8_forest/t8_forest_partition.cxx
+++ b/src/t8_forest/t8_forest_partition.cxx
@@ -119,7 +119,7 @@ t8_forest_partition_create_offsets (t8_forest_t forest)
 static void
 t8_forest_partition_test_desc (t8_forest_t forest)
 {
-  t8_element_t *element, *elem_desc;
+  t8_element_t *elem_desc;
   t8_linearidx_t first_desc_id;
   t8_locidx_t ielem;
   t8_eclass_scheme_c *ts;
@@ -139,7 +139,7 @@ t8_forest_partition_test_desc (t8_forest_t forest)
   for (ielem = 0; ielem < t8_forest_get_tree_element_count (tree); ielem++) {
     /* Iterate over elems, for each one create the first descendant and check
      * its linear id versus the linear id of first_desc. */
-    element = t8_element_array_index_locidx (&tree->elements, ielem);
+    const t8_element_t *element = t8_element_array_index_locidx (&tree->elements, ielem);
     ts->t8_element_first_descendant (element, elem_desc, forest->maxlevel);
     level = ts->t8_element_level (elem_desc);
     T8_ASSERT (level == ts->t8_element_level (elem_desc));
@@ -569,7 +569,6 @@ t8_forest_partition_fill_buffer (t8_forest_t forest_from, char **send_buffer, in
   int last_element_is_last_tree_element = 0;
   t8_forest_partition_tree_info_t *tree_info;
   t8_locidx_t *pnum_trees_send;
-  void *pfirst_element;
   size_t elem_size;
 
   current_element = first_element_send;
@@ -634,9 +633,9 @@ t8_forest_partition_fill_buffer (t8_forest_t forest_from, char **send_buffer, in
     tree_info_pos += sizeof (t8_forest_partition_tree_info_t);
     /* We can now fill the send buffer with all elements of that tree */
     if (num_elements_send > 0) {
-      pfirst_element = t8_element_array_index_locidx (&tree->elements, first_tree_element);
+      const t8_element_t * pfirst_element = t8_element_array_index_locidx (&tree->elements, first_tree_element);
       elem_size = t8_element_array_get_size (&tree->elements);
-      memcpy (*send_buffer + element_pos, pfirst_element, num_elements_send * elem_size);
+      memcpy (*send_buffer + element_pos, (void *) pfirst_element, num_elements_send * elem_size);
       element_pos += num_elements_send * elem_size;
     }
   }
@@ -902,7 +901,6 @@ t8_forest_partition_recv_message (t8_forest_t forest, sc_MPI_Comm comm, int proc
   t8_forest_partition_tree_info_t *tree_info;
   t8_tree_t tree, last_tree;
   size_t element_size;
-  void *first_new_element;
   t8_eclass_scheme_c *eclass_scheme;
 
   if (proc != forest->mpirank) {
@@ -988,13 +986,13 @@ t8_forest_partition_recv_message (t8_forest_t forest, sc_MPI_Comm comm, int proc
       new_num_elements = old_num_elements + tree_info->num_elements;
       /* Enlarge the elements array */
       t8_element_array_resize (&tree->elements, new_num_elements);
-      first_new_element = t8_element_array_index_locidx (&tree->elements, old_num_elements);
+      t8_element_t * first_new_element = t8_element_array_index_locidx_mutable (&tree->elements, old_num_elements);
       /* Get the size of an element of the tree */
       eclass_scheme = t8_forest_get_eclass_scheme (forest->set_from, tree->eclass);
       element_size = eclass_scheme->t8_element_size ();
       T8_ASSERT (element_size == t8_element_array_get_size (&tree->elements));
       /* Copy the elements from the receive buffer to the elements array */
-      memcpy (first_new_element, recv_buffer + element_cursor, tree_info->num_elements * element_size);
+      memcpy ((void *) first_new_element, recv_buffer + element_cursor, tree_info->num_elements * element_size);
     }
 
     /* compute the new number of local elements */

--- a/src/t8_forest/t8_forest_partition.cxx
+++ b/src/t8_forest/t8_forest_partition.cxx
@@ -633,7 +633,7 @@ t8_forest_partition_fill_buffer (t8_forest_t forest_from, char **send_buffer, in
     tree_info_pos += sizeof (t8_forest_partition_tree_info_t);
     /* We can now fill the send buffer with all elements of that tree */
     if (num_elements_send > 0) {
-      const t8_element_t * pfirst_element = t8_element_array_index_locidx (&tree->elements, first_tree_element);
+      const t8_element_t *pfirst_element = t8_element_array_index_locidx (&tree->elements, first_tree_element);
       elem_size = t8_element_array_get_size (&tree->elements);
       memcpy (*send_buffer + element_pos, (void *) pfirst_element, num_elements_send * elem_size);
       element_pos += num_elements_send * elem_size;
@@ -986,7 +986,7 @@ t8_forest_partition_recv_message (t8_forest_t forest, sc_MPI_Comm comm, int proc
       new_num_elements = old_num_elements + tree_info->num_elements;
       /* Enlarge the elements array */
       t8_element_array_resize (&tree->elements, new_num_elements);
-      t8_element_t * first_new_element = t8_element_array_index_locidx_mutable (&tree->elements, old_num_elements);
+      t8_element_t *first_new_element = t8_element_array_index_locidx_mutable (&tree->elements, old_num_elements);
       /* Get the size of an element of the tree */
       eclass_scheme = t8_forest_get_eclass_scheme (forest->set_from, tree->eclass);
       element_size = eclass_scheme->t8_element_size ();

--- a/src/t8_forest/t8_forest_partition.cxx
+++ b/src/t8_forest/t8_forest_partition.cxx
@@ -635,7 +635,7 @@ t8_forest_partition_fill_buffer (t8_forest_t forest_from, char **send_buffer, in
     if (num_elements_send > 0) {
       const t8_element_t *pfirst_element = t8_element_array_index_locidx (&tree->elements, first_tree_element);
       elem_size = t8_element_array_get_size (&tree->elements);
-      memcpy (*send_buffer + element_pos, (void *) pfirst_element, num_elements_send * elem_size);
+      memcpy (*send_buffer + element_pos, (const void *) pfirst_element, num_elements_send * elem_size);
       element_pos += num_elements_send * elem_size;
     }
   }

--- a/src/t8_forest/t8_forest_private.c
+++ b/src/t8_forest/t8_forest_private.c
@@ -35,7 +35,7 @@ t8_forest_get_tree_element (t8_tree_t tree, t8_locidx_t elem_in_tree)
 t8_element_t*
 t8_forest_get_tree_element_mutable (t8_tree_t tree, t8_locidx_t elem_in_tree)
 {
-  return (t8_element_t *) t8_forest_get_tree_element (tree, elem_in_tree);
+  return (t8_element_t*) t8_forest_get_tree_element (tree, elem_in_tree);
 }
 
 const t8_element_array_t*
@@ -50,5 +50,5 @@ t8_forest_get_tree_element_array (const t8_forest_t forest, t8_locidx_t ltreeid)
 t8_element_array_t*
 t8_forest_get_tree_element_array_mutable (const t8_forest_t forest, t8_locidx_t ltreeid)
 {
-  return (t8_element_array_t *) t8_forest_get_tree_element_array (forest, ltreeid);
+  return (t8_element_array_t*) t8_forest_get_tree_element_array (forest, ltreeid);
 }

--- a/src/t8_forest/t8_forest_private.c
+++ b/src/t8_forest/t8_forest_private.c
@@ -24,7 +24,7 @@
 #include <t8_forest/t8_forest_private.h>
 #include <t8_forest/t8_forest_general.h>
 
-t8_element_t*
+const t8_element_t*
 t8_forest_get_tree_element (t8_tree_t tree, t8_locidx_t elem_in_tree)
 {
   T8_ASSERT (tree != NULL);
@@ -32,11 +32,23 @@ t8_forest_get_tree_element (t8_tree_t tree, t8_locidx_t elem_in_tree)
   return t8_element_array_index_locidx (&tree->elements, elem_in_tree);
 }
 
-t8_element_array_t*
-t8_forest_get_tree_element_array (t8_forest_t forest, t8_locidx_t ltreeid)
+t8_element_t*
+t8_forest_get_tree_element_mutable (t8_tree_t tree, t8_locidx_t elem_in_tree)
+{
+  return (t8_element_t *) t8_forest_get_tree_element (tree, elem_in_tree);
+}
+
+const t8_element_array_t*
+t8_forest_get_tree_element_array (const t8_forest_t forest, t8_locidx_t ltreeid)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
   T8_ASSERT (0 <= ltreeid && ltreeid < t8_forest_get_num_local_trees (forest));
 
   return &t8_forest_get_tree (forest, ltreeid)->elements;
+}
+
+t8_element_array_t*
+t8_forest_get_tree_element_array_mutable (const t8_forest_t forest, t8_locidx_t ltreeid)
+{
+  return (t8_element_array_t *) t8_forest_get_tree_element_array (forest, ltreeid);
 }

--- a/src/t8_forest/t8_forest_private.h
+++ b/src/t8_forest/t8_forest_private.h
@@ -159,23 +159,41 @@ t8_forest_get_coarse_tree_ext (t8_forest_t forest, t8_locidx_t ltreeid, t8_locid
 void
 t8_forest_compute_elements_offset (t8_forest_t forest);
 
-/** Return an element of a tree.
+/** Return an element of a tree. Const version.
+ * \param [in]  tree  The tree.
+ * \param [in]  elem_in_tree The index of the element within the tree.
+ * \return      Returns the element with index \a elem_in_tree of the
+ *              element array of \a tree.
+ */
+const t8_element_t *
+t8_forest_get_tree_element (t8_tree_t tree, t8_locidx_t elem_in_tree);
+
+/** Return an element of a tree. Mutable version.
  * \param [in]  tree  The tree.
  * \param [in]  elem_in_tree The index of the element within the tree.
  * \return      Returns the element with index \a elem_in_tree of the
  *              element array of \a tree.
  */
 t8_element_t *
-t8_forest_get_tree_element (t8_tree_t tree, t8_locidx_t elem_in_tree);
+t8_forest_get_tree_element_mutable (t8_tree_t tree, t8_locidx_t elem_in_tree);
 
-/** Return the array of elements of a tree.
+/** Return the array of elements of a tree. Const version.
+ * \param [in]  forest   The forest.
+ * \param [in]  ltreeid  The local id of a local tree. Must be a valid local tree id.
+ * \return      Returns the array of elements of the tree.
+ * \a forest must be committed before calling this function.
+ */
+const t8_element_array_t *
+t8_forest_get_tree_element_array (t8_forest_t forest, t8_locidx_t ltreeid);
+
+/** Return the array of elements of a tree. Mutable version.
  * \param [in]  forest   The forest.
  * \param [in]  ltreeid  The local id of a local tree. Must be a valid local tree id.
  * \return      Returns the array of elements of the tree.
  * \a forest must be committed before calling this function.
  */
 t8_element_array_t *
-t8_forest_get_tree_element_array (t8_forest_t forest, t8_locidx_t ltreeid);
+t8_forest_get_tree_element_array_mutable (const t8_forest_t forest, t8_locidx_t ltreeid);
 
 /** Find the owner process of a given element, deprecated version.
  * Use t8_forest_element_find_owner instead.


### PR DESCRIPTION
**_Describe your changes here:_**

- Added const parameters to all functions where possible of the element array class.
- Added additional "_mutable" versions of function if it was necessary to have a non-const version besides a const version.
- Applied the changes throughout t8code

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
