### PR TITLE
Fix incomplete trees test.

### DIFF
--- a/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
@@ -153,31 +153,31 @@ t8_adapt_callback (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t whic
   const int id_mod_12 = lelement_id % 12;
   int return_val;
   switch (id_mod_12) {
-    case 0:
-    case 1:
-    case 2:
+  case 0:
+  case 1:
+  case 2:
     /* < 3 */
-      return_val = 0; // keep element
-      break;
-    case 3:
-    case 4:
-    case 5:
+    return_val = 0;  // keep element
+    break;
+  case 3:
+  case 4:
+  case 5:
     /* < 6 */
-      if (is_family) {
-        return_val = -1; // Coarsen family
-      } 
-      else {
-        return_val = 0; // keep if not part of a family
-      }
-      break;
-    case 6:
-    case 7:
-    case 8:
-      return_val = -2; // remove
-      break;
-    default:
-      return_val = 1; // refine
-      break;
+    if (is_family) {
+      return_val = -1;  // Coarsen family
+    }
+    else {
+      return_val = 0;  // keep if not part of a family
+    }
+    break;
+  case 6:
+  case 7:
+  case 8:
+    return_val = -2;  // remove
+    break;
+  default:
+    return_val = 1;  // refine
+    break;
   }
 
   T8_ASSERT (-3 < return_val);


### PR DESCRIPTION
**_Describe your changes here:_**

The test test/t8_forest_incomplete/t8_gtest_iterate_replace crashed on more than 2 processes.
This happened because the refinement rule removed all elements of a tree, which is not supported.
I changed the refinement rule such that the first element of a tree is always kept.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
