### PR TITLE
Cleanup benchmark time_new_refine

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -16,4 +16,5 @@ add_t8_benchmark( NAME t8_time_forest_partition SOURCES time_forest_partition.cx
 add_t8_benchmark( NAME t8_time_prism_adapt SOURCES t8_time_prism_adapt.cxx )
 add_t8_benchmark( NAME t8_time_fractal SOURCES t8_time_fractal.cxx )
 add_t8_benchmark( NAME t8_time_set_join_by_vertices SOURCES t8_time_set_join_by_vertices.cxx )
+add_t8_benchmark( NAME t8_time_new_refine SOURCES time_new_refine.c )
 add_t8_benchmark( NAME t8_bunny SOURCES ExtremeScaling/bunny.cxx )

--- a/benchmarks/Makefile.am
+++ b/benchmarks/Makefile.am
@@ -8,7 +8,7 @@ bin_PROGRAMS += \
   benchmarks/t8_time_prism_adapt \
   benchmarks/t8_time_fractal \
   benchmarks/t8_time_set_join_by_vertices \
- benchmarks/t8_time_new_refine
+  benchmarks/t8_time_new_refine
  # benchmarks/t8_time_refine_type03
 
 benchmarks_t8_time_new_refine_SOURCES = benchmarks/time_new_refine.c

--- a/benchmarks/Makefile.am
+++ b/benchmarks/Makefile.am
@@ -7,11 +7,11 @@ bin_PROGRAMS += \
   benchmarks/t8_time_forest_partition \
   benchmarks/t8_time_prism_adapt \
   benchmarks/t8_time_fractal \
-  benchmarks/t8_time_set_join_by_vertices
-#  benchmarks/t8_time_new_refine \
-#  benchmarks/t8_time_refine_type03
+  benchmarks/t8_time_set_join_by_vertices \
+ benchmarks/t8_time_new_refine
+ # benchmarks/t8_time_refine_type03
 
-#benchmarks_t8_time_new_refine_SOURCES = benchmarks/time_new_refine.c
+benchmarks_t8_time_new_refine_SOURCES = benchmarks/time_new_refine.c
 #benchmarks_t8_time_refine_type03_SOURCES = benchmarks/time_refine_type03.c
 benchmarks_t8_time_partition_SOURCES = benchmarks/time_partition.cxx
 benchmarks_t8_time_forest_partition_SOURCES = benchmarks/time_forest_partition.cxx

--- a/benchmarks/time_new_refine.c
+++ b/benchmarks/time_new_refine.c
@@ -38,11 +38,7 @@ static int
 t8_basic_adapt_refine (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree, t8_locidx_t lelement_id,
                        t8_eclass_scheme_c *ts, const int is_family, const int num_elements, t8_element_t *elements[])
 {
-#if 0
   int                 level;
-#endif
-  T8_ASSERT (!is_family || num_elements == t8_eclass_num_children[ts->eclass]);
-#if 0
   level = t8_element_level (ts, elements[0]);
   /* coarsen */
   if (num_elements > 1) {
@@ -50,7 +46,6 @@ t8_basic_adapt_refine (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t 
       return -1;
     return 0;
   }
-#endif
   return 1;
 }
 

--- a/benchmarks/time_new_refine.c
+++ b/benchmarks/time_new_refine.c
@@ -35,8 +35,8 @@
 #include <t8_forest/t8_forest_types.h> /* TODO: This file should not be included from an application */
 /* This function refines every element */
 static int
-t8_basic_adapt_refine (t8_forest_t forest, t8_locidx_t which_tree, t8_eclass_scheme_t *ts, const int is_family,
-                       const int num_elements, t8_element_t *elements[])
+t8_basic_adapt_refine (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree, t8_locidx_t lelement_id,
+                       t8_eclass_scheme_c *ts, const int is_family, const int num_elements, t8_element_t *elements[])
 {
 #if 0
   int                 level;
@@ -56,8 +56,8 @@ t8_basic_adapt_refine (t8_forest_t forest, t8_locidx_t which_tree, t8_eclass_sch
 
 /* This function coarsens each element */
 static int
-t8_basic_adapt_coarsen (t8_forest_t forest, t8_locidx_t which_tree, t8_eclass_scheme_t *ts, const int is_family,
-                        int num_elements, t8_element_t *elements[])
+t8_basic_adapt_coarsen (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree, t8_locidx_t lelement_id,
+                        t8_eclass_scheme_c *ts, const int is_family, int num_elements, t8_element_t *elements[])
 {
   if (is_family) {
     return -1;
@@ -87,8 +87,8 @@ t8_timings_adapt (int start_l, int end_l, int runs, int dim)
   t8_forest_set_cmesh (forests[0],
                        t8_cmesh_new_hypercube (eclass, sc_MPI_COMM_WORLD, 0), 0);
 */
-  t8_forest_set_cmesh (forests[0], t8_cmesh_new_bigmesh (eclass, 512, sc_MPI_COMM_WORLD, 0), sc_MPI_COMM_WORLD);
-  t8_forest_set_scheme (forests[0], t8_scheme_new_default ());
+  t8_forest_set_cmesh (forests[0], t8_cmesh_new_bigmesh (eclass, 512, sc_MPI_COMM_WORLD), sc_MPI_COMM_WORLD);
+  t8_forest_set_scheme (forests[0], t8_scheme_new_default_cxx ());
   t8_forest_set_level (forests[0], start_l);
   t8_forest_commit (forests[0]);
 
@@ -137,7 +137,7 @@ t8_timings_new (int level, int dim)
 
   t8_forest_init (&forest);
   t8_forest_set_cmesh (forest, t8_cmesh_new_hypercube (eclass, sc_MPI_COMM_WORLD, 0, 0, 0), sc_MPI_COMM_WORLD);
-  t8_forest_set_scheme (forest, t8_scheme_new_default ());
+  t8_forest_set_scheme (forest, t8_scheme_new_default_cxx ());
   t8_forest_set_level (forest, level);
   t8_forest_commit (forest);
 

--- a/benchmarks/time_new_refine.c
+++ b/benchmarks/time_new_refine.c
@@ -21,9 +21,11 @@
 */
 
 #include <sc_refcount.h>
-#include <t8_schemes/t8_default/t8_dtri.h>
-#include <t8_schemes/t8_default/t8_dtet.h>
-#include <t8_schemes/t8_default.h>
+#include <t8_cmesh/t8_cmesh_examples.h>
+#include <t8_element_c_interface.h>
+#include <t8_schemes/t8_default/t8_default_c_interface.h>
+#include <t8_schemes/t8_default/t8_default_tri/t8_dtri.h>
+#include <t8_schemes/t8_default/t8_default_tet/t8_dtet.h>
 #include <t8_forest/t8_forest_adapt.h>
 #include <t8_forest/t8_forest_general.h>
 #include <sc_flops.h>

--- a/benchmarks/time_new_refine.c
+++ b/benchmarks/time_new_refine.c
@@ -38,7 +38,7 @@ static int
 t8_basic_adapt_refine (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree, t8_locidx_t lelement_id,
                        t8_eclass_scheme_c *ts, const int is_family, const int num_elements, t8_element_t *elements[])
 {
-  int                 level;
+  int level;
   level = t8_element_level (ts, elements[0]);
   /* coarsen */
   if (num_elements > 1) {


### PR DESCRIPTION
**_Describe your changes here:_**

Closes #689. This PR cleans up the benchmark `time_new_refine.c` by updating it to make it compile using the latest API changes and removing `#if 0` `#endif` preprocessor macros.
As this benchmark was commented out of the build system for a long time, I do not know if it is still relevant.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
