### PR TITLE
CMake: fix install folder structure and added option to compile benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option( T8CODE_BUILD_AS_SHARED_LIBRARY "Whether t8code should be built as a shar
 option( T8CODE_BUILD_TESTS "Build t8code's automated tests" ON )
 option( T8CODE_BUILD_TUTORIALS "Build t8code's tutorials" ON )
 option( T8CODE_BUILD_EXAMPLES "Build t8code's examples" ON )
+option( T8CODE_BUILD_BENCHMARKS "Build t8code's benchmarks" ON )
 
 option( T8CODE_ENABLE_MPI "Enable t8code's features which rely on MPI" ON )
 option( T8CODE_ENABLE_VTK "Enable t8code's features which rely on VTK" OFF )
@@ -92,6 +93,10 @@ endif()
 
 if ( T8CODE_BUILD_EXAMPLES )
     add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/example )
+endif()
+
+if ( T8CODE_BUILD_BENCHMARKS )
+    add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/benchmarks )
 endif()
 
 if ( BUILD_DOCUMENTATION ) 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,19 @@
+function( add_t8_benchmark )
+    set( options "" )
+    set( oneValueArgs "NAME" )
+    set( multiValueArgs "SOURCES" )
+    cmake_parse_arguments( ADD_T8_BENCHMARK "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+    add_executable( ${ADD_T8_BENCHMARK_NAME} ${ADD_T8_BENCHMARK_SOURCES} )
+    target_include_directories( ${ADD_T8_BENCHMARK_NAME} PRIVATE ${PROJECT_SOURCE_DIR} )
+    target_link_libraries( ${ADD_T8_BENCHMARK_NAME} PRIVATE T8 SC::SC )
+
+    install( TARGETS ${ADD_T8_BENCHMARK_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin )
+endfunction()
+
+add_t8_benchmark( NAME t8_time_partition SOURCES time_partition.cxx )
+add_t8_benchmark( NAME t8_time_forest_partition SOURCES time_forest_partition.cxx )
+add_t8_benchmark( NAME t8_time_prism_adapt SOURCES t8_time_prism_adapt.cxx )
+add_t8_benchmark( NAME t8_time_fractal SOURCES t8_time_fractal.cxx )
+add_t8_benchmark( NAME t8_time_set_join_by_vertices SOURCES t8_time_set_join_by_vertices.cxx )
+add_t8_benchmark( NAME t8_bunny SOURCES ExtremeScaling/bunny.cxx )

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -19,7 +19,7 @@ function( add_t8_example )
     target_link_libraries( ${ADD_T8_EXAMPLE_NAME} PRIVATE T8 t8example SC::SC )
     target_include_directories( ${ADD_T8_EXAMPLE_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/.. )
 
-    install( TARGETS ${ADD_T8_EXAMPLE_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/example )
+    install( TARGETS ${ADD_T8_EXAMPLE_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin )
 endfunction()
 
 add_t8_example( NAME t8_advection                       SOURCES advect/t8_advection.cxx )

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -8,7 +8,7 @@ function( add_t8_tutorial )
     target_link_libraries( ${ADD_T8_TUTORIAL_NAME} PRIVATE T8 SC::SC )
     target_include_directories( ${ADD_T8_TUTORIAL_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/.. )
 
-    install( TARGETS ${ADD_T8_TUTORIAL_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/tutorials )
+    install( TARGETS ${ADD_T8_TUTORIAL_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin )
 endfunction()
 
 add_t8_tutorial( NAME t8_step0_helloworld               SOURCES general/t8_step0_helloworld.cxx )


### PR DESCRIPTION
**_Describe your changes here:_**

This PR changes the CMake build system to install all binaries (tutorials, examples) in the /bin folder instead of in separate tutorials/ and example/ folders to mimic the autotools build system and adds an option to compile benchmarks as well.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
