### PR TITLE
Revert "enable partitioned cmeshs in tests"

### DIFF
--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1419,17 +1419,6 @@ t8_forest_new_uniform (t8_cmesh_t cmesh, t8_scheme_cxx_t *scheme, const int leve
   /* Initialize the forest */
   t8_forest_init (&forest);
   /* Set the cmesh, scheme and level */
-
-  if (cmesh->set_partition) {
-    t8_cmesh_t cmesh_uniform_partition;
-    t8_cmesh_init (&cmesh_uniform_partition);
-    t8_cmesh_set_derive (cmesh_uniform_partition, cmesh);
-    t8_scheme_cxx_ref (scheme);
-    t8_cmesh_set_partition_uniform (cmesh_uniform_partition, level, scheme);
-    t8_cmesh_commit (cmesh_uniform_partition, comm);
-    cmesh = cmesh_uniform_partition;
-  }
-
   t8_forest_set_cmesh (forest, cmesh, comm);
   t8_forest_set_scheme (forest, scheme);
   t8_forest_set_level (forest, level);

--- a/test/t8_cmesh/t8_gtest_cmesh_set_join_by_vertices.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_set_join_by_vertices.cxx
@@ -450,9 +450,6 @@ class t8_cmesh_set_join_by_vertices_class: public testing::TestWithParam<cmesh_e
     }
 
     cmesh = GetParam ()->cmesh_create ();
-    if (cmesh->set_partition) {
-      GTEST_SKIP ();
-    }
   }
 
   void

--- a/test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_hypercube_param.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parametrized_examples/t8_cmesh_new_hypercube_param.hxx
@@ -61,7 +61,7 @@ example_set *cmesh_example = (example_set *) new cmesh_cartesian_product_params<
   std::make_pair (periodic_eclasses.begin (), periodic_eclasses.end ()),
   std::make_pair (cmesh_params::my_comms.begin (), cmesh_params::my_comms.end ()),
   std::make_pair (cmesh_params::do_bcast.begin (), cmesh_params::do_bcast.end ()),
-  std::make_pair (cmesh_params::partition.begin (), cmesh_params::partition.end ()),
+  std::make_pair (cmesh_params::no_partition.begin (), cmesh_params::no_partition.end ()),
   std::make_pair (cmesh_params::periodic.begin (), cmesh_params::periodic.end ()), cmesh_wrapper, param_to_string,
   "t8_cmesh_new_hypercube_");
 
@@ -72,7 +72,7 @@ example_set *cmesh_example_pyra = (example_set *) new cmesh_cartesian_product_pa
   std::make_pair (nonperiodic_eclasses.begin (), nonperiodic_eclasses.end ()),
   std::make_pair (cmesh_params::my_comms.begin (), cmesh_params::my_comms.end ()),
   std::make_pair (cmesh_params::do_bcast.begin (), cmesh_params::do_bcast.end ()),
-  std::make_pair (cmesh_params::partition.begin (), cmesh_params::partition.end ()),
+  std::make_pair (cmesh_params::no_partition.begin (), cmesh_params::no_partition.end ()),
   std::make_pair (cmesh_params::no_periodic.begin (), cmesh_params::no_periodic.end ()), cmesh_wrapper, param_to_string,
   "t8_cmesh_new_hypercube_");
 }  // namespace new_hypercube_cmesh


### PR DESCRIPTION
Reverts DLR-AMR/t8code#1103

The tests were failing on main.