### PR TITLE
enable partitioned cmeshs in tests

### DIFF
--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1419,6 +1419,17 @@ t8_forest_new_uniform (t8_cmesh_t cmesh, t8_scheme_cxx_t *scheme, const int leve
   /* Initialize the forest */
   t8_forest_init (&forest);
   /* Set the cmesh, scheme and level */
+
+  if (cmesh->set_partition) {
+    t8_cmesh_t cmesh_uniform_partition;
+    t8_cmesh_init (&cmesh_uniform_partition);
+    t8_cmesh_set_derive (cmesh_uniform_partition, cmesh);
+    t8_scheme_cxx_ref (scheme);
+    t8_cmesh_set_partition_uniform (cmesh_uniform_partition, level, scheme);
+    t8_cmesh_commit (cmesh_uniform_partition, comm);
+    cmesh = cmesh_uniform_partition;
+  }
+
   t8_forest_set_cmesh (forest, cmesh, comm);
   t8_forest_set_scheme (forest, scheme);
   t8_forest_set_level (forest, level);

--- a/test/t8_cmesh/t8_gtest_cmesh_set_join_by_vertices.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_set_join_by_vertices.cxx
@@ -450,6 +450,9 @@ class t8_cmesh_set_join_by_vertices_class: public testing::TestWithParam<cmesh_e
     }
 
     cmesh = GetParam ()->cmesh_create ();
+    if (cmesh->set_partition) {
+      GTEST_SKIP ();
+    }
   }
 
   void

--- a/test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_hypercube_param.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_hypercube_param.hxx
@@ -61,7 +61,7 @@ example_set *cmesh_example = (example_set *) new cmesh_cartesian_product_params<
   std::make_pair (periodic_eclasses.begin (), periodic_eclasses.end ()),
   std::make_pair (cmesh_params::my_comms.begin (), cmesh_params::my_comms.end ()),
   std::make_pair (cmesh_params::do_bcast.begin (), cmesh_params::do_bcast.end ()),
-  std::make_pair (cmesh_params::no_partition.begin (), cmesh_params::no_partition.end ()),
+  std::make_pair (cmesh_params::partition.begin (), cmesh_params::partition.end ()),
   std::make_pair (cmesh_params::periodic.begin (), cmesh_params::periodic.end ()), cmesh_wrapper, param_to_string,
   "t8_cmesh_new_hypercube_");
 
@@ -72,7 +72,7 @@ example_set *cmesh_example_pyra = (example_set *) new cmesh_cartesian_product_pa
   std::make_pair (nonperiodic_eclasses.begin (), nonperiodic_eclasses.end ()),
   std::make_pair (cmesh_params::my_comms.begin (), cmesh_params::my_comms.end ()),
   std::make_pair (cmesh_params::do_bcast.begin (), cmesh_params::do_bcast.end ()),
-  std::make_pair (cmesh_params::no_partition.begin (), cmesh_params::no_partition.end ()),
+  std::make_pair (cmesh_params::partition.begin (), cmesh_params::partition.end ()),
   std::make_pair (cmesh_params::no_periodic.begin (), cmesh_params::no_periodic.end ()), cmesh_wrapper, param_to_string,
   "t8_cmesh_new_hypercube_");
 }  // namespace new_hypercube_cmesh


### PR DESCRIPTION
**_Describe your changes here:_**
For a long time, we had the partitioned cmeshs disabled, since tests were failing.
This PR enables them again. Some tests still fail on 8 procs, but this is being worked on


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
