### PR TITLE
Fix: openMPI shared mem comm type

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,7 @@ target_sources( T8 PRIVATE
     t8_element.cxx 
     t8_element_c_interface.cxx 
     t8_mesh.c
+    t8_mpi.c
     t8_netcdf.c 
     t8_refcount.c 
     t8_version.c 
@@ -170,6 +171,7 @@ target_compile_definitions( T8 PUBLIC T8_LIBS="${T8_LIBS}" )
 
 install( FILES
     t8.h
+    t8_mpi.h
     t8_cmesh.h
     t8_cmesh.hxx
     t8_cmesh_netcdf.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -97,6 +97,7 @@ libt8_internal_headers = \
   src/t8_cmesh/t8_cmesh_trees.h src/t8_cmesh/t8_cmesh_partition.h \
   src/t8_cmesh/t8_cmesh_copy.h \
   src/t8_cmesh/t8_cmesh_offset.h \
+  src/t8_mpi.h \
   src/t8_vtk/t8_vtk_polydata.hxx \
   src/t8_vtk/t8_vtk_unstructured.hxx \
   src/t8_vtk/t8_vtk_parallel.hxx \
@@ -106,7 +107,7 @@ libt8_internal_headers = \
   src/t8_windows.h \
   src/t8_vtk/t8_vtk_writer_helper.hxx
 libt8_compiled_sources = \
-  src/t8.c src/t8_eclass.c src/t8_mesh.c \
+  src/t8.c src/t8_mpi.c src/t8_eclass.c src/t8_mesh.c \
   src/t8_element.cxx \
   src/t8_element_c_interface.cxx \
   src/t8_refcount.c src/t8_cmesh/t8_cmesh.cxx \

--- a/src/t8.h
+++ b/src/t8.h
@@ -108,7 +108,7 @@ typedef int64_t t8_gloidx_t;
 /** A type for storing SFC indices */
 typedef uint64_t t8_linearidx_t;
 /** The MPI datatype of t8_linearidx_t */
-#define T8_MPI_LINEARIDX sc_MPI_UNSIGNED_LONG_LONG
+#define T8_MPI_LINEARIDX sc_MPI_LONG_LONG_INT
 
 #define T8_PADDING_SIZE (sizeof (void *))
 /** Compute the number of bytes that have to be added to a given byte_count

--- a/src/t8.h
+++ b/src/t8.h
@@ -52,6 +52,9 @@
  * It needs to be followed by a semicolon to look like a statement. */
 #define T8_EXTERN_C_END() SC_EXTERN_C_END
 
+/* always include t8_mpi.h */
+#include <t8_mpi.h>
+
 /* call this after including all headers */
 T8_EXTERN_C_BEGIN ();
 

--- a/src/t8.h
+++ b/src/t8.h
@@ -108,7 +108,7 @@ typedef int64_t t8_gloidx_t;
 /** A type for storing SFC indices */
 typedef uint64_t t8_linearidx_t;
 /** The MPI datatype of t8_linearidx_t */
-#define T8_MPI_LINEARIDX sc_MPI_LONG_LONG_INT
+#define T8_MPI_LINEARIDX sc_MPI_UNSIGNED_LONG_LONG
 
 #define T8_PADDING_SIZE (sizeof (void *))
 /** Compute the number of bytes that have to be added to a given byte_count

--- a/src/t8.h
+++ b/src/t8.h
@@ -108,7 +108,7 @@ typedef int64_t t8_gloidx_t;
 /** A type for storing SFC indices */
 typedef uint64_t t8_linearidx_t;
 /** The MPI datatype of t8_linearidx_t */
-#define T8_MPI_LINEARIDX sc_MPI_UNSIGNED_LONG_LONG
+#define T8_MPI_LINEARIDX t8_MPI_UNSIGNED_LONG_LONG
 
 #define T8_PADDING_SIZE (sizeof (void *))
 /** Compute the number of bytes that have to be added to a given byte_count

--- a/src/t8_data/t8_shmem.c
+++ b/src/t8_data/t8_shmem.c
@@ -198,7 +198,7 @@ t8_shmem_array_allgather (const void *sendbuf, int sendcount, sc_MPI_Datatype se
   T8_ASSERT (t8_shmem_array_is_initialized (recvarray));
   T8_ASSERT (!t8_shmem_array_is_writing_possible (recvarray));
 
-  sc_shmem_allgather ((void *) sendbuf, sendcount, sendtype, recvarray->array, recvcount, recvtype, recvarray->comm);
+  t8_shmem_allgather ((void *) sendbuf, sendcount, sendtype, recvarray->array, recvcount, recvtype, recvarray->comm);
 }
 
 void

--- a/src/t8_mpi.c
+++ b/src/t8_mpi.c
@@ -176,6 +176,7 @@ t8_shmem_allgather_basic (void *sendbuf, int sendcount, sc_MPI_Datatype sendtype
   SC_CHECK_MPI (mpiret);
 }
 
+#if defined(__bgq__) || defined(SC_ENABLE_MPIWINSHARED)
 static void
 t8_shmem_allgather_common (void *sendbuf, int sendcount, sc_MPI_Datatype sendtype, void *recvbuf, int recvcount,
                            sc_MPI_Datatype recvtype, sc_MPI_Comm comm, sc_MPI_Comm intranode, sc_MPI_Comm internode)
@@ -207,6 +208,7 @@ t8_shmem_allgather_common (void *sendbuf, int sendcount, sc_MPI_Datatype sendtyp
   }
   sc_shmem_write_end (recvbuf, comm);
 }
+#endif
 
 #if !defined(SC_SHMEM_DEFAULT)
 #define SC_SHMEM_DEFAULT SC_SHMEM_BASIC

--- a/src/t8_mpi.c
+++ b/src/t8_mpi.c
@@ -148,4 +148,10 @@ t8_MPI_Gather (void *p, int np, sc_MPI_Datatype tp, void *q, int nq, sc_MPI_Data
   return sc_MPI_SUCCESS;
 }
 
+int
+t8_MPI_Allgather (void *p, int np, sc_MPI_Datatype tp, void *q, int nq, sc_MPI_Datatype tq, sc_MPI_Comm comm)
+{
+  return t8_MPI_Gather (p, np, tp, q, nq, tq, 0, comm);
+}
+
 #endif

--- a/src/t8_mpi.c
+++ b/src/t8_mpi.c
@@ -1,0 +1,63 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#include <t8.h>
+#include <t8_mpi.h>
+
+size_t
+t8_mpi_sizeof (sc_MPI_Datatype t)
+{
+  if (t == sc_MPI_BYTE || t == t8_MPI_INT8_T)
+    return 1;
+  if (t == sc_MPI_CHAR || t == sc_MPI_UNSIGNED_CHAR)
+    return sizeof (char);
+  if (t == sc_MPI_SHORT || t == sc_MPI_UNSIGNED_SHORT)
+    return sizeof (short);
+  if (t == sc_MPI_INT || t == sc_MPI_UNSIGNED)
+    return sizeof (int);
+  if (t == sc_MPI_LONG || t == sc_MPI_UNSIGNED_LONG)
+    return sizeof (long);
+  if (t == sc_MPI_LONG_LONG_INT || t == t8_MPI_UNSIGNED_LONG_LONG)
+    return sizeof (long long);
+  if (t == sc_MPI_FLOAT)
+    return sizeof (float);
+  if (t == sc_MPI_DOUBLE)
+    return sizeof (double);
+  if (t == sc_MPI_LONG_DOUBLE)
+    return sizeof (long double);
+  if (t == sc_MPI_2INT)
+    return 2 * sizeof (int);
+
+  SC_ABORT_NOT_REACHED ();
+}
+
+#ifndef T8_ENABLE_MPI
+
+int
+t8_MPI_Type_size (sc_MPI_Datatype datatype, int *size)
+{
+  *size = t8_mpi_sizeof (datatype);
+
+  return sc_MPI_SUCCESS;
+}
+
+#endif

--- a/src/t8_mpi.c
+++ b/src/t8_mpi.c
@@ -125,4 +125,27 @@ t8_MPI_Unpack (const void *inbuf, int insize, int *position, void *outbuf, int o
   return sc_MPI_SUCCESS;
 }
 
+int
+t8_MPI_Gather (void *p, int np, sc_MPI_Datatype tp, void *q, int nq, sc_MPI_Datatype tq, int rank, sc_MPI_Comm comm)
+{
+  size_t lp;
+#ifdef SC_ENABLE_DEBUG
+  size_t lq;
+#endif
+
+  SC_ASSERT (rank == 0 && np >= 0 && nq >= 0);
+
+  /* *INDENT-OFF* horrible indent bug */
+  lp = (size_t) np * t8_mpi_sizeof (tp);
+#ifdef SC_ENABLE_DEBUG
+  lq = (size_t) nq * t8_mpi_sizeof (tq);
+#endif
+  /* *INDENT-ON* */
+
+  SC_ASSERT (lp == lq);
+  memcpy (q, p, lp);
+
+  return sc_MPI_SUCCESS;
+}
+
 #endif

--- a/src/t8_mpi.h
+++ b/src/t8_mpi.h
@@ -109,7 +109,7 @@ t8_MPI_Gather (void *, int, sc_MPI_Datatype, void *, int, sc_MPI_Datatype, int, 
 
 /** Execute the MPI_Allgather algorithm. */
 int
-sc_MPI_Allgather (void *, int, sc_MPI_Datatype, void *, int, sc_MPI_Datatype, sc_MPI_Comm);
+t8_MPI_Allgather (void *, int, sc_MPI_Datatype, void *, int, sc_MPI_Datatype, sc_MPI_Comm);
 #endif
 
 /** Return the size of MPI datatypes.

--- a/src/t8_mpi.h
+++ b/src/t8_mpi.h
@@ -45,6 +45,10 @@ T8_EXTERN_C_BEGIN ();
 
 #define t8_MPI_Type_size MPI_Type_size
 
+#define t8_MPI_Pack MPI_Pack
+#define t8_MPI_Pack_size MPI_Pack_size
+#define t8_MPI_Unpack MPI_Unpack
+
 #else /* !T8_ENABLE_MPI */
 
 #define t8_MPI_INT8_T (1)
@@ -57,6 +61,45 @@ T8_EXTERN_C_BEGIN ();
  */
 int
 t8_MPI_Type_size (sc_MPI_Datatype datatype, int *size);
+
+/** Determine space needed to pack several instances of the same datatype.
+ * \param [in] incount        Number of elements to pack.
+ * \param [in] datatype       Datatype of elements to pack.
+ * \param [in] comm           Valid MPI communicator.
+ * \param [out] size          Number of bytes needed to packed \b incount
+ *                            instances of \b datatype.
+ * \return                    MPI_SUCCESS on success.
+ */
+int
+t8_MPI_Pack_size (int incount, sc_MPI_Datatype datatype, sc_MPI_Comm comm, int *size);
+
+/** Pack several instances of the same datatype into contiguous memory.
+ * \param [in] inbuf          Buffer of elements of type \b datatype.
+ * \param [in] incount        Number of elements in \b inbuf.
+ * \param [in] datatype       Datatype of elements in \b inbuf.
+ * \param [out] outbuf        Output buffer in which elements are packed.
+ * \param [in] outsize        Size of output buffer in bytes.
+ * \param [in, out] position  The current position in the output buffer.
+ * \param [in] comm           Valid MPI communicator.
+ * \return                    MPI_SUCCESS on success.
+ */
+int
+t8_MPI_Pack (const void *inbuf, int incount, sc_MPI_Datatype datatype, void *outbuf, int outsize, int *position,
+             sc_MPI_Comm comm);
+
+/** Unpack contiguous memory into several instances of the same datatype.
+ * \param [in] inbuf          Buffer of packed data.
+ * \param [in] insize         Number of bytes in \b inbuf
+ * \param [in, out] position  The current position in the input buffer.
+ * \param [out] outbuf        Output buffer in which elements are unpacked.
+ * \param [in] outcount       Number of elements to unpack.
+ * \param [in] datatype       Datatype of elements to be unpacked.
+ * \param [in] comm           Valid MPI communicator.
+ * \return                    MPI_SUCCESS on success.
+ */
+int
+t8_MPI_Unpack (const void *inbuf, int insize, int *position, void *outbuf, int outcount, sc_MPI_Datatype datatype,
+               sc_MPI_Comm comm);
 
 #endif
 

--- a/src/t8_mpi.h
+++ b/src/t8_mpi.h
@@ -50,6 +50,7 @@ T8_EXTERN_C_BEGIN ();
 #define t8_MPI_Unpack MPI_Unpack
 
 #define t8_MPI_Gather MPI_Gather
+#define t8_MPI_Allgather MPI_Allgather
 
 #else /* !T8_ENABLE_MPI */
 
@@ -106,6 +107,9 @@ t8_MPI_Unpack (const void *inbuf, int insize, int *position, void *outbuf, int o
 int
 t8_MPI_Gather (void *, int, sc_MPI_Datatype, void *, int, sc_MPI_Datatype, int, sc_MPI_Comm);
 
+/** Execute the MPI_Allgather algorithm. */
+int
+sc_MPI_Allgather (void *, int, sc_MPI_Datatype, void *, int, sc_MPI_Datatype, sc_MPI_Comm);
 #endif
 
 /** Return the size of MPI datatypes.

--- a/src/t8_mpi.h
+++ b/src/t8_mpi.h
@@ -119,6 +119,20 @@ sc_MPI_Allgather (void *, int, sc_MPI_Datatype, void *, int, sc_MPI_Datatype, sc
 size_t
 t8_mpi_sizeof (sc_MPI_Datatype t);
 
+/** Fill a shmem array with an allgather.
+ *
+ * \param[in] sendbuf         the source from this process
+ * \param[in] sendcount       the number of items to allgather
+ * \param[in] sendtype        the type of items to allgather
+ * \param[in,out] recvbuf     the destination shmem array
+ * \param[in] recvcount       the number of items to allgather
+ * \param[in] recvtype        the type of items to allgather
+ * \param[in] comm            the mpi communicator
+ */
+void
+t8_shmem_allgather (void *sendbuf, int sendcount, sc_MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                    sc_MPI_Datatype recvtype, sc_MPI_Comm comm);
+
 T8_EXTERN_C_END ();
 
 #endif /* !T8_MPI_H */

--- a/src/t8_mpi.h
+++ b/src/t8_mpi.h
@@ -1,0 +1,72 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_mpi.h
+ *
+ *This file provides a consistent MPI interface for MPI datatypes
+ * whether t8code is configure with MPI or without. This files
+ * contains patched functions from libsc.
+ */
+
+#ifndef T8_MPI_H
+#define T8_MPI_H
+
+/* include config headers */
+#ifndef T8_CMAKE_BUILD
+#include <t8_config.h>
+#endif
+
+T8_EXTERN_C_BEGIN ();
+
+#ifdef T8_ENABLE_MPI
+#include <mpi.h>
+
+#define t8_MPI_INT8_T MPI_INT8_T
+#define t8_MPI_UNSIGNED_LONG_LONG MPI_UNSIGNED_LONG_LONG
+
+#define t8_MPI_Type_size MPI_Type_size
+
+#else /* !T8_ENABLE_MPI */
+
+#define t8_MPI_INT8_T (1)
+#define t8_MPI_UNSIGNED_LONG_LONG (0x4c000409)
+
+/** Return size of an MPI datatype.
+ * \param [in] datatype     Valid MPI datatype.
+ * \param [out] size        Size of MPI datatype in bytes.
+ * \return                  MPI_SUCCESS on success.
+ */
+int
+t8_MPI_Type_size (sc_MPI_Datatype datatype, int *size);
+
+#endif
+
+/** Return the size of MPI datatypes.
+ * \param [in] t    MPI datatype.
+ * \return          Returns the size in bytes.
+ */
+size_t
+t8_mpi_sizeof (sc_MPI_Datatype t);
+
+T8_EXTERN_C_END ();
+
+#endif /* !T8_MPI_H */

--- a/src/t8_mpi.h
+++ b/src/t8_mpi.h
@@ -49,6 +49,8 @@ T8_EXTERN_C_BEGIN ();
 #define t8_MPI_Pack_size MPI_Pack_size
 #define t8_MPI_Unpack MPI_Unpack
 
+#define t8_MPI_Gather MPI_Gather
+
 #else /* !T8_ENABLE_MPI */
 
 #define t8_MPI_INT8_T (1)
@@ -100,6 +102,9 @@ t8_MPI_Pack (const void *inbuf, int incount, sc_MPI_Datatype datatype, void *out
 int
 t8_MPI_Unpack (const void *inbuf, int insize, int *position, void *outbuf, int outcount, sc_MPI_Datatype datatype,
                sc_MPI_Comm comm);
+
+int
+t8_MPI_Gather (void *, int, sc_MPI_Datatype, void *, int, sc_MPI_Datatype, int, sc_MPI_Comm);
 
 #endif
 

--- a/src/t8_mpi.h
+++ b/src/t8_mpi.h
@@ -54,8 +54,8 @@ T8_EXTERN_C_BEGIN ();
 
 #else /* !T8_ENABLE_MPI */
 
-#define t8_MPI_INT8_T (1)
-#define t8_MPI_UNSIGNED_LONG_LONG (0x4c000409)
+#define t8_MPI_INT8_T ((sc_MPI_Datatype) 1)
+#define t8_MPI_UNSIGNED_LONG_LONG ((sc_MPI_Datatype) 0x4c000409)
 
 /** Return size of an MPI datatype.
  * \param [in] datatype     Valid MPI datatype.

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
@@ -671,7 +671,7 @@ t8_default_scheme_hex_c::t8_element_MPI_Pack (t8_element_t **const elements, con
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Pack (&quads[ielem]->z, 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -690,7 +690,7 @@ t8_default_scheme_hex_c::t8_element_MPI_Pack_size (const unsigned int count, sc_
   singlesize += 3 * datasize;
 
   /* level */
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -712,7 +712,7 @@ t8_default_scheme_hex_c::t8_element_MPI_Unpack (void *recvbuf, const int buffer_
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->z), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
@@ -671,7 +671,7 @@ t8_default_scheme_hex_c::t8_element_MPI_Pack (t8_element_t **const elements, con
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Pack (&quads[ielem]->z, 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -690,7 +690,7 @@ t8_default_scheme_hex_c::t8_element_MPI_Pack_size (const unsigned int count, sc_
   singlesize += 3 * datasize;
 
   /* level */
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -712,7 +712,7 @@ t8_default_scheme_hex_c::t8_element_MPI_Unpack (void *recvbuf, const int buffer_
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->z), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, sc_MPI_BYTE, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, sc_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
@@ -671,7 +671,7 @@ t8_default_scheme_hex_c::t8_element_MPI_Pack (t8_element_t **const elements, con
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Pack (&quads[ielem]->z, 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = t8_MPI_Pack (&quads[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -690,7 +690,7 @@ t8_default_scheme_hex_c::t8_element_MPI_Pack_size (const unsigned int count, sc_
   singlesize += 3 * datasize;
 
   /* level */
-  mpiret = sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
+  mpiret = t8_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -712,7 +712,7 @@ t8_default_scheme_hex_c::t8_element_MPI_Unpack (void *recvbuf, const int buffer_
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->z), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, t8_MPI_INT8_T, comm);
+    mpiret = t8_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
@@ -671,7 +671,7 @@ t8_default_scheme_hex_c::t8_element_MPI_Pack (t8_element_t **const elements, con
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Pack (&quads[ielem]->z, 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -690,7 +690,7 @@ t8_default_scheme_hex_c::t8_element_MPI_Pack_size (const unsigned int count, sc_
   singlesize += 3 * datasize;
 
   /* level */
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -712,7 +712,7 @@ t8_default_scheme_hex_c::t8_element_MPI_Unpack (void *recvbuf, const int buffer_
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->z), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, sc_MPI_BYTE, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
@@ -465,7 +465,7 @@ t8_default_scheme_line_c::t8_element_MPI_Pack (t8_element_t **const elements, co
   for (unsigned int ielem = 0; ielem < count; ielem++) {
     mpiret = sc_MPI_Pack (&(lines[ielem]->x), 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&lines[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&lines[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -482,7 +482,7 @@ t8_default_scheme_line_c::t8_element_MPI_Pack_size (const unsigned int count, sc
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -500,7 +500,7 @@ t8_default_scheme_line_c::t8_element_MPI_Unpack (void *recvbuf, const int buffer
   for (unsigned int ielem = 0; ielem < count; ielem++) {
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(lines[ielem]->x), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(lines[ielem]->level), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(lines[ielem]->level), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
@@ -465,7 +465,7 @@ t8_default_scheme_line_c::t8_element_MPI_Pack (t8_element_t **const elements, co
   for (unsigned int ielem = 0; ielem < count; ielem++) {
     mpiret = sc_MPI_Pack (&(lines[ielem]->x), 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&lines[ielem]->level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&lines[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -482,7 +482,7 @@ t8_default_scheme_line_c::t8_element_MPI_Pack_size (const unsigned int count, sc
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -500,7 +500,7 @@ t8_default_scheme_line_c::t8_element_MPI_Unpack (void *recvbuf, const int buffer
   for (unsigned int ielem = 0; ielem < count; ielem++) {
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(lines[ielem]->x), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(lines[ielem]->level), 1, sc_MPI_BYTE, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(lines[ielem]->level), 1, sc_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
@@ -465,7 +465,7 @@ t8_default_scheme_line_c::t8_element_MPI_Pack (t8_element_t **const elements, co
   for (unsigned int ielem = 0; ielem < count; ielem++) {
     mpiret = sc_MPI_Pack (&(lines[ielem]->x), 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&lines[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = t8_MPI_Pack (&lines[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -482,7 +482,7 @@ t8_default_scheme_line_c::t8_element_MPI_Pack_size (const unsigned int count, sc
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
-  mpiret = sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
+  mpiret = t8_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -500,7 +500,7 @@ t8_default_scheme_line_c::t8_element_MPI_Unpack (void *recvbuf, const int buffer
   for (unsigned int ielem = 0; ielem < count; ielem++) {
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(lines[ielem]->x), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(lines[ielem]->level), 1, t8_MPI_INT8_T, comm);
+    mpiret = t8_MPI_Unpack (recvbuf, buffer_size, position, &(lines[ielem]->level), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
@@ -465,7 +465,7 @@ t8_default_scheme_line_c::t8_element_MPI_Pack (t8_element_t **const elements, co
   for (unsigned int ielem = 0; ielem < count; ielem++) {
     mpiret = sc_MPI_Pack (&(lines[ielem]->x), 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&lines[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&lines[ielem]->level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -482,7 +482,7 @@ t8_default_scheme_line_c::t8_element_MPI_Pack_size (const unsigned int count, sc
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -500,7 +500,7 @@ t8_default_scheme_line_c::t8_element_MPI_Unpack (void *recvbuf, const int buffer
   for (unsigned int ielem = 0; ielem < count; ielem++) {
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(lines[ielem]->x), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(lines[ielem]->level), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(lines[ielem]->level), 1, sc_MPI_BYTE, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
@@ -488,11 +488,11 @@ t8_default_scheme_prism_c::t8_element_MPI_Pack (t8_element_t **const elements, c
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Pack (&prisms[ielem]->tri.y, 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&prisms[ielem]->tri.type, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&prisms[ielem]->tri.type, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
 
     T8_ASSERT (prisms[ielem]->line.level == prisms[ielem]->tri.level);
-    mpiret = sc_MPI_Pack (&prisms[ielem]->line.level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&prisms[ielem]->line.level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -511,7 +511,7 @@ t8_default_scheme_prism_c::t8_element_MPI_Pack_size (const unsigned int count, s
   singlesize += 3 * datasize;
 
   /*type, level*/
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += 2 * datasize;
 
@@ -533,9 +533,9 @@ t8_default_scheme_prism_c::t8_element_MPI_Unpack (void *recvbuf, const int buffe
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.y), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.type), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.type), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.level), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.level), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
     prisms[ielem]->line.level = prisms[ielem]->tri.level;
   }

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
@@ -488,11 +488,11 @@ t8_default_scheme_prism_c::t8_element_MPI_Pack (t8_element_t **const elements, c
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Pack (&prisms[ielem]->tri.y, 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&prisms[ielem]->tri.type, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&prisms[ielem]->tri.type, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
 
     T8_ASSERT (prisms[ielem]->line.level == prisms[ielem]->tri.level);
-    mpiret = sc_MPI_Pack (&prisms[ielem]->line.level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&prisms[ielem]->line.level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -511,7 +511,7 @@ t8_default_scheme_prism_c::t8_element_MPI_Pack_size (const unsigned int count, s
   singlesize += 3 * datasize;
 
   /*type, level*/
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += 2 * datasize;
 
@@ -533,9 +533,9 @@ t8_default_scheme_prism_c::t8_element_MPI_Unpack (void *recvbuf, const int buffe
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.y), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.type), 1, sc_MPI_BYTE, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.type), 1, sc_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.level), 1, sc_MPI_BYTE, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.level), 1, sc_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
     prisms[ielem]->line.level = prisms[ielem]->tri.level;
   }

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
@@ -488,11 +488,11 @@ t8_default_scheme_prism_c::t8_element_MPI_Pack (t8_element_t **const elements, c
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Pack (&prisms[ielem]->tri.y, 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&prisms[ielem]->tri.type, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = t8_MPI_Pack (&prisms[ielem]->tri.type, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
 
     T8_ASSERT (prisms[ielem]->line.level == prisms[ielem]->tri.level);
-    mpiret = sc_MPI_Pack (&prisms[ielem]->line.level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = t8_MPI_Pack (&prisms[ielem]->line.level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -511,7 +511,7 @@ t8_default_scheme_prism_c::t8_element_MPI_Pack_size (const unsigned int count, s
   singlesize += 3 * datasize;
 
   /*type, level*/
-  mpiret = sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
+  mpiret = t8_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += 2 * datasize;
 
@@ -533,7 +533,7 @@ t8_default_scheme_prism_c::t8_element_MPI_Unpack (void *recvbuf, const int buffe
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.y), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.type), 1, t8_MPI_INT8_T, comm);
+    mpiret = t8_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.type), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.level), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
@@ -488,11 +488,11 @@ t8_default_scheme_prism_c::t8_element_MPI_Pack (t8_element_t **const elements, c
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Pack (&prisms[ielem]->tri.y, 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&prisms[ielem]->tri.type, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&prisms[ielem]->tri.type, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
 
     T8_ASSERT (prisms[ielem]->line.level == prisms[ielem]->tri.level);
-    mpiret = sc_MPI_Pack (&prisms[ielem]->line.level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&prisms[ielem]->line.level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -511,7 +511,7 @@ t8_default_scheme_prism_c::t8_element_MPI_Pack_size (const unsigned int count, s
   singlesize += 3 * datasize;
 
   /*type, level*/
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += 2 * datasize;
 
@@ -533,9 +533,9 @@ t8_default_scheme_prism_c::t8_element_MPI_Unpack (void *recvbuf, const int buffe
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.y), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.type), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.type), 1, sc_MPI_BYTE, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.level), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(prisms[ielem]->tri.level), 1, sc_MPI_BYTE, comm);
     SC_CHECK_MPI (mpiret);
     prisms[ielem]->line.level = prisms[ielem]->tri.level;
   }

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
@@ -452,8 +452,8 @@ t8_default_scheme_pyramid_c::t8_element_MPI_Pack (t8_element_t **const elements,
     t8_dtet_t *p = &pyramids[ielem]->pyramid;
     t8_dtet_element_pack (&p, 1, send_buffer, buffer_size, position, comm);
 
-    SC_CHECK_MPI (
-      sc_MPI_Pack (&pyramids[ielem]->switch_shape_at_level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm));
+    SC_CHECK_MPI (sc_MPI_Pack (&pyramids[ielem]->switch_shape_at_level, 1, sc_MPI_INT8_T, send_buffer, buffer_size,
+                               position, comm));
   }
 }
 
@@ -468,7 +468,7 @@ t8_default_scheme_pyramid_c::t8_element_MPI_Pack_size (const unsigned int count,
   singlesize += datasize;
 
   /* switch shape at level */
-  SC_CHECK_MPI (sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize));
+  SC_CHECK_MPI (sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize));
   singlesize += datasize;
 
   *pack_size = count * singlesize;
@@ -487,7 +487,7 @@ t8_default_scheme_pyramid_c::t8_element_MPI_Unpack (void *recvbuf, const int buf
     t8_dtet_element_unpack (recvbuf, buffer_size, position, &p, 1, comm);
 
     mpiret
-      = sc_MPI_Unpack (recvbuf, buffer_size, position, &pyramids[ielem]->switch_shape_at_level, 1, sc_MPI_BYTE, comm);
+      = sc_MPI_Unpack (recvbuf, buffer_size, position, &pyramids[ielem]->switch_shape_at_level, 1, sc_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
@@ -452,8 +452,8 @@ t8_default_scheme_pyramid_c::t8_element_MPI_Pack (t8_element_t **const elements,
     t8_dtet_t *p = &pyramids[ielem]->pyramid;
     t8_dtet_element_pack (&p, 1, send_buffer, buffer_size, position, comm);
 
-    SC_CHECK_MPI (sc_MPI_Pack (&pyramids[ielem]->switch_shape_at_level, 1, sc_MPI_BYTE, send_buffer, buffer_size,
-                               position, comm));
+    SC_CHECK_MPI (
+      sc_MPI_Pack (&pyramids[ielem]->switch_shape_at_level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm));
   }
 }
 

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
@@ -452,7 +452,7 @@ t8_default_scheme_pyramid_c::t8_element_MPI_Pack (t8_element_t **const elements,
     t8_dtet_t *p = &pyramids[ielem]->pyramid;
     t8_dtet_element_pack (&p, 1, send_buffer, buffer_size, position, comm);
 
-    SC_CHECK_MPI (sc_MPI_Pack (&pyramids[ielem]->switch_shape_at_level, 1, sc_MPI_INT8_T, send_buffer, buffer_size,
+    SC_CHECK_MPI (sc_MPI_Pack (&pyramids[ielem]->switch_shape_at_level, 1, sc_MPI_BYTE, send_buffer, buffer_size,
                                position, comm));
   }
 }
@@ -468,7 +468,7 @@ t8_default_scheme_pyramid_c::t8_element_MPI_Pack_size (const unsigned int count,
   singlesize += datasize;
 
   /* switch shape at level */
-  SC_CHECK_MPI (sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize));
+  SC_CHECK_MPI (sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize));
   singlesize += datasize;
 
   *pack_size = count * singlesize;
@@ -487,7 +487,7 @@ t8_default_scheme_pyramid_c::t8_element_MPI_Unpack (void *recvbuf, const int buf
     t8_dtet_element_unpack (recvbuf, buffer_size, position, &p, 1, comm);
 
     mpiret
-      = sc_MPI_Unpack (recvbuf, buffer_size, position, &pyramids[ielem]->switch_shape_at_level, 1, sc_MPI_INT8_T, comm);
+      = sc_MPI_Unpack (recvbuf, buffer_size, position, &pyramids[ielem]->switch_shape_at_level, 1, sc_MPI_BYTE, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
@@ -452,7 +452,7 @@ t8_default_scheme_pyramid_c::t8_element_MPI_Pack (t8_element_t **const elements,
     t8_dtet_t *p = &pyramids[ielem]->pyramid;
     t8_dtet_element_pack (&p, 1, send_buffer, buffer_size, position, comm);
 
-    SC_CHECK_MPI (sc_MPI_Pack (&pyramids[ielem]->switch_shape_at_level, 1, t8_MPI_INT8_T, send_buffer, buffer_size,
+    SC_CHECK_MPI (t8_MPI_Pack (&pyramids[ielem]->switch_shape_at_level, 1, t8_MPI_INT8_T, send_buffer, buffer_size,
                                position, comm));
   }
 }
@@ -468,7 +468,7 @@ t8_default_scheme_pyramid_c::t8_element_MPI_Pack_size (const unsigned int count,
   singlesize += datasize;
 
   /* switch shape at level */
-  SC_CHECK_MPI (sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize));
+  SC_CHECK_MPI (t8_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize));
   singlesize += datasize;
 
   *pack_size = count * singlesize;
@@ -487,7 +487,7 @@ t8_default_scheme_pyramid_c::t8_element_MPI_Unpack (void *recvbuf, const int buf
     t8_dtet_element_unpack (recvbuf, buffer_size, position, &p, 1, comm);
 
     mpiret
-      = sc_MPI_Unpack (recvbuf, buffer_size, position, &pyramids[ielem]->switch_shape_at_level, 1, t8_MPI_INT8_T, comm);
+      = t8_MPI_Unpack (recvbuf, buffer_size, position, &pyramids[ielem]->switch_shape_at_level, 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
@@ -452,7 +452,7 @@ t8_default_scheme_pyramid_c::t8_element_MPI_Pack (t8_element_t **const elements,
     t8_dtet_t *p = &pyramids[ielem]->pyramid;
     t8_dtet_element_pack (&p, 1, send_buffer, buffer_size, position, comm);
 
-    SC_CHECK_MPI (sc_MPI_Pack (&pyramids[ielem]->switch_shape_at_level, 1, sc_MPI_INT8_T, send_buffer, buffer_size,
+    SC_CHECK_MPI (sc_MPI_Pack (&pyramids[ielem]->switch_shape_at_level, 1, t8_MPI_INT8_T, send_buffer, buffer_size,
                                position, comm));
   }
 }
@@ -468,7 +468,7 @@ t8_default_scheme_pyramid_c::t8_element_MPI_Pack_size (const unsigned int count,
   singlesize += datasize;
 
   /* switch shape at level */
-  SC_CHECK_MPI (sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize));
+  SC_CHECK_MPI (sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize));
   singlesize += datasize;
 
   *pack_size = count * singlesize;
@@ -487,7 +487,7 @@ t8_default_scheme_pyramid_c::t8_element_MPI_Unpack (void *recvbuf, const int buf
     t8_dtet_element_unpack (recvbuf, buffer_size, position, &p, 1, comm);
 
     mpiret
-      = sc_MPI_Unpack (recvbuf, buffer_size, position, &pyramids[ielem]->switch_shape_at_level, 1, sc_MPI_INT8_T, comm);
+      = sc_MPI_Unpack (recvbuf, buffer_size, position, &pyramids[ielem]->switch_shape_at_level, 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
@@ -799,7 +799,7 @@ t8_default_scheme_quad_c::t8_element_MPI_Pack (t8_element_t **const elements, co
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Pack (&quads[ielem]->y, 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -818,7 +818,7 @@ t8_default_scheme_quad_c::t8_element_MPI_Pack_size (const unsigned int count, sc
   singlesize += 2 * datasize;
 
   /* level */
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -838,7 +838,7 @@ t8_default_scheme_quad_c::t8_element_MPI_Unpack (void *recvbuf, const int buffer
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->y), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, sc_MPI_BYTE, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
@@ -799,7 +799,7 @@ t8_default_scheme_quad_c::t8_element_MPI_Pack (t8_element_t **const elements, co
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Pack (&quads[ielem]->y, 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -818,7 +818,7 @@ t8_default_scheme_quad_c::t8_element_MPI_Pack_size (const unsigned int count, sc
   singlesize += 2 * datasize;
 
   /* level */
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -838,7 +838,7 @@ t8_default_scheme_quad_c::t8_element_MPI_Unpack (void *recvbuf, const int buffer
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->y), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, sc_MPI_BYTE, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, sc_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
@@ -799,7 +799,7 @@ t8_default_scheme_quad_c::t8_element_MPI_Pack (t8_element_t **const elements, co
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Pack (&quads[ielem]->y, 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -818,7 +818,7 @@ t8_default_scheme_quad_c::t8_element_MPI_Pack_size (const unsigned int count, sc
   singlesize += 2 * datasize;
 
   /* level */
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -838,7 +838,7 @@ t8_default_scheme_quad_c::t8_element_MPI_Unpack (void *recvbuf, const int buffer
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->y), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
@@ -799,7 +799,7 @@ t8_default_scheme_quad_c::t8_element_MPI_Pack (t8_element_t **const elements, co
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Pack (&quads[ielem]->y, 1, sc_MPI_INT, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&quads[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = t8_MPI_Pack (&quads[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -818,7 +818,7 @@ t8_default_scheme_quad_c::t8_element_MPI_Pack_size (const unsigned int count, sc
   singlesize += 2 * datasize;
 
   /* level */
-  mpiret = sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
+  mpiret = t8_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -838,7 +838,7 @@ t8_default_scheme_quad_c::t8_element_MPI_Unpack (void *recvbuf, const int buffer
     SC_CHECK_MPI (mpiret);
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->y), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, t8_MPI_INT8_T, comm);
+    mpiret = t8_MPI_Unpack (recvbuf, buffer_size, position, &(quads[ielem]->level), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
@@ -1718,9 +1718,9 @@ t8_dtri_element_pack (t8_dtri_t **const elements, const unsigned int count, void
     SC_CHECK_MPI (mpiret);
 #endif
 
-    mpiret = sc_MPI_Pack (&elements[ielem]->type, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = t8_MPI_Pack (&elements[ielem]->type, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&elements[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = t8_MPI_Pack (&elements[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -1744,7 +1744,7 @@ t8_dtri_element_pack_size (const unsigned int count, sc_MPI_Comm comm, int *pack
   singlesize += coord_count * datasize;
 
   /* type, level*/
-  mpiret = sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
+  mpiret = t8_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += 2 * datasize;
 
@@ -1766,9 +1766,9 @@ t8_dtri_element_unpack (void *recvbuf, const int buffer_size, int *position, t8_
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->z), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
 #endif
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->type), 1, t8_MPI_INT8_T, comm);
+    mpiret = t8_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->type), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->level), 1, t8_MPI_INT8_T, comm);
+    mpiret = t8_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->level), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
@@ -1718,9 +1718,9 @@ t8_dtri_element_pack (t8_dtri_t **const elements, const unsigned int count, void
     SC_CHECK_MPI (mpiret);
 #endif
 
-    mpiret = sc_MPI_Pack (&elements[ielem]->type, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&elements[ielem]->type, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&elements[ielem]->level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&elements[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -1744,7 +1744,7 @@ t8_dtri_element_pack_size (const unsigned int count, sc_MPI_Comm comm, int *pack
   singlesize += coord_count * datasize;
 
   /* type, level*/
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += 2 * datasize;
 
@@ -1766,9 +1766,9 @@ t8_dtri_element_unpack (void *recvbuf, const int buffer_size, int *position, t8_
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->z), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
 #endif
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->type), 1, sc_MPI_BYTE, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->type), 1, sc_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->level), 1, sc_MPI_BYTE, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->level), 1, sc_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
@@ -1718,9 +1718,9 @@ t8_dtri_element_pack (t8_dtri_t **const elements, const unsigned int count, void
     SC_CHECK_MPI (mpiret);
 #endif
 
-    mpiret = sc_MPI_Pack (&elements[ielem]->type, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&elements[ielem]->type, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&elements[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&elements[ielem]->level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -1744,7 +1744,7 @@ t8_dtri_element_pack_size (const unsigned int count, sc_MPI_Comm comm, int *pack
   singlesize += coord_count * datasize;
 
   /* type, level*/
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += 2 * datasize;
 
@@ -1766,9 +1766,9 @@ t8_dtri_element_unpack (void *recvbuf, const int buffer_size, int *position, t8_
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->z), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
 #endif
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->type), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->type), 1, sc_MPI_BYTE, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->level), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->level), 1, sc_MPI_BYTE, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
@@ -1718,9 +1718,9 @@ t8_dtri_element_pack (t8_dtri_t **const elements, const unsigned int count, void
     SC_CHECK_MPI (mpiret);
 #endif
 
-    mpiret = sc_MPI_Pack (&elements[ielem]->type, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&elements[ielem]->type, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Pack (&elements[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&elements[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -1744,7 +1744,7 @@ t8_dtri_element_pack_size (const unsigned int count, sc_MPI_Comm comm, int *pack
   singlesize += coord_count * datasize;
 
   /* type, level*/
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += 2 * datasize;
 
@@ -1766,9 +1766,9 @@ t8_dtri_element_unpack (void *recvbuf, const int buffer_size, int *position, t8_
     mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->z), 1, sc_MPI_INT, comm);
     SC_CHECK_MPI (mpiret);
 #endif
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->type), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->type), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->level), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(elements[ielem]->level), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
@@ -352,7 +352,7 @@ t8_default_scheme_vertex_c::t8_element_MPI_Pack (t8_element_t **const elements, 
   int mpiret;
   t8_dvertex_t **vertices = (t8_dvertex_t **) elements;
   for (unsigned int ielem = 0; ielem < count; ielem++) {
-    mpiret = sc_MPI_Pack (&vertices[ielem]->level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&vertices[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -365,7 +365,7 @@ t8_default_scheme_vertex_c::t8_element_MPI_Pack_size (const unsigned int count, 
   int datasize = 0;
   int mpiret;
 
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -381,7 +381,7 @@ t8_default_scheme_vertex_c::t8_element_MPI_Unpack (void *recvbuf, const int buff
   int mpiret;
   t8_dvertex_t **vertices = (t8_dvertex_t **) elements;
   for (unsigned int ielem = 0; ielem < count; ielem++) {
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(vertices[ielem]->level), 1, sc_MPI_BYTE, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(vertices[ielem]->level), 1, sc_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
@@ -352,7 +352,7 @@ t8_default_scheme_vertex_c::t8_element_MPI_Pack (t8_element_t **const elements, 
   int mpiret;
   t8_dvertex_t **vertices = (t8_dvertex_t **) elements;
   for (unsigned int ielem = 0; ielem < count; ielem++) {
-    mpiret = sc_MPI_Pack (&vertices[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = t8_MPI_Pack (&vertices[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -365,7 +365,7 @@ t8_default_scheme_vertex_c::t8_element_MPI_Pack_size (const unsigned int count, 
   int datasize = 0;
   int mpiret;
 
-  mpiret = sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
+  mpiret = t8_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -381,7 +381,7 @@ t8_default_scheme_vertex_c::t8_element_MPI_Unpack (void *recvbuf, const int buff
   int mpiret;
   t8_dvertex_t **vertices = (t8_dvertex_t **) elements;
   for (unsigned int ielem = 0; ielem < count; ielem++) {
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(vertices[ielem]->level), 1, t8_MPI_INT8_T, comm);
+    mpiret = t8_MPI_Unpack (recvbuf, buffer_size, position, &(vertices[ielem]->level), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
@@ -352,7 +352,7 @@ t8_default_scheme_vertex_c::t8_element_MPI_Pack (t8_element_t **const elements, 
   int mpiret;
   t8_dvertex_t **vertices = (t8_dvertex_t **) elements;
   for (unsigned int ielem = 0; ielem < count; ielem++) {
-    mpiret = sc_MPI_Pack (&vertices[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&vertices[ielem]->level, 1, sc_MPI_BYTE, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -365,7 +365,7 @@ t8_default_scheme_vertex_c::t8_element_MPI_Pack_size (const unsigned int count, 
   int datasize = 0;
   int mpiret;
 
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, sc_MPI_BYTE, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -381,7 +381,7 @@ t8_default_scheme_vertex_c::t8_element_MPI_Unpack (void *recvbuf, const int buff
   int mpiret;
   t8_dvertex_t **vertices = (t8_dvertex_t **) elements;
   for (unsigned int ielem = 0; ielem < count; ielem++) {
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(vertices[ielem]->level), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(vertices[ielem]->level), 1, sc_MPI_BYTE, comm);
     SC_CHECK_MPI (mpiret);
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
@@ -352,7 +352,7 @@ t8_default_scheme_vertex_c::t8_element_MPI_Pack (t8_element_t **const elements, 
   int mpiret;
   t8_dvertex_t **vertices = (t8_dvertex_t **) elements;
   for (unsigned int ielem = 0; ielem < count; ielem++) {
-    mpiret = sc_MPI_Pack (&vertices[ielem]->level, 1, sc_MPI_INT8_T, send_buffer, buffer_size, position, comm);
+    mpiret = sc_MPI_Pack (&vertices[ielem]->level, 1, t8_MPI_INT8_T, send_buffer, buffer_size, position, comm);
     SC_CHECK_MPI (mpiret);
   }
 }
@@ -365,7 +365,7 @@ t8_default_scheme_vertex_c::t8_element_MPI_Pack_size (const unsigned int count, 
   int datasize = 0;
   int mpiret;
 
-  mpiret = sc_MPI_Pack_size (1, sc_MPI_INT8_T, comm, &datasize);
+  mpiret = sc_MPI_Pack_size (1, t8_MPI_INT8_T, comm, &datasize);
   SC_CHECK_MPI (mpiret);
   singlesize += datasize;
 
@@ -381,7 +381,7 @@ t8_default_scheme_vertex_c::t8_element_MPI_Unpack (void *recvbuf, const int buff
   int mpiret;
   t8_dvertex_t **vertices = (t8_dvertex_t **) elements;
   for (unsigned int ielem = 0; ielem < count; ielem++) {
-    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(vertices[ielem]->level), 1, sc_MPI_INT8_T, comm);
+    mpiret = sc_MPI_Unpack (recvbuf, buffer_size, position, &(vertices[ielem]->level), 1, t8_MPI_INT8_T, comm);
     SC_CHECK_MPI (mpiret);
   }
 }


### PR DESCRIPTION
**_Describe your changes here:_**

This PR updates the libsc submodule to the lastest development containing the necessary fix in libsc's CMake build system to close #1109. Some of libsc's types have been deprecated. As a result, modifications had to be made on parts that relied on these MPI types. I think someone with better experience with the SFC schemes can weigh in whether I made the correct modifications.

Closes #1109

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
