### PR TITLE
Fix comment of t8_geom_linear_interpolation

### DIFF
--- a/src/t8_geometry/t8_geometry_helpers.c
+++ b/src/t8_geometry/t8_geometry_helpers.c
@@ -57,7 +57,7 @@ void
 t8_geom_triangular_interpolation (const double *coefficients, const double *corner_values, const int corner_value_dim,
                                   const int interpolation_dim, double *evaluated_function)
 {
-  /* The algorithm is able to calculate any point in a triangle or tetrahedron using barycentric coordinates.
+  /* The algorithm is able to calculate any point in a triangle or tetrahedron using cartesian coordinates.
    * All points are calculated by the sum of each corner point (e.g. p1 -> corner point 1) multiplied by a
    * scalar, which in this case are the reference coordinates (ref_coords).
    */
@@ -67,10 +67,12 @@ t8_geom_triangular_interpolation (const double *coefficients, const double *corn
     temp[i_dim] = (corner_values[corner_value_dim + i_dim] - /* (p2 - p1) * ref_coords */
                    corner_values[i_dim])
                     * coefficients[0]
+
                   + (interpolation_dim == 3
                        ? (corner_values[3 * corner_value_dim + i_dim] - corner_values[2 * corner_value_dim + i_dim])
                            * coefficients[1]
                        : 0.) /* (p4 - p3) * ref_coords */
+
                   + (corner_values[2 * corner_value_dim + i_dim] - corner_values[corner_value_dim + i_dim])
                       * coefficients[interpolation_dim - 1] /* (p3 - p2) * ref_coords */
                   + corner_values[i_dim];                   /* p1 */

--- a/src/t8_geometry/t8_geometry_helpers.h
+++ b/src/t8_geometry/t8_geometry_helpers.h
@@ -68,8 +68,12 @@ void
 t8_geom_linear_interpolation (const double *coefficients, const double *corner_values, int corner_value_dim,
                               int interpolation_dim, double *evaluated_function);
 
-/** Triangular interpolation between 3 points (triangle) or 4 points (tetrahedron) using barycentric coordinates.
- * \param [in]    coefficients        An array of size \a interpolation_dim giving the coefficients used for the interpolation
+/** Triangular interpolation between 3 points (triangle) or 4 points (tetrahedron) using cartesian coordinates.
+ * The input coefficients have to be given as coordinates in the reference triangle (interpolation_dim = 2) with points
+ * (0,0) (1,0) (1,1)
+ * or the reference tet (interpolation_dim = 3) with points
+ * (0,0,0) (1,0,0) (1,1,0) (1,1,1).
+ * \param [in]    coefficients        An array of size \a interpolation_dim giving the coefficients in the reference triangle/tet used for the interpolation
  * \param [in]    corner_values       An array of size 
                                                        3 * \a corner_value_dim for \a interpolation_dim == 2 or
                                                        4 * \a corner_value_dim for \a interpolation_dim == 3, 


### PR DESCRIPTION
**_Describe your changes here:_**

The comment for t8_geom_linear_interpolation stated that it was using barycentric coordinates when in fact it was using cartesian coordinates.
Fixed the comment.
Also added empty lines to increase readability.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
