### PR TITLE
Feature enable more procs for check

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,9 @@ dist_t8aclocal_DATA = config/t8_include.m4 \
                       config/t8_stdpp.m4 \
                       config/t8_netcdf.m4 \
                       config/t8_vtk.m4 \
-                      config/t8_occ.m4
+                      config/t8_occ.m4 \
+                      config/t8_mpi.m4
+
 
 # install t8code data in the correct directory
 t8datadir = $(datadir)/t8code/data

--- a/config/t8_mpi.m4
+++ b/config/t8_mpi.m4
@@ -1,33 +1,17 @@
 
-
-
-dnl We are not using precious variables for simplicity
-dnl AC_ARG_VAR([$1_MPIRUN], [mpirun wrapper to invoke for tests on make check])
-
-
-dnl AC_SUBST([T8_MPIRUN])
-
-dnl AC_ARG_VAR([$1_MPI_TEST_FLAGS], [arguments passed to mpirun wrapper on make check])
-
-dnl AC_SUBST([T8_MPI_TEST_FLAGS])
+dnl T8_CHECK_MPI_TEST_FLAGS
+dnl Add configure option "custom-test-command" to define a custom
+dnl command to run tests. For example "mpirun -np 8".
+dnl This will overwrite the variable T8_MPI_TEST_FLAGS.
 
 AC_DEFUN([T8_CHECK_MPI_TEST_FLAGS], [
 	AC_MSG_CHECKING([number of MPI processes used for testing])
-T8_ARG_WITH([test_mpi_num_processes],
-  [Number of MPI processes used for testing. Defaults to 2 if not provided.],
-  [TEST_MPI_NUM_PROCESSES])
+T8_ARG_WITH([custom-test-command],
+  [Define custom test command, e.g.: mpirun -n 4.],
+  [CUSTOM_TEST_COMMAND])
 
-  if test "x$T8_WITH_TEST_MPI_NUM_PROCESSES" != xno ; then
-    T8_MPI_TEST_FLAGS=
-    if test "x$HAVE_PKG_MPI" = xyes ; then
-      AC_CHECK_PROGS([T8_MPIRUN], [mpirun mpiexec])
-      if test "x$$1_MPIRUN" = xmpirun ; then
-        T8_MPI_TEST_FLAGS="-np $T8_WITH_TEST_MPI_NUM_PROCESSES"
-      elif test "x$$1_MPIRUN" = xmpiexec ; then
-        T8_MPI_TEST_FLAGS="-n $T8_WITH_TEST_MPI_NUM_PROCESSES"
-      else
-        T8_MPIRUN=
-      fi
-    fi
+  if test "x$T8_WITH_CUSTOM_TEST_COMMAND" != xno ; then
+    T8_MPI_TEST_FLAGS=$T8_WITH_CUSTOM_TEST_COMMAND
+
   fi
 ])

--- a/config/t8_mpi.m4
+++ b/config/t8_mpi.m4
@@ -1,0 +1,33 @@
+
+
+
+dnl We are not using precious variables for simplicity
+dnl AC_ARG_VAR([$1_MPIRUN], [mpirun wrapper to invoke for tests on make check])
+
+
+dnl AC_SUBST([T8_MPIRUN])
+
+dnl AC_ARG_VAR([$1_MPI_TEST_FLAGS], [arguments passed to mpirun wrapper on make check])
+
+dnl AC_SUBST([T8_MPI_TEST_FLAGS])
+
+AC_DEFUN([T8_CHECK_MPI_TEST_FLAGS], [
+	AC_MSG_CHECKING([number of MPI processes used for testing])
+T8_ARG_WITH([test_mpi_num_processes],
+  [Number of MPI processes used for testing. Defaults to 2 if not provided.],
+  [TEST_MPI_NUM_PROCESSES])
+
+  if test "x$T8_WITH_TEST_MPI_NUM_PROCESSES" != xno ; then
+    T8_MPI_TEST_FLAGS=
+    if test "x$HAVE_PKG_MPI" = xyes ; then
+      AC_CHECK_PROGS([T8_MPIRUN], [mpirun mpiexec])
+      if test "x$$1_MPIRUN" = xmpirun ; then
+        T8_MPI_TEST_FLAGS="-np $T8_WITH_TEST_MPI_NUM_PROCESSES"
+      elif test "x$$1_MPIRUN" = xmpiexec ; then
+        T8_MPI_TEST_FLAGS="-n $T8_WITH_TEST_MPI_NUM_PROCESSES"
+      else
+        T8_MPIRUN=
+      fi
+    fi
+  fi
+]

--- a/config/t8_mpi.m4
+++ b/config/t8_mpi.m4
@@ -30,4 +30,4 @@ T8_ARG_WITH([test_mpi_num_processes],
       fi
     fi
   fi
-]
+])

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,7 @@ dnl Enable C++ and Fortran
 fi
 
 SC_MPI_ENGAGE([T8])
+T8_CHECK_MPI_TEST_FLAGS()
 
 dnl Check for all Fortran related options and features
 T8_CHECK_FORTRAN


### PR DESCRIPTION
**_Describe your changes here:_**

Add a new configure option "custom-test-command".
This is the command use to run test. So setting it to "mpirun -np 8" will execute the tests with 8 processes.

Related to #1134 

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
