### PR TITLE
Add doc and check for t8_cmesh_set_partition_uniform

### DIFF
--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -205,10 +205,10 @@ t8_cmesh_set_partition_range (t8_cmesh_t cmesh, int set_face_knowledge, t8_gloid
 void
 t8_cmesh_set_partition_offsets (t8_cmesh_t cmesh, t8_shmem_array_t tree_offsets);
 
-/** Declare if the cmesh is understood as a partitioned cmesh where the partition
- * table is derived from an assumed uniform refinement of a given level.
+/** Declare if a derived cmesh should be partitioned according to a
+ * uniform refinement of a given level for the provided scheme.
  * This call is only valid when the cmesh is not yet committed via a call
- * to \ref t8_cmesh_commit.
+ * to \ref t8_cmesh_commit and when the cmesh will be derived.
  * \param [in,out] cmesh          The cmesh to be updated.
  * \param [in]     element_level  The refinement_level.
  * \param [in]     ts             The element scheme describing the refinement pattern.

--- a/src/t8_cmesh/t8_cmesh_commit.cxx
+++ b/src/t8_cmesh/t8_cmesh_commit.cxx
@@ -248,6 +248,10 @@ t8_cmesh_commit_partitioned_new (t8_cmesh_t cmesh, sc_MPI_Comm comm)
     /* Get the number of local trees */
     cmesh->num_local_trees = t8_offset_num_trees (cmesh->mpirank, tree_offsets);
   }
+  else {
+    SC_CHECK_ABORT (cmesh->set_partition_level < 0,
+                    "Do not use t8_cmesh_set_partition_uniform when creating a cmesh from stash!\n");
+  }
   /* The first_tree and first_tree_shared entries must be set by now */
   T8_ASSERT (cmesh->first_tree >= 0);
   T8_ASSERT (cmesh->first_tree_shared >= 0);


### PR DESCRIPTION
**_Describe your changes here:_**
t8_cmesh_set_partition_uniform is only allowed to be called when deriving a cmesh, since when commiting from stash we do not know which proc is responsible for which part of the tree information. 


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [x] Should this use case be added to the github action?
  - [x] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [x] The author added a BSD statement to `doc/` (or already has one)
