### PR TITLE
Adding CMake pedantic build mode option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ project( T8CODE
 include( CTest )
 
 option( T8CODE_BUILD_AS_SHARED_LIBRARY "Whether t8code should be built as a shared or a static library" ON )
+option( T8CODE_BUILD_PEDANTIC "Compile t8code with `-Wall -pedantic -Werror` as done in the Github CI." OFF )
 option( T8CODE_BUILD_TESTS "Build t8code's automated tests" ON )
 option( T8CODE_BUILD_TUTORIALS "Build t8code's tutorials" ON )
 option( T8CODE_BUILD_EXAMPLES "Build t8code's examples" ON )
@@ -31,7 +32,7 @@ if( NOT CMAKE_BUILD_TYPE )
     set( CMAKE_BUILD_TYPE "Release" )
 endif()
 
-set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Release RelWithDebInfo Debug)
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Release RelWithDebInfo Debug Github-CI)
 
 set( CMAKE_C_STANDARD 11 )
 set( CMAKE_C_STANDARD_REQUIRED ON )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if( NOT CMAKE_BUILD_TYPE )
     set( CMAKE_BUILD_TYPE "Release" )
 endif()
 
-set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Release RelWithDebInfo Debug Github-CI)
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Release RelWithDebInfo Debug)
 
 set( CMAKE_C_STANDARD 11 )
 set( CMAKE_C_STANDARD_REQUIRED ON )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,13 @@ if( T8CODE_ENABLE_LESS_TESTS )
     target_compile_definitions( T8 PUBLIC T8_ENABLE_LESS_TESTS=1 )
 endif()
 
+if( T8CODE_BUILD_PEDANTIC )
+  # TODO: Add `-Wextra -Wpedantic`. As of now, t8code would not compile with this.
+  target_compile_options( T8 PUBLIC -Wall -pedantic -Werror )
+  set (T8_CPPFLAGS "${T8_CPPFLAGS} -W -Wall -Wpedantic -Werror")
+  set (T8_CFLAGS "${T8_CFLAGS} -W -Wall -Wpedantic -Werror")
+endif()
+
 target_sources( T8 PRIVATE 
     t8.c 
     t8_eclass.c 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if( T8CODE_BUILD_PEDANTIC )
   # TODO: Add `-Wextra -Wpedantic`. As of now, t8code would not compile with this.
   target_compile_options( T8 PUBLIC -Wall -pedantic -Werror )
-  set (T8_CPPFLAGS "${T8_CPPFLAGS} -W -Wall -Wpedantic -Werror")
+  set (T8_CXXFLAGS "${T8_CXXFLAGS} -W -Wall -Wpedantic -Werror")
   set (T8_CFLAGS "${T8_CFLAGS} -W -Wall -Wpedantic -Werror")
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,7 @@ endif()
 
 if( T8CODE_BUILD_PEDANTIC )
   # TODO: Add `-Wextra -Wpedantic`. As of now, t8code would not compile with this.
+  # See also: https://github.com/DLR-AMR/t8code/issues/1155.
   target_compile_options( T8 PUBLIC -Wall -pedantic -Werror )
   set (T8_CXXFLAGS "${T8_CXXFLAGS} -W -Wall -Wpedantic -Werror")
   set (T8_CFLAGS "${T8_CFLAGS} -W -Wall -Wpedantic -Werror")


### PR DESCRIPTION
**_Describe your changes here:_**

This is another CMake option, if enabled. adds `-Wall -pedantic -Werror`. This is the same set of flags used in the GitHub CI right now.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
