### PR TITLE
Fix offset assertion, for empty procs first tree is allowed to equal num trees

### DIFF
--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1241,7 +1241,7 @@ t8_forest_tree_shared (t8_forest_t forest, int first_or_last)
   T8_ASSERT (first_or_last == 0 || first_or_last == 1);
   T8_ASSERT (forest != NULL);
   T8_ASSERT (forest->first_local_tree > -1);
-  T8_ASSERT (forest->first_local_tree < forest->global_num_trees);
+  T8_ASSERT (forest->first_local_tree <= forest->global_num_trees);
   T8_ASSERT (forest->last_local_tree < forest->global_num_trees);
 #if T8_ENABLE_DEBUG
   if (forest->first_local_tree == 0 && forest->last_local_tree == -1) {


### PR DESCRIPTION
**_Describe your changes here:_**

This PR fixes the following mwe, that runs into the wrong assertion on 8 procs.
On empty procs, first_tree might equal num_trees.

```
#include <t8.h>
#include <t8_cmesh/t8_cmesh_examples.h>
#include <t8_schemes/t8_default/t8_default_cxx.hxx>
#include <t8_forest/t8_forest_general.h>

static void
t8_mwe_cmesh_partition (){
  int level = 1;
  t8_cmesh_t cmesh = t8_cmesh_new_hypercube(T8_ECLASS_LINE, sc_MPI_COMM_WORLD, 0, 0, 0);
  t8_cmesh_t partitioned_cmesh;
  t8_cmesh_init(&partitioned_cmesh);
  t8_scheme_cxx_t *ts = t8_scheme_new_default_cxx();
  t8_scheme_cxx_ref(ts);
  t8_cmesh_set_derive(partitioned_cmesh, cmesh);
  t8_cmesh_set_partition_uniform(partitioned_cmesh, level, ts);
  t8_cmesh_commit(partitioned_cmesh, sc_MPI_COMM_WORLD);
  
  t8_forest_t forest = t8_forest_new_uniform(partitioned_cmesh, ts, level, 0, sc_MPI_COMM_WORLD);
  t8_forest_unref (&forest);
}

int
main (int argc, char **argv)
{
  int mpiret;

  mpiret = sc_MPI_Init (&argc, &argv);
  SC_CHECK_MPI (mpiret);

  sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_ESSENTIAL);
  t8_init (SC_LP_DEBUG);

  t8_mwe_cmesh_partition();

  sc_finalize ();

  mpiret = sc_MPI_Finalize ();
  SC_CHECK_MPI (mpiret);
  return 0;
}
```

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
