### PR TITLE
CMake: add check for netcdf_par.h header file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ endif()
 
 if( T8CODE_ENABLE_NETCDF )
     find_package( netCDF REQUIRED )
+    include(cmake/CheckNetCDFPar.cmake)
 endif()
 
 # Override default for this libsc option

--- a/cmake/CheckNetCDFPar.cmake
+++ b/cmake/CheckNetCDFPar.cmake
@@ -1,0 +1,17 @@
+include( CheckCSourceCompiles )
+function( check_netcdf_par )
+  set( CMAKE_REQUIRED_LIBRARIES netCDF::netcdf )
+
+  check_c_source_compiles(
+    "
+        #include <netcdf.h>
+        #include <netcdf_par.h>
+
+        int main() {
+          return 0;
+        }
+    "
+    NETCDF_HAVE_NETCDF_PAR)
+endfunction()
+
+check_netcdf_par()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,10 +27,9 @@ endif()
 
 if( T8CODE_ENABLE_NETCDF )
   target_link_libraries( T8 PUBLIC netCDF::netcdf )
-
   target_compile_definitions(T8 PUBLIC
     T8_WITH_NETCDF
-    $<$<BOOL:${NETCDF_HAVE_NETCDF_PAR}>:T8_WITH_NETCDF_PAR> )
+    $<$<AND:$<BOOL:${NETCDF_HAVE_NETCDF_PAR}>,$<BOOL:${T8CODE_ENABLE_MPI}>>:T8_WITH_NETCDF_PAR> )
 endif()
 
 set_target_properties( T8 PROPERTIES OUTPUT_NAME t8 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,9 +27,10 @@ endif()
 
 if( T8CODE_ENABLE_NETCDF )
   target_link_libraries( T8 PUBLIC netCDF::netcdf )
+
   target_compile_definitions(T8 PUBLIC
     T8_WITH_NETCDF
-    $<$<BOOL:${T8CODE_ENABLE_MPI}>:T8_WITH_NETCDF_PAR> )
+    $<$<BOOL:${NETCDF_HAVE_NETCDF_PAR}>:T8_WITH_NETCDF_PAR> )
 endif()
 
 set_target_properties( T8 PROPERTIES OUTPUT_NAME t8 )


### PR DESCRIPTION
**_Describe your changes here:_**

This PR adds a check in the CMake build system for the `netcdf_par.h` header file.

Closes #1191

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
