### PR TITLE
Add tree compatibility test for example cmesh geoms

### DIFF
--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.hxx
@@ -84,6 +84,23 @@ struct t8_geometry_quadrangulated_disk: public t8_geometry_with_vertices
     return T8_GEOMETRY_TYPE_UNDEFINED;
   };
 
+  /**
+   * Check for compatibility of the currently loaded tree with the geometry.
+   * Only quad elements are supported by this geometry.
+   * \return                True if the geometry is compatible with the tree.
+   */
+  bool
+  t8_geom_check_tree_compatibility () const
+  {
+    if (active_tree_class != T8_ECLASS_QUAD) {
+      t8_productionf ("t8_geometry_quadrangulated_disk is not compatible with tree type %s\n"
+                      "It is only compatible with quad elements.\n",
+                      t8_eclass_to_string[active_tree_class]);
+      return true;
+    }
+    return false;
+  }
+
   /* Load tree data is inherited from t8_geometry_with_vertices. */
 };
 
@@ -124,6 +141,23 @@ struct t8_geometry_triangulated_spherical_surface: public t8_geometry_with_verti
                              double *jacobian) const
   {
     SC_ABORT_NOT_REACHED ();
+  }
+
+  /**
+   * Check for compatibility of the currently loaded tree with the geometry.
+   * Only triangle elements are supported by this geometry.
+   * \return                True if the geometry is compatible with the tree.
+   */
+  bool
+  t8_geom_check_tree_compatibility () const
+  {
+    if (active_tree_class != T8_ECLASS_TRIANGLE) {
+      t8_productionf ("t8_geometry_triangulated_spherical_surface is not compatible with tree type %s\n"
+                      "It is only compatible with triangle elements.\n",
+                      t8_eclass_to_string[active_tree_class]);
+      return true;
+    }
+    return false;
   }
 
   /* Load tree data is inherited from t8_geometry_with_vertices. */
@@ -167,6 +201,23 @@ struct t8_geometry_quadrangulated_spherical_surface: public t8_geometry_with_ver
     SC_ABORT_NOT_REACHED ();
   }
 
+  /**
+   * Check for compatibility of the currently loaded tree with the geometry.
+   * Only quad elements are supported by this geometry.
+   * \return                True if the geometry is compatible with the tree.
+   */
+  bool
+  t8_geom_check_tree_compatibility () const
+  {
+    if (active_tree_class != T8_ECLASS_QUAD) {
+      t8_productionf ("t8_geometry_quadrangulated_spherical_surface is not compatible with tree type %s\n"
+                      "It is only compatible with quad elements.\n",
+                      t8_eclass_to_string[active_tree_class]);
+      return true;
+    }
+    return false;
+  }
+
   /* Load tree data is inherited from t8_geometry_with_vertices. */
 };
 
@@ -206,6 +257,23 @@ struct t8_geometry_cubed_spherical_shell: public t8_geometry_with_vertices
                              double *jacobian) const
   {
     SC_ABORT_NOT_REACHED ();
+  }
+
+  /**
+   * Check for compatibility of the currently loaded tree with the geometry.
+   * Only hex elements are supported by this geometry.
+   * \return                True if the geometry is compatible with the tree.
+   */
+  bool
+  t8_geom_check_tree_compatibility () const
+  {
+    if (active_tree_class != T8_ECLASS_HEX) {
+      t8_productionf ("t8_geometry_cubed_spherical_shell is not compatible with tree type %s\n"
+                      "It is only compatible with hex elements.\n",
+                      t8_eclass_to_string[active_tree_class]);
+      return true;
+    }
+    return false;
   }
 
   /* Load tree data is inherited from t8_geometry_with_vertices. */
@@ -249,6 +317,23 @@ struct t8_geometry_prismed_spherical_shell: public t8_geometry_with_vertices
     SC_ABORT_NOT_REACHED ();
   }
 
+  /**
+   * Check for compatibility of the currently loaded tree with the geometry.
+   * Only prism elements are supported by this geometry.
+   * \return                True if the geometry is compatible with the tree.
+   */
+  bool
+  t8_geom_check_tree_compatibility () const
+  {
+    if (active_tree_class != T8_ECLASS_PRISM) {
+      t8_productionf ("t8_geometry_prismed_spherical_shell is not compatible with tree type %s\n"
+                      "It is only compatible with prism elements.\n",
+                      t8_eclass_to_string[active_tree_class]);
+      return true;
+    }
+    return false;
+  }
+
   /* Load tree data is inherited from t8_geometry_with_vertices. */
 };
 
@@ -288,6 +373,23 @@ struct t8_geometry_cubed_sphere: public t8_geometry_with_vertices
                              double *jacobian) const
   {
     SC_ABORT_NOT_REACHED ();
+  }
+
+  /**
+   * Check for compatibility of the currently loaded tree with the geometry.
+   * Only hex elements are supported by this geometry.
+   * \return                True if the geometry is compatible with the tree.
+   */
+  bool
+  t8_geom_check_tree_compatibility () const
+  {
+    if (active_tree_class != T8_ECLASS_HEX) {
+      t8_productionf ("t8_geometry_cubed_sphere is not compatible with tree type %s\n"
+                      "It is only compatible with hex elements.\n",
+                      t8_eclass_to_string[active_tree_class]);
+      return true;
+    }
+    return false;
   }
 
   /* Load tree data is inherited from t8_geometry_with_vertices. */


### PR DESCRIPTION
**_Describe your changes here:_**
I made a bigger PR [here](https://github.com/DLR-AMR/t8code/pull/1205). This PR lets cmesh commit check, if a geometry is valid with the current cmesh. For this the geometries get a function which checks a tree for validity. I am not really sure if I implemented it correctly for your geometries, so it would be nice if you can take a look at this. Furthermore it would be nice if you could implement such a function for your new geometry int this PR:
https://github.com/DLR-AMR/t8code/pull/1185


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
