### PR TITLE
More const for t8_cmesh_partition

### DIFF
--- a/src/t8_cmesh/t8_cmesh_copy.c
+++ b/src/t8_cmesh/t8_cmesh_copy.c
@@ -33,7 +33,7 @@
 #include "t8_cmesh_copy.h"
 
 void
-t8_cmesh_copy (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, sc_MPI_Comm comm)
+t8_cmesh_copy (t8_cmesh_t cmesh, const t8_cmesh_t cmesh_from, sc_MPI_Comm comm)
 {
   size_t num_parts, iz;
   t8_locidx_t first_tree, num_trees, first_ghost, num_ghosts;

--- a/src/t8_cmesh/t8_cmesh_geometry.cxx
+++ b/src/t8_cmesh/t8_cmesh_geometry.cxx
@@ -43,7 +43,7 @@ t8_cmesh_register_geometry (t8_cmesh_t cmesh, t8_geometry_c **geometry)
 }
 
 void
-t8_cmesh_set_tree_geometry (t8_cmesh_t cmesh, t8_gloidx_t gtreeid, const t8_geometry_c *geom)
+t8_cmesh_set_tree_geometry (t8_cmesh_t cmesh, const t8_gloidx_t gtreeid, const t8_geometry_c *geom)
 {
   T8_ASSERT (t8_cmesh_is_initialized (cmesh));
   /* Add the hash of the geometry as an attribute to the tree. */
@@ -53,7 +53,7 @@ t8_cmesh_set_tree_geometry (t8_cmesh_t cmesh, t8_gloidx_t gtreeid, const t8_geom
 }
 
 const t8_geometry_c *
-t8_cmesh_get_tree_geometry (t8_cmesh_t cmesh, t8_gloidx_t gtreeid)
+t8_cmesh_get_tree_geometry (const t8_cmesh_t cmesh, const t8_gloidx_t gtreeid)
 {
   T8_ASSERT (t8_cmesh_is_committed (cmesh));
   t8_geometry_handler *geom_handler = cmesh->geometry_handler;
@@ -70,7 +70,7 @@ t8_cmesh_get_tree_geometry (t8_cmesh_t cmesh, t8_gloidx_t gtreeid)
 }
 
 size_t
-t8_cmesh_get_tree_geom_hash (t8_cmesh_t cmesh, t8_gloidx_t gtreeid)
+t8_cmesh_get_tree_geom_hash (const t8_cmesh_t cmesh, const t8_gloidx_t gtreeid)
 {
   T8_ASSERT (t8_cmesh_is_committed (cmesh));
   t8_geometry_handler *geom_handler = cmesh->geometry_handler;

--- a/src/t8_cmesh/t8_cmesh_netcdf.c
+++ b/src/t8_cmesh/t8_cmesh_netcdf.c
@@ -101,7 +101,7 @@ typedef struct
 
 /* The UGRID conventions are applied for dimension and variable descriptions */
 static void
-t8_cmesh_init_ugrid_namespace_context (t8_cmesh_netcdf_ugrid_namespace_t *namespace_conv, int dim)
+t8_cmesh_init_ugrid_namespace_context (t8_cmesh_netcdf_ugrid_namespace_t *namespace_conv, const int dim)
 {
   if (dim == 2) {
     namespace_conv->mesh = "Mesh2";

--- a/src/t8_cmesh/t8_cmesh_offset.c
+++ b/src/t8_cmesh/t8_cmesh_offset.c
@@ -364,7 +364,7 @@ t8_offset_all_owners_of_tree (const int mpisize, const t8_gloidx_t gtree, const 
 /* Return 1 if the process will not send any trees, that is if it is
  * empty or has only one shared tree. */
 int
-t8_offset_nosend (int proc, int mpisize, const t8_gloidx_t *offset_from, const t8_gloidx_t *offset_to)
+t8_offset_nosend (const int proc, const int mpisize, const t8_gloidx_t *offset_from, const t8_gloidx_t *offset_to)
 {
   t8_gloidx_t num_trees;
 
@@ -432,7 +432,7 @@ t8_offset_nosend (int proc, int mpisize, const t8_gloidx_t *offset_from, const t
 /* Return one if proca sends trees to procb when partitioning from
  * offset_from to offset_to */
 int
-t8_offset_sendsto (int proca, int procb, const t8_gloidx_t *t8_offset_from, const t8_gloidx_t *t8_offset_to)
+t8_offset_sendsto (const int proca, const int procb, const t8_gloidx_t *t8_offset_from, const t8_gloidx_t *t8_offset_to)
 {
   t8_gloidx_t proca_first, proca_last;
   t8_gloidx_t procb_first, procb_last;
@@ -476,7 +476,7 @@ t8_offset_sendsto (int proca, int procb, const t8_gloidx_t *t8_offset_from, cons
 /* Determine whether a process A will send a tree T to a process B.
  */
 int
-t8_offset_sendstree (int proc_send, int proc_to, t8_gloidx_t gtree, const t8_gloidx_t *offset_from,
+t8_offset_sendstree (const int proc_send, const int proc_to, const t8_gloidx_t gtree, const t8_gloidx_t *offset_from,
                      const t8_gloidx_t *offset_to)
 {
   /* If the tree is not the last tree on proc_send it is send if
@@ -512,7 +512,8 @@ t8_offset_sendstree (int proc_send, int proc_to, t8_gloidx_t gtree, const t8_glo
 /* Count the number of sending procs from start to end sending to mpirank
  * A process counts as sending if it has at least one non-shared local tree */
 int
-t8_offset_range_send (int start, int end, int mpirank, const t8_gloidx_t *offset_from, const t8_gloidx_t *offset_to)
+t8_offset_range_send (const int start, const int end, const int mpirank, const t8_gloidx_t *offset_from,
+                      const t8_gloidx_t *offset_to)
 {
   int count = 0, i;
 
@@ -525,7 +526,7 @@ t8_offset_range_send (int start, int end, int mpirank, const t8_gloidx_t *offset
 }
 
 void
-t8_offset_print (t8_shmem_array_t offset, sc_MPI_Comm comm)
+t8_offset_print (const t8_shmem_array_t offset, sc_MPI_Comm comm)
 {
 #if T8_ENABLE_DEBUG
   char buf[BUFSIZ] = "| ";

--- a/src/t8_cmesh/t8_cmesh_partition.cxx
+++ b/src/t8_cmesh/t8_cmesh_partition.cxx
@@ -39,7 +39,8 @@
  * Output: The face neighbor entry is changed to match its new id in cmesh.
  */
 static void
-t8_cmesh_partition_send_change_neighbor (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, t8_locidx_t *neighbor, int to_proc)
+t8_cmesh_partition_send_change_neighbor (const t8_cmesh_t cmesh, const t8_cmesh_t cmesh_from, t8_locidx_t *neighbor,
+                                         const int to_proc)
 {
   t8_gloidx_t temp;
   const t8_gloidx_t *tree_offset = t8_shmem_array_get_gloidx_array (cmesh->tree_offsets);
@@ -75,7 +76,8 @@ t8_cmesh_partition_send_change_neighbor (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from
  * We also insert their global ids into the hash table of global_id -> local_id
  */
 static void
-t8_partition_new_ghost_ids (t8_cmesh_t cmesh, t8_part_tree_t recv_part, t8_locidx_t first_ghost, int proc)
+t8_partition_new_ghost_ids (const t8_cmesh_t cmesh, const t8_part_tree_t recv_part, const t8_locidx_t first_ghost,
+                            const int proc)
 {
   t8_locidx_t ghost_it;
   t8_cghost_t ghost;
@@ -122,7 +124,7 @@ t8_partition_new_ghost_ids (t8_cmesh_t cmesh, t8_part_tree_t recv_part, t8_locid
 /* From num_local_trees_per_eclass compute num_trees_per_eclass.
  * collective function */
 void
-t8_cmesh_gather_trees_per_eclass (t8_cmesh_t cmesh, sc_MPI_Comm comm)
+t8_cmesh_gather_trees_per_eclass (const t8_cmesh_t cmesh, sc_MPI_Comm comm)
 {
   t8_gloidx_t temp_trees_per_eclass[T8_ECLASS_COUNT];
   int ieclass;
@@ -179,7 +181,7 @@ t8_cmesh_gather_trees_per_eclass (t8_cmesh_t cmesh, sc_MPI_Comm comm)
  * additional flag whether to check if cmesh is committed.
  * Warning: use with caution with check_commit = 0 */
 static void
-t8_cmesh_gather_treecount_ext (t8_cmesh_t cmesh, sc_MPI_Comm comm, int check_commit)
+t8_cmesh_gather_treecount_ext (const t8_cmesh_t cmesh, sc_MPI_Comm comm, const int check_commit)
 {
   t8_gloidx_t tree_offset;
   int is_empty, has_empty;
@@ -234,7 +236,7 @@ t8_cmesh_gather_treecount_ext (t8_cmesh_t cmesh, sc_MPI_Comm comm, int check_com
 /* Given a cmesh create its tree_offsets from the local number of
  * trees on each process */
 void
-t8_cmesh_gather_treecount (t8_cmesh_t cmesh, sc_MPI_Comm comm)
+t8_cmesh_gather_treecount (const t8_cmesh_t cmesh, sc_MPI_Comm comm)
 {
   t8_cmesh_gather_treecount_ext (cmesh, comm, 1);
 }
@@ -242,14 +244,14 @@ t8_cmesh_gather_treecount (t8_cmesh_t cmesh, sc_MPI_Comm comm)
 /* Given a cmesh create its tree_offsets from the local number of
  * trees on each process */
 void
-t8_cmesh_gather_treecount_nocommit (t8_cmesh_t cmesh, sc_MPI_Comm comm)
+t8_cmesh_gather_treecount_nocommit (const t8_cmesh_t cmesh, sc_MPI_Comm comm)
 {
   t8_cmesh_gather_treecount_ext (cmesh, comm, 0);
 }
 
 /* A fast way to compute the sendrange */
 static t8_locidx_t
-t8_cmesh_partition_sendrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *send_first, int *send_last)
+t8_cmesh_partition_sendrange (const t8_cmesh_t cmesh, const t8_cmesh_t cmesh_from, int *send_first, int *send_last)
 {
   t8_gloidx_t first_tree = t8_cmesh_get_first_treeid (cmesh_from);
   int sendfirst;
@@ -398,7 +400,7 @@ t8_cmesh_partition_sendrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *send
 
 /* A fast way to compute the receive range */
 static void
-t8_cmesh_partition_recvrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *recv_first, int *recv_last)
+t8_cmesh_partition_recvrange (const t8_cmesh_t cmesh, const t8_cmesh_t cmesh_from, int *recv_first, int *recv_last)
 {
   int recvfirst;
   int recvlast;
@@ -456,7 +458,7 @@ t8_cmesh_partition_recvrange (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *recv
 /* Compute the number of bytes that need to be allocated in the send buffer
  * for the neighbor entries of ghost */
 static size_t
-t8_partition_compute_gnb (t8_cmesh_t cmesh_from, sc_array_t *send_as_ghost)
+t8_partition_compute_gnb (const t8_cmesh_t cmesh_from, sc_array_t *send_as_ghost)
 {
   size_t ghost_neighbor_bytes = 0, ighost;
   t8_locidx_t ghost_id;
@@ -484,7 +486,7 @@ t8_partition_compute_gnb (t8_cmesh_t cmesh_from, sc_array_t *send_as_ghost)
 /* Compute the number of bytes that need to be allocated in the send buffer
  * for the attribute entries of all ghosts. */
 static size_t
-t8_partition_compute_gab (t8_cmesh_t cmesh_from, sc_array_t *send_as_ghost, size_t *attr_info_bytes)
+t8_partition_compute_gab (const t8_cmesh_t cmesh_from, sc_array_t *send_as_ghost, size_t *attr_info_bytes)
 {
   size_t ghost_attribute_bytes = 0, ighost;
   t8_locidx_t ghost_id, ghost_id_min_offset;
@@ -524,7 +526,7 @@ t8_partition_compute_gab (t8_cmesh_t cmesh_from, sc_array_t *send_as_ghost, size
  *  - we are the smallest rank under all procs sending a tree to p that
  *    has this tree as ghost or local tree . */
 static int
-t8_cmesh_send_ghost (t8_cmesh_t cmesh, const struct t8_cmesh *cmesh_from, int p, t8_locidx_t tree)
+t8_cmesh_send_ghost (const t8_cmesh_t cmesh, const struct t8_cmesh *cmesh_from, const int p, const t8_locidx_t tree)
 {
   t8_gloidx_t tree_id, *ghost_neighbors, neighbor;
   const t8_gloidx_t *from_offsets;
@@ -644,11 +646,12 @@ t8_cmesh_send_ghost (t8_cmesh_t cmesh, const struct t8_cmesh *cmesh_from, int p,
 
 /* copy all tree/ghost/attribute data to the send buffer */
 static void
-t8_cmesh_partition_copy_data (char *send_buffer, t8_cmesh_t cmesh, const struct t8_cmesh *cmesh_from,
-                              t8_locidx_t num_trees, size_t attr_info_bytes, size_t ghost_attr_info_bytes,
-                              size_t ghost_neighbor_bytes, size_t tree_neighbor_bytes, size_t tree_attribute_bytes,
-                              sc_array_t *send_as_ghost, t8_locidx_t send_first, t8_locidx_t send_last,
-                              size_t total_alloc, int to_proc)
+t8_cmesh_partition_copy_data (char *send_buffer, t8_cmesh_t cmesh, const t8_cmesh *cmesh_from,
+                              const t8_locidx_t num_trees, const size_t attr_info_bytes,
+                              const size_t ghost_attr_info_bytes, const size_t ghost_neighbor_bytes,
+                              const size_t tree_neighbor_bytes, const size_t tree_attribute_bytes,
+                              sc_array_t *send_as_ghost, const t8_locidx_t send_first, const t8_locidx_t send_last,
+                              const size_t total_alloc, const int to_proc)
 {
   t8_ctree_t tree, tree_cpy;
   int num_attributes;
@@ -900,9 +903,10 @@ t8_cmesh_partition_copy_data (char *send_buffer, t8_cmesh_t cmesh, const struct 
  *    therefore need to be kept local.
  */
 static void
-t8_cmesh_partition_sendtreeloop (t8_cmesh_t cmesh, const struct t8_cmesh *cmesh_from, t8_locidx_t range_start,
-                                 t8_locidx_t range_end, size_t *tree_neighbor_bytes, size_t *attr_bytes,
-                                 size_t *attr_info_bytes, int8_t *ghost_flag_send, int iproc, sc_array_t *send_as_ghost)
+t8_cmesh_partition_sendtreeloop (t8_cmesh_t cmesh, const t8_cmesh *cmesh_from, const t8_locidx_t range_start,
+                                 const t8_locidx_t range_end, size_t *tree_neighbor_bytes, size_t *attr_bytes,
+                                 size_t *attr_info_bytes, int8_t *ghost_flag_send, const int iproc,
+                                 sc_array_t *send_as_ghost)
 {
   t8_ctree_t tree;
   t8_locidx_t neighbor, *face_neighbor, itree;
@@ -1188,8 +1192,8 @@ t8_cmesh_partition_sendloop (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, int *num_r
 }
 
 void
-t8_cmesh_partition_receive_message (t8_cmesh_t cmesh, sc_MPI_Comm comm, int proc_recv, sc_MPI_Status *status,
-                                    int *local_procid, int recv_first, t8_locidx_t *num_ghosts)
+t8_cmesh_partition_receive_message (t8_cmesh_t cmesh, sc_MPI_Comm comm, const int proc_recv, sc_MPI_Status *status,
+                                    const int *local_procid, const int recv_first, t8_locidx_t *num_ghosts)
 {
   int mpiret;
   int recv_bytes;
@@ -1229,7 +1233,7 @@ t8_cmesh_partition_receive_message (t8_cmesh_t cmesh, sc_MPI_Comm comm, int proc
 /* fr and lr are only for debugging, see t8_cmesh_partition_debug_listprocs */
 /* TODO: Remove the const qualifier at the cmesh_from parameter */
 static void
-t8_cmesh_partition_recvloop (t8_cmesh_t cmesh, const struct t8_cmesh *cmesh_from, const t8_gloidx_t *tree_offset,
+t8_cmesh_partition_recvloop (t8_cmesh_t cmesh, const t8_cmesh *cmesh_from, const t8_gloidx_t *tree_offset,
                              char *my_buffer, size_t my_buffer_bytes, sc_MPI_Comm comm, int fr, int lr)
 {
   int num_receive, *local_procid; /* ranks of the processor from which we will receive */
@@ -1378,8 +1382,8 @@ t8_cmesh_partition_recvloop (t8_cmesh_t cmesh, const struct t8_cmesh *cmesh_from
 }
 
 static void
-t8_cmesh_partition_debug_listprocs (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, sc_MPI_Comm comm, int *fs, int *ls,
-                                    int *fr, int *lr)
+t8_cmesh_partition_debug_listprocs (const t8_cmesh_t cmesh, const t8_cmesh_t cmesh_from, sc_MPI_Comm comm, int *fs,
+                                    int *ls, int *fr, int *lr)
 {
   int mpiret, mpisize, mpirank, p;
   char out[BUFSIZ] = "";
@@ -1428,7 +1432,7 @@ t8_cmesh_partition_debug_listprocs (t8_cmesh_t cmesh, t8_cmesh_t cmesh_from, sc_
 /* TODO: remove offset argument and use cmesh_from.tree_offsets */
 /* TODO: remove const */
 static void
-t8_cmesh_partition_given (t8_cmesh_t cmesh, const struct t8_cmesh *cmesh_from, const t8_gloidx_t *tree_offset,
+t8_cmesh_partition_given (const t8_cmesh_t cmesh, const t8_cmesh_t cmesh_from, const t8_gloidx_t *tree_offset,
                           sc_MPI_Comm comm)
 {
   int send_first, send_last, num_request_alloc; /* ranks of the processor to which we will send */
@@ -1607,7 +1611,7 @@ t8_cmesh_partition (t8_cmesh_t cmesh, sc_MPI_Comm comm)
 }
 
 void
-t8_cmesh_offset_print (t8_cmesh_t cmesh, sc_MPI_Comm comm)
+t8_cmesh_offset_print (const t8_cmesh_t cmesh, sc_MPI_Comm comm)
 {
 #if T8_ENABLE_DEBUG
   int offset_isnew = 0;
@@ -1632,7 +1636,7 @@ t8_cmesh_offset_print (t8_cmesh_t cmesh, sc_MPI_Comm comm)
 
 /* Create a partition that concentrates everything at a given proc */
 t8_shmem_array_t
-t8_cmesh_offset_concentrate (int proc, sc_MPI_Comm comm, t8_gloidx_t num_trees)
+t8_cmesh_offset_concentrate (const int proc, sc_MPI_Comm comm, const t8_gloidx_t num_trees)
 {
   int mpirank, mpiret, mpisize, iproc;
   t8_shmem_array_t shmem_array;
@@ -1674,7 +1678,7 @@ t8_cmesh_offset_concentrate (int proc, sc_MPI_Comm comm, t8_gloidx_t num_trees)
 /* Create a random partition */
 /* if shared is nonzero than first trees can be shared */
 t8_shmem_array_t
-t8_cmesh_offset_random (sc_MPI_Comm comm, t8_gloidx_t num_trees, int shared, unsigned seed)
+t8_cmesh_offset_random (sc_MPI_Comm comm, const t8_gloidx_t num_trees, const int shared, const unsigned seed)
 {
   int iproc, mpisize, mpiret, random_number, mpirank;
   int first_shared;

--- a/src/t8_cmesh/t8_cmesh_partition.cxx
+++ b/src/t8_cmesh/t8_cmesh_partition.cxx
@@ -1761,7 +1761,7 @@ t8_cmesh_offset_random (sc_MPI_Comm comm, const t8_gloidx_t num_trees, const int
 
 /* TODO: Check that percent is the same on each process */
 t8_shmem_array_t
-t8_cmesh_offset_percent (t8_cmesh_t cmesh, sc_MPI_Comm comm, int percent)
+t8_cmesh_offset_percent (const t8_cmesh_t cmesh, sc_MPI_Comm comm, const int percent)
 {
   t8_gloidx_t new_first_tree, old_first_tree;
   t8_locidx_t old_num_trees_pm1;
@@ -1826,7 +1826,7 @@ t8_cmesh_offset_percent (t8_cmesh_t cmesh, sc_MPI_Comm comm, int percent)
  * trees to the next process. The last process does not send any trees. */
 /* TODO: This function was not tested with shared trees yet. */
 t8_shmem_array_t
-t8_cmesh_offset_half (t8_cmesh_t cmesh, sc_MPI_Comm comm)
+t8_cmesh_offset_half (const t8_cmesh_t cmesh, sc_MPI_Comm comm)
 {
   return t8_cmesh_offset_percent (cmesh, comm, 50);
 }


### PR DESCRIPTION
Added const into the signatures of the functions in t8-cmesh_partition.cxx



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
