### PR TITLE
Fix a small TODO

### DIFF
--- a/src/t8_cmesh/t8_cmesh_partition.cxx
+++ b/src/t8_cmesh/t8_cmesh_partition.cxx
@@ -1766,7 +1766,7 @@ t8_cmesh_offset_percent (t8_cmesh_t cmesh, sc_MPI_Comm comm, int percent)
   int created = 0;
 #if T8_ENABLE_DEBUG
   int total = 0;
-  sc_MPI_Allgather (&percent, 1, sc_MPI_INT, &total, 1, sc_MPI_INT, comm);
+  sc_MPI_Allreduce (&percent, &total, 1, sc_MPI_INT, sc_MPI_SUM, comm);
   T8_ASSERT (total == 100);
 #endif
 

--- a/src/t8_cmesh/t8_cmesh_partition.cxx
+++ b/src/t8_cmesh/t8_cmesh_partition.cxx
@@ -1755,7 +1755,6 @@ t8_cmesh_offset_random (sc_MPI_Comm comm, t8_gloidx_t num_trees, int shared, uns
   return shmem_array;
 }
 
-/* TODO: Check that percent is the same on each process */
 t8_shmem_array_t
 t8_cmesh_offset_percent (t8_cmesh_t cmesh, sc_MPI_Comm comm, int percent)
 {
@@ -1765,6 +1764,11 @@ t8_cmesh_offset_percent (t8_cmesh_t cmesh, sc_MPI_Comm comm, int percent)
   const t8_gloidx_t *old_partition;
   int mpirank, mpisize, mpiret;
   int created = 0;
+#if T8_ENABLE_DEBUG
+  int total = 0;
+  sc_MPI_Allgather (&percent, 1, sc_MPI_INT, &total, 1, sc_MPI_INT, comm);
+  T8_ASSERT (total == 100);
+#endif
 
   T8_ASSERT (t8_cmesh_is_committed (cmesh));
   T8_ASSERT (t8_cmesh_comm_is_valid (cmesh, comm));


### PR DESCRIPTION
Found a small TODO and fixed it. 

Allreduce percentages in debug-mode and check if they add up to 100 for cmesh_partition_percentage. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
