### PR TITLE
Rename T8_TREE/GHOST_FIRST_ATT to T8_TREE/GHOST_FIRST_ATT_INFO

### DIFF
--- a/src/t8_cmesh/t8_cmesh_partition.cxx
+++ b/src/t8_cmesh/t8_cmesh_partition.cxx
@@ -863,7 +863,7 @@ t8_cmesh_partition_copy_data (char *send_buffer, t8_cmesh_t cmesh, const t8_cmes
       /* The byte count of this ghosts attribute info structs */
       this_ghosts_att_info_size = num_attributes * sizeof (t8_attribute_info_struct_t);
       /* Copy all attribute info data of this ghost */
-      first_attr_info = (t8_attribute_info_struct_t *) T8_GHOST_FIRST_ATT (ghost_cpy);
+      first_attr_info = (t8_attribute_info_struct_t *) T8_GHOST_FIRST_ATT_INFO (ghost_cpy);
       memcpy (first_attr_info, attr_info, this_ghosts_att_info_size);
       temp_offset_ghost_att += this_ghosts_att_info_size;
 

--- a/src/t8_cmesh/t8_cmesh_trees.c
+++ b/src/t8_cmesh/t8_cmesh_trees.c
@@ -760,7 +760,7 @@ t8_cmesh_trees_get_attribute (const t8_cmesh_trees_t trees, const t8_locidx_t lt
     ghost = NULL;
     /* number of attributes and pointer to first att_info struct */
     num_attributes = tree->num_attributes;
-    first_att_info = T8_TREE_FIRST_ATT (tree);
+    first_att_info = T8_TREE_FIRST_ATT_INFO (tree);
   }
   else {
     /* Get a pointer to the ghost */
@@ -768,7 +768,7 @@ t8_cmesh_trees_get_attribute (const t8_cmesh_trees_t trees, const t8_locidx_t lt
     tree = NULL;
     /* number of attributes and pointer to first att_info struct */
     num_attributes = ghost->num_attributes;
-    first_att_info = T8_GHOST_FIRST_ATT (ghost);
+    first_att_info = T8_GHOST_FIRST_ATT_INFO (ghost);
   }
 
   key_id.key = key;

--- a/src/t8_cmesh/t8_cmesh_trees.h
+++ b/src/t8_cmesh/t8_cmesh_trees.h
@@ -121,7 +121,7 @@ T8_EXTERN_C_BEGIN ();
 /* TODO: document */
 
 /* Given a tree return the beginning of its attributes block */
-#define T8_TREE_FIRST_ATT_INFO (t) ((char *) (t) + (t)->att_offset)
+#define T8_TREE_FIRST_ATT_INFO(t) ((char *) (t) + (t)->att_offset)
 
 /* Given a tree and an index i return the i-th attribute index of that tree */
 #define T8_TREE_ATTR_INFO(t, i) \
@@ -137,7 +137,7 @@ T8_EXTERN_C_BEGIN ();
 #define T8_TREE_TTF(t) (T8_TREE_FACE (t) + t8_eclass_num_faces[(t)->eclass] * sizeof (t8_locidx_t))
 
 /* Given a ghost return the beginning of its attribute block */
-#define T8_GHOST_FIRST_ATT_INFO (g) T8_TREE_FIRST_ATT_INFO (g)
+#define T8_GHOST_FIRST_ATT_INFO(g) T8_TREE_FIRST_ATT_INFO (g)
 
 /* Given a ghost and an index i return the i-th attribute index of that ghost */
 #define T8_GHOST_ATTR_INFO(g, i) T8_TREE_ATTR_INFO (g, i)

--- a/src/t8_cmesh/t8_cmesh_trees.h
+++ b/src/t8_cmesh/t8_cmesh_trees.h
@@ -121,14 +121,14 @@ T8_EXTERN_C_BEGIN ();
 /* TODO: document */
 
 /* Given a tree return the beginning of its attributes block */
-#define T8_TREE_FIRST_ATT(t) ((char *) (t) + (t)->att_offset)
+#define T8_TREE_FIRST_ATT_INFO (t) ((char *) (t) + (t)->att_offset)
 
 /* Given a tree and an index i return the i-th attribute index of that tree */
 #define T8_TREE_ATTR_INFO(t, i) \
   ((t8_attribute_info_struct_t *) ((char *) (t) + (t)->att_offset + (i) * sizeof (t8_attribute_info_struct_t)))
 
 /* Given a tree and an attribute info return the attribute */
-#define T8_TREE_ATTR(t, ai) (T8_TREE_FIRST_ATT (t) + (ai)->attribute_offset)
+#define T8_TREE_ATTR(t, ai) (T8_TREE_FIRST_ATT_INFO (t) + (ai)->attribute_offset)
 
 /* Given a tree return its face_neighbor array */
 #define T8_TREE_FACE(t) ((char *) (t) + (t)->neigh_offset)
@@ -137,7 +137,7 @@ T8_EXTERN_C_BEGIN ();
 #define T8_TREE_TTF(t) (T8_TREE_FACE (t) + t8_eclass_num_faces[(t)->eclass] * sizeof (t8_locidx_t))
 
 /* Given a ghost return the beginning of its attribute block */
-#define T8_GHOST_FIRST_ATT(g) T8_TREE_FIRST_ATT (g)
+#define T8_GHOST_FIRST_ATT_INFO (g) T8_TREE_FIRST_ATT_INFO (g)
 
 /* Given a ghost and an index i return the i-th attribute index of that ghost */
 #define T8_GHOST_ATTR_INFO(g, i) T8_TREE_ATTR_INFO (g, i)


### PR DESCRIPTION
**_Describe your changes here:_**

Closes #1163 renaming the macros T8_TREE_FIRST_ATT and T8_GHOST_FIRST_ATT to T8_TREE_FIRST_ATT_INFO and T8_GHOST_FIRST_ATT_INFO.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
