### PR TITLE
Adjust behaviour for forests with vertex elements for t8_forest_min_nonempty_level 

### DIFF
--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -258,6 +258,10 @@ t8_forest_min_nonempty_level (t8_cmesh_t cmesh, t8_scheme_cxx_t *scheme)
     }
   }
 
+  if (min_num_children == 1) {
+    return -1;
+  }
+
   /* To compute the level, we need the smallest l such that
    * trees * min_num_child^l >= mpisize
    *  <=>  l >= log (mpisize/trees) / log (min_num_child)

--- a/src/t8_forest/t8_forest_private.h
+++ b/src/t8_forest/t8_forest_private.h
@@ -89,7 +89,7 @@ void
 t8_forest_compute_maxlevel (t8_forest_t forest);
 
 /** Compute the minimum possible uniform refinement level on a cmesh such
- * that no process is empty.
+ * that no process is empty. Returns -1, if cmesh contains a vertex tree.
  * \param [in]  cmesh       The cmesh.
  * \param [in]  scheme      The element scheme for which refinement is considered.
  * \return                  The smallest refinement level l, such that a


### PR DESCRIPTION
**_Describe your changes here:_**
Currently, for vertex elements, t8_forest_min_nonempty_level results in (int)ceil(log(a)/log(1)), which is not defined.
As for vertex trees, no level gains additional elements, and no level results in all nonempty procs, we return -1.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
