### PR TITLE
Fix 1083 iterate replace test failing

### DIFF
--- a/test/t8_forest/t8_gtest_element_is_leaf.cxx
+++ b/test/t8_forest/t8_gtest_element_is_leaf.cxx
@@ -97,8 +97,8 @@ class element_is_leaf: public testing::TestWithParam<std::tuple<int, cmesh_examp
     }
   }
 
-  t8_forest_t forest = NULL;
-  t8_forest_t forest_adapt = NULL;
+  t8_forest_t forest {NULL};
+  t8_forest_t forest_adapt {NULL};
   t8_scheme_cxx_t *scheme;
 };
 

--- a/test/t8_forest/t8_gtest_element_is_leaf.cxx
+++ b/test/t8_forest/t8_gtest_element_is_leaf.cxx
@@ -97,8 +97,8 @@ class element_is_leaf: public testing::TestWithParam<std::tuple<int, cmesh_examp
     }
   }
 
-  t8_forest_t forest {NULL};
-  t8_forest_t forest_adapt {NULL};
+  t8_forest_t forest { NULL };
+  t8_forest_t forest_adapt { NULL };
   t8_scheme_cxx_t *scheme;
 };
 

--- a/test/t8_forest/t8_gtest_element_is_leaf.cxx
+++ b/test/t8_forest/t8_gtest_element_is_leaf.cxx
@@ -73,6 +73,7 @@ class element_is_leaf: public testing::TestWithParam<std::tuple<int, cmesh_examp
     t8_cmesh_t cmesh = std::get<1> (GetParam ())->cmesh_create ();
     if (t8_cmesh_is_empty (cmesh)) {
       /* forest_commit does not support empty cmeshes, we skip this case */
+      t8_cmesh_unref (&cmesh);
       GTEST_SKIP ();
     }
     /* Build the default scheme (TODO: Test this with all schemes) */
@@ -88,17 +89,16 @@ class element_is_leaf: public testing::TestWithParam<std::tuple<int, cmesh_examp
   void
   TearDown () override
   {
-    if (t8_cmesh_is_empty (cmesh)) {
-      t8_cmesh_destroy (&cmesh);
-    }
-    else {
+    if (forest != NULL) {
       t8_forest_unref (&forest);
+    }
+    if (forest_adapt != NULL) {
       t8_forest_unref (&forest_adapt);
     }
   }
 
-  t8_cmesh_t cmesh;
-  t8_forest_t forest, forest_adapt;
+  t8_forest_t forest = NULL;
+  t8_forest_t forest_adapt = NULL;
   t8_scheme_cxx_t *scheme;
 };
 

--- a/test/t8_forest/t8_gtest_element_is_leaf.cxx
+++ b/test/t8_forest/t8_gtest_element_is_leaf.cxx
@@ -70,7 +70,7 @@ class element_is_leaf: public testing::TestWithParam<std::tuple<int, cmesh_examp
   {
     /* Construct a cmesh */
     const int level = std::get<0> (GetParam ());
-    cmesh = std::get<1> (GetParam ())->cmesh_create ();
+    t8_cmesh_t cmesh = std::get<1> (GetParam ())->cmesh_create ();
     if (t8_cmesh_is_empty (cmesh)) {
       /* forest_commit does not support empty cmeshes, we skip this case */
       GTEST_SKIP ();

--- a/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
@@ -55,7 +55,7 @@ class forest_iterate: public testing::TestWithParam<cmesh_example_base *> {
       t8_forest_unref (&forest);
     }
   }
-  t8_forest_t forest {NULL};
+  t8_forest_t forest { NULL };
 };
 
 /** This structure contains an array with all return values of all

--- a/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
@@ -55,7 +55,7 @@ class forest_iterate: public testing::TestWithParam<cmesh_example_base *> {
       t8_forest_unref (&forest);
     }
   }
-  t8_forest_t forest = NULL;
+  t8_forest_t forest {NULL};
 };
 
 /** This structure contains an array with all return values of all

--- a/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
@@ -40,7 +40,7 @@ class forest_iterate: public testing::TestWithParam<cmesh_example_base *> {
   void
   SetUp () override
   {
-    cmesh = GetParam ()->cmesh_create ();
+    t8_cmesh_t cmesh = GetParam ()->cmesh_create ();
     if (t8_cmesh_is_empty (cmesh)) {
       /* empty cmeshes are currently not supported */
       GTEST_SKIP ();
@@ -50,15 +50,11 @@ class forest_iterate: public testing::TestWithParam<cmesh_example_base *> {
   void
   TearDown () override
   {
-    if (t8_cmesh_is_empty (cmesh)) {
-      t8_cmesh_unref (&cmesh);
-    }
-    else {
+    if (forest != NULL) {
       t8_forest_unref (&forest);
     }
   }
-  t8_cmesh_t cmesh;
-  t8_forest_t forest;
+  t8_forest_t forest = NULL;
 };
 
 /** This structure contains an array with all return values of all

--- a/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
@@ -43,6 +43,7 @@ class forest_iterate: public testing::TestWithParam<cmesh_example_base *> {
     t8_cmesh_t cmesh = GetParam ()->cmesh_create ();
     if (t8_cmesh_is_empty (cmesh)) {
       /* empty cmeshes are currently not supported */
+      t8_cmesh_unref (&cmesh);
       GTEST_SKIP ();
     }
     forest = t8_forest_new_uniform (cmesh, t8_scheme_new_default_cxx (), 4, 0, sc_MPI_COMM_WORLD);


### PR DESCRIPTION
**_Describe your changes here:_**

The test test/t8_forest_incomplete/t8_gtest_iterate_replace failed on Mac and had memory issues on Ubuntu.

The problem was a wrong reference handling of a cmesh as test variable.
The cmesh was associated with a forest and the forest changed the cmesh due to partitioning.

During clean up the test tried to remove the original cmesh (which did not exist any longer) instead of removing the new, changed cmesh.

The same logical error occured in the new element_is_leaf test as well.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
