### PR TITLE
Add padding option to element reference coords

### DIFF
--- a/benchmarks/time_forest_partition.cxx
+++ b/benchmarks/time_forest_partition.cxx
@@ -83,7 +83,7 @@ t8_anchor_element (t8_forest_t forest, t8_locidx_t which_tree,
                                               t8_forest_ltreeid_to_cmesh_ltreeid
                                               (forest, which_tree));
 
-  t8_forest_element_coordinate (forest, which_tree, element, tree_vertices,
+  t8_forest_element_coordinate_from_corner_number (forest, which_tree, element, tree_vertices,
                                 0, elem_anchor_f);
 #if 0
   /* get the element anchor node */

--- a/example/IO/cmesh/gmsh/t8_load_and_refine_square_w_hole.cxx
+++ b/example/IO/cmesh/gmsh/t8_load_and_refine_square_w_hole.cxx
@@ -72,9 +72,9 @@ t8_midpoint (t8_forest_t forest, t8_locidx_t which_tree, t8_eclass_scheme_c *ts,
     /* We approximate the midpoint of a square as the middle of
      * the diagonal from vertex 0 to vertex 3 */
     /* Get the coordinates of the elements  0-th vertex */
-    t8_forest_element_coordinate (forest, which_tree, element, 0, corner[0]);
+    t8_forest_element_coordinate_from_corner_number (forest, which_tree, element, 0, corner[0]);
     /* Get the coordinates of the elements  3rd vertex */
-    t8_forest_element_coordinate (forest, which_tree, element, 3, corner[1]);
+    t8_forest_element_coordinate_from_corner_number (forest, which_tree, element, 3, corner[1]);
 
     for (j = 0; j < 3; j++) {
       elem_mid_point[j] += corner[0][j] / 2.;
@@ -94,7 +94,7 @@ t8_midpoint (t8_forest_t forest, t8_locidx_t which_tree, t8_eclass_scheme_c *ts,
     for (i = 0; i < 3; i++) {
       corner[i] = T8_ALLOC (double, 3);
       /* Get the coordinates of the elements  i-th vertex */
-      t8_forest_element_coordinate (forest, which_tree, element, i, corner[i]);
+      t8_forest_element_coordinate_from_corner_number (forest, which_tree, element, i, corner[i]);
       /* At a third of the vertex coordinates to the midpoint coordinates */
       for (j = 0; j < 3; j++) {
         elem_mid_point[j] += corner[i][j] / 3.;

--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -76,14 +76,14 @@ t8_common_within_levelset (t8_forest_t forest, t8_locidx_t ltreeid, t8_element_t
     double coords[3];
 
     /* Compute LS function at first corner */
-    t8_forest_element_coordinate (forest, ltreeid, element, 0, coords);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, coords);
     /* compute the level-set function at this corner */
     value = levelset (coords, t, udata);
     /* sign = 1 if value > 0, -1 if value < 0, 0 if value = 0 */
     sign = value > 0 ? 1 : -(value < 0);
     /* iterate over all corners */
     for (icorner = 1; icorner < num_corners; icorner++) {
-      t8_forest_element_coordinate (forest, ltreeid, element, icorner, coords);
+      t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, icorner, coords);
       /* compute the level-set function at this corner */
       value = levelset (coords, t, udata);
       if ((value > 0 && sign <= 0) || (value == 0 && sign != 0) || (value < 0 && sign >= 0)) {

--- a/example/forest/t8_test_face_iterate.cxx
+++ b/example/forest/t8_test_face_iterate.cxx
@@ -49,7 +49,7 @@ t8_test_fiterate_callback (t8_forest_t forest, t8_locidx_t ltreeid, const t8_ele
 
   if (leaf_index >= 0) {
     coords = ((t8_test_fiterate_udata_t *) user_data)->coords;
-    t8_forest_element_coordinate (forest, ltreeid, element, 0, coords);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, coords);
     t8_debugf ("Leaf element in tree %i at face %i, tree local index %i has corner 0 coords %lf %lf %lf\n", ltreeid,
                face, (int) leaf_index, coords[0], coords[1], coords[2]);
     ((t8_test_fiterate_udata_t *) user_data)->count++;

--- a/src/t8_cmesh/t8_cmesh_examples.cxx
+++ b/src/t8_cmesh/t8_cmesh_examples.cxx
@@ -3239,7 +3239,7 @@ t8_cmesh_new_spherical_shell (t8_eclass_t eclass, t8_geometry_c *geometry,
       /* Retrieve 2D element vertices. */
       double elem_vertices_2d[T8_ECLASS_MAX_CORNERS * 3];
       for (int ivert = 0; ivert < t8_eclass_num_vertices[eclass_2d]; ivert++) {
-        t8_forest_element_coordinate (forest, itree_local, element, ivert, elem_vertices_2d + ivert * 3);
+        t8_forest_element_coordinate_from_corner_number (forest, itree_local, element, ivert, elem_vertices_2d + ivert * 3);
       }
 
       {

--- a/src/t8_element.hxx
+++ b/src/t8_element.hxx
@@ -578,12 +578,17 @@ struct t8_eclass_scheme
    * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
    *                          in the reference space of the element.
    * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [in] padding      Only used if \a num_coords > 1.
+   *                          The amount of padding in \a ref_coords between array elements:
+   *                          For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+   *                          For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+   *                          For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
    * \param [out] out_coords  The coordinates of the points in the
    *                          reference space of the tree.
    */
   virtual void
   t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords, const size_t num_coords,
-                               double *out_coords) const
+                               const size_t padding, double *out_coords) const
     = 0;
 
   /** Count how many leaf descendants of a given uniform level an element would produce.

--- a/src/t8_forest/t8_forest.cxx
+++ b/src/t8_forest/t8_forest.cxx
@@ -408,7 +408,7 @@ t8_forest_element_coordinate (t8_forest_t forest, t8_locidx_t ltree_id, const t8
 }
 
 void
-t8_forest_element_from_ref_coords_ext (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
+t8_forest_element_coordinate_from_ref_coords_ext (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
                                        const double *ref_coords, const size_t num_coords, double *coords_out,
                                        const double *stretch_factors)
 {
@@ -445,10 +445,10 @@ t8_forest_element_from_ref_coords_ext (t8_forest_t forest, t8_locidx_t ltreeid, 
 }
 
 void
-t8_forest_element_from_ref_coords (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
+t8_forest_element_coordinate_from_ref_coords (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
                                    const double *ref_coords, const size_t num_coords, double *coords_out)
 {
-  t8_forest_element_from_ref_coords_ext (forest, ltreeid, element, ref_coords, num_coords, coords_out, NULL);
+  t8_forest_element_coordinate_from_ref_coords_ext (forest, ltreeid, element, ref_coords, num_coords, coords_out, NULL);
 }
 
 /* Compute the diameter of an element. */
@@ -504,7 +504,7 @@ t8_forest_element_centroid (t8_forest_t forest, t8_locidx_t ltreeid, const t8_el
   /* Get the element class and calculate the centroid using its element
    * reference coordinates */
   const t8_element_shape_t element_shape = t8_element_shape (ts, element);
-  t8_forest_element_from_ref_coords (forest, ltreeid, element, t8_element_centroid_ref_coords[element_shape], 1,
+  t8_forest_element_coordinate_from_ref_coords (forest, ltreeid, element, t8_element_centroid_ref_coords[element_shape], 1,
                                      coordinates);
 }
 

--- a/src/t8_forest/t8_forest.cxx
+++ b/src/t8_forest/t8_forest.cxx
@@ -383,7 +383,7 @@ t8_forest_is_equal (t8_forest_t forest_a, t8_forest_t forest_b)
  */
 /* TODO: replace ltree_id argument with ts argument. */
 void
-t8_forest_element_coordinate (t8_forest_t forest, t8_locidx_t ltree_id, const t8_element_t *element, int corner_number,
+t8_forest_element_coordinate_from_corner_number (t8_forest_t forest, t8_locidx_t ltree_id, const t8_element_t *element, int corner_number,
                               double *coordinates)
 {
   double vertex_coords[3] = { 0.0 };
@@ -477,7 +477,7 @@ t8_forest_element_diam (t8_forest_t forest, t8_locidx_t ltreeid, const t8_elemen
   dist = 0;
   for (i = 0; i < num_corners; i++) {
     /* Compute coordinates of this corner */
-    t8_forest_element_coordinate (forest, ltreeid, element, i, coordinates);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, i, coordinates);
     /* Compute the distance to the midpoint */
     dist += t8_vec_dist (coordinates, centroid);
   }
@@ -516,8 +516,8 @@ t8_forest_element_line_length (t8_forest_t forest, t8_locidx_t ltreeid, const t8
   double coordinates_a[3], coordinates_b[3];
   double length;
 
-  t8_forest_element_coordinate (forest, ltreeid, element, corner_a, coordinates_a);
-  t8_forest_element_coordinate (forest, ltreeid, element, corner_b, coordinates_b);
+  t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, corner_a, coordinates_a);
+  t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, corner_b, coordinates_b);
 
   /* Compute the euclidean distance */
   length = t8_vec_dist (coordinates_a, coordinates_b);
@@ -620,9 +620,9 @@ t8_forest_element_volume (t8_forest_t forest, t8_locidx_t ltreeid, const t8_elem
     T8_ASSERT (corner_a != 0 && corner_b != 0);
     T8_ASSERT (corner_a != corner_b);
     /* Compute the coordinates of vertex 0, a and b */
-    t8_forest_element_coordinate (forest, ltreeid, element, 0, coordinates[0]);
-    t8_forest_element_coordinate (forest, ltreeid, element, corner_a, coordinates[1]);
-    t8_forest_element_coordinate (forest, ltreeid, element, corner_b, coordinates[2]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, coordinates[0]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, corner_a, coordinates[1]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, corner_b, coordinates[2]);
     return 2 * t8_forest_element_triangle_area (coordinates);
   } break;
   case T8_ECLASS_TRIANGLE: {
@@ -641,7 +641,7 @@ t8_forest_element_volume (t8_forest_t forest, t8_locidx_t ltreeid, const t8_elem
      * triangle always spans a parallelogram.
      */
     for (i = 0; i < 3; i++) {
-      t8_forest_element_coordinate (forest, ltreeid, element, i, coordinates[i]);
+      t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, i, coordinates[i]);
     }
     return t8_forest_element_triangle_area (coordinates);
   } break;
@@ -658,7 +658,7 @@ t8_forest_element_volume (t8_forest_t forest, t8_locidx_t ltreeid, const t8_elem
 
     /* Compute the 4 corner coordinates */
     for (i = 0; i < 4; i++) {
-      t8_forest_element_coordinate (forest, ltreeid, element, i, coordinates[i]);
+      t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, i, coordinates[i]);
     }
 
     return t8_forest_element_tet_volume (coordinates);
@@ -671,10 +671,10 @@ t8_forest_element_volume (t8_forest_t forest, t8_locidx_t ltreeid, const t8_elem
     int i;
 
     /* Get the coordinates of the four corners */
-    t8_forest_element_coordinate (forest, ltreeid, element, 0, coordinates[0]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 1, coordinates[1]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 2, coordinates[2]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 4, coordinates[3]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, coordinates[0]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 1, coordinates[1]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 2, coordinates[2]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 4, coordinates[3]);
 
     /* Compute the difference of each corner with corner 0 */
     for (i = 1; i < 4; i++) {
@@ -694,24 +694,24 @@ t8_forest_element_volume (t8_forest_t forest, t8_locidx_t ltreeid, const t8_elem
     double coordinates[4][3], volume;
 
     /* The first tetrahedron has prism vertices 0, 1, 2, and 4 */
-    t8_forest_element_coordinate (forest, ltreeid, element, 0, coordinates[0]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 1, coordinates[1]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 2, coordinates[2]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 4, coordinates[3]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, coordinates[0]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 1, coordinates[1]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 2, coordinates[2]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 4, coordinates[3]);
     volume = t8_forest_element_tet_volume (coordinates);
 
     /* The second tetrahedron has prism vertices 0, 2, 3, and 4 */
-    t8_forest_element_coordinate (forest, ltreeid, element, 0, coordinates[0]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 2, coordinates[1]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 3, coordinates[2]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 4, coordinates[3]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, coordinates[0]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 2, coordinates[1]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 3, coordinates[2]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 4, coordinates[3]);
     volume += t8_forest_element_tet_volume (coordinates);
 
     /* The third tetrahedron has prism vertices 2, 3, 4, and 5 */
-    t8_forest_element_coordinate (forest, ltreeid, element, 2, coordinates[0]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 3, coordinates[1]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 4, coordinates[2]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 5, coordinates[3]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 2, coordinates[0]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 3, coordinates[1]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 4, coordinates[2]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 5, coordinates[3]);
     volume += t8_forest_element_tet_volume (coordinates);
 
     return volume;
@@ -719,15 +719,15 @@ t8_forest_element_volume (t8_forest_t forest, t8_locidx_t ltreeid, const t8_elem
   case T8_ECLASS_PYRAMID: {
     double volume, coordinates[4][3];
     /* The first tetrahedron has pyra vertices 0, 1, 3 and 4 */
-    t8_forest_element_coordinate (forest, ltreeid, element, 0, coordinates[0]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 1, coordinates[1]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 3, coordinates[2]);
-    t8_forest_element_coordinate (forest, ltreeid, element, 4, coordinates[3]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, coordinates[0]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 1, coordinates[1]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 3, coordinates[2]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 4, coordinates[3]);
     volume = t8_forest_element_tet_volume (coordinates);
 
     /* The second tetrahedron has pyra vertices 0, 3, 2 and 4 */
 
-    t8_forest_element_coordinate (forest, ltreeid, element, 2, coordinates[1]);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 2, coordinates[1]);
 
     volume += t8_forest_element_tet_volume (coordinates);
     return volume;
@@ -777,7 +777,7 @@ t8_forest_element_face_area (t8_forest_t forest, t8_locidx_t ltreeid, const t8_e
     /* Compute the coordinates of the triangle's vertices */
     for (i = 0; i < 3; i++) {
       face_corner = ts->t8_element_get_face_corner (element, face, i);
-      t8_forest_element_coordinate (forest, ltreeid, element, face_corner, coordinates[i]);
+      t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, face_corner, coordinates[i]);
     }
 
     /* Compute the area of the triangle */
@@ -800,7 +800,7 @@ t8_forest_element_face_area (t8_forest_t forest, t8_locidx_t ltreeid, const t8_e
       /* Compute the coordinates of the first triangle's vertices */
       for (i = 0; i < 3; i++) {
         face_corner = ts->t8_element_get_face_corner (element, face, i);
-        t8_forest_element_coordinate (forest, ltreeid, element, face_corner, coordinates[i]);
+        t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, face_corner, coordinates[i]);
       }
       /* Compute the first triangle's area */
       area = 0;
@@ -810,7 +810,7 @@ t8_forest_element_face_area (t8_forest_t forest, t8_locidx_t ltreeid, const t8_e
        * we recompute all corner coordinates for the second triangle. */
       for (i = 0; i < 3; i++) {
         face_corner = ts->t8_element_get_face_corner (element, face, i + 1);
-        t8_forest_element_coordinate (forest, ltreeid, element, face_corner, coordinates[i]);
+        t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, face_corner, coordinates[i]);
       }
 
       area += t8_forest_element_triangle_area (coordinates);
@@ -844,7 +844,7 @@ t8_forest_element_face_centroid (t8_forest_t forest, t8_locidx_t ltreeid, const 
     /* Get the index of the corner that is the face */
     corner = ts->t8_element_get_face_corner (element, face, 0);
     /* Compute the coordinates of this corner */
-    t8_forest_element_coordinate (forest, ltreeid, element, corner, centroid);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, corner, centroid);
     return;
   } break;
   case T8_ECLASS_LINE: {
@@ -855,8 +855,8 @@ t8_forest_element_face_centroid (t8_forest_t forest, t8_locidx_t ltreeid, const 
     corner_a = ts->t8_element_get_face_corner (element, face, 0);
     corner_b = ts->t8_element_get_face_corner (element, face, 1);
     /* Compute the vertex coordinates of these corners */
-    t8_forest_element_coordinate (forest, ltreeid, element, corner_a, vertex_a);
-    t8_forest_element_coordinate (forest, ltreeid, element, corner_b, centroid);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, corner_a, vertex_a);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, corner_b, centroid);
 
     /* Compute the average of those coordinates */
     /* centroid = centroid + vertex_a */
@@ -874,7 +874,7 @@ t8_forest_element_face_centroid (t8_forest_t forest, t8_locidx_t ltreeid, const 
     num_corners = face_shape == T8_ECLASS_TRIANGLE ? 3 : 4;
     for (i = 0; i < num_corners; i++) {
       corner = ts->t8_element_get_face_corner (element, face, i);
-      t8_forest_element_coordinate (forest, ltreeid, element, corner, coordinates[i]);
+      t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, corner, coordinates[i]);
     }
 
     for (i = 1; i < num_corners; i++) {
@@ -964,8 +964,8 @@ t8_forest_element_face_normal (t8_forest_t forest, t8_locidx_t ltreeid, const t8
     int sign;
 
     /* Get the coordinates of v_0 and v_1 */
-    t8_forest_element_coordinate (forest, ltreeid, element, 0, v_0);
-    t8_forest_element_coordinate (forest, ltreeid, element, 1, normal);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, v_0);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 1, normal);
 
     /* Compute normal = v_1 - v_0 */
     t8_vec_axpy (v_0, normal, -1);
@@ -1004,8 +1004,8 @@ t8_forest_element_face_normal (t8_forest_t forest, t8_locidx_t ltreeid, const t8
     corner_a = ts->t8_element_get_face_corner (element, face, 0);
     corner_b = ts->t8_element_get_face_corner (element, face, 1);
     /* Compute the coordinates of the endnotes */
-    t8_forest_element_coordinate (forest, ltreeid, element, corner_a, vertex_a);
-    t8_forest_element_coordinate (forest, ltreeid, element, corner_b, vertex_b);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, corner_a, vertex_a);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, corner_b, vertex_b);
     /* Compute the center */
     t8_forest_element_centroid (forest, ltreeid, element, center);
 
@@ -1056,10 +1056,10 @@ t8_forest_element_face_normal (t8_forest_t forest, t8_locidx_t ltreeid, const t8
     {
       double p_0[3], p_1[3], p_2[3], p_3[3];
       /* Compute the vertex coordinates of the quad */
-      t8_forest_element_coordinate (forest, ltreeid, element, 0, p_0);
-      t8_forest_element_coordinate (forest, ltreeid, element, 1, p_1);
-      t8_forest_element_coordinate (forest, ltreeid, element, 2, p_2);
-      t8_forest_element_coordinate (forest, ltreeid, element, 3, p_3);
+      t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, p_0);
+      t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 1, p_1);
+      t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 2, p_2);
+      t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 3, p_3);
       if (!t8_four_points_coplanar (p_0, p_1, p_2, p_3, 1e-16)) {
         t8_debugf ("WARNING: Computing normal to a quad that is not coplanar. This computation will be inaccurate.\n");
       }
@@ -1076,7 +1076,7 @@ t8_forest_element_face_normal (t8_forest_t forest, t8_locidx_t ltreeid, const t8
       /* Compute the i-th corner */
       corner = ts->t8_element_get_face_corner (element, face, i);
       /* Compute the coordinates of this corner */
-      t8_forest_element_coordinate (forest, ltreeid, element, corner, corner_vertices[i]);
+      t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, corner, corner_vertices[i]);
     }
     /* Subtract vertex 0 from the other two */
     t8_vec_axpy (corner_vertices[0], corner_vertices[1], -1);

--- a/src/t8_forest/t8_forest_geometrical.h
+++ b/src/t8_forest/t8_forest_geometrical.h
@@ -52,8 +52,8 @@ t8_forest_get_dimension (const t8_forest_t forest);
  *                             the x, y and z coordinates of the vertex.
  */
 void
-t8_forest_element_coordinate_from_corner_number (t8_forest_t forest, t8_locidx_t ltree_id, const t8_element_t *element, int corner_number,
-                              double *coordinates);
+t8_forest_element_coordinate_from_corner_number (t8_forest_t forest, t8_locidx_t ltree_id, const t8_element_t *element,
+                                                 int corner_number, double *coordinates);
 
 /** Compute the coordinates of a point inside an element inside a tree.
  *  The point is given in reference coordinates inside the element and gets
@@ -66,6 +66,11 @@ t8_forest_element_coordinate_from_corner_number (t8_forest_t forest, t8_locidx_t
  * \param [in]      element           The element.
  * \param [in]      ref_coords        The reference coordinates of the point inside the element.
  * \param [in]      num_coords        The number of coordinate sets in ref_coord (dimension x double).
+ * \param [in]      padding           Only used if \a num_coords > 1.
+ *                                    The amount of padding in \a ref_coords between array elements:
+ *                                    For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+ *                                    For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+ *                                    For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
  * \param [out]     coords_out        On input an allocated array to store 3 doubles, on output
  *                                    the x, y and z coordinates of the point inside the domain.
  * \param [in]      stretch_factors   If provided, elements are stretched according to the stretch factors
@@ -74,8 +79,9 @@ t8_forest_element_coordinate_from_corner_number (t8_forest_t forest, t8_locidx_t
 
 void
 t8_forest_element_coordinate_from_ref_coords_ext (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
-                                       const double *ref_coords, const size_t num_coords, double *coords_out,
-                                       const double *stretch_factors);
+                                                  const double *ref_coords, const size_t num_coords,
+                                                  const size_t padding, double *coords_out,
+                                                  const double *stretch_factors);
 
 /** Compute the coordinates of a point inside an element inside a tree.
  *  The point is given in reference coordinates inside the element and gets
@@ -86,12 +92,19 @@ t8_forest_element_coordinate_from_ref_coords_ext (t8_forest_t forest, t8_locidx_
  * \param [in]      element           The element.
  * \param [in]      ref_coords        The reference coordinates of the point inside the element.
  * \param [in]      num_coords        The number of coordinate sets in ref_coord (dimension x double).
+ * \param [in]      padding           Only used if \a num_coords > 1.
+ *                                    The amount of padding in \a ref_coords between array elements:
+ *                                    For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+ *                                    For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+ *                                    For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
  * \param [out]     coords_out        On input an allocated array to store 3 doubles, on output
  *                                    the x, y and z coordinates of the point inside the domain.
  */
+
 void
 t8_forest_element_coordinate_from_ref_coords (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
-                                   const double *ref_coords, const size_t num_coords, double *coords_out);
+                                              const double *ref_coords, const size_t num_coords, const size_t padding,
+                                              double *coords_out);
 
 /** Compute the coordinates of the centroid of an element if a geometry
  * for this tree is registered in the forest's cmesh.

--- a/src/t8_forest/t8_forest_geometrical.h
+++ b/src/t8_forest/t8_forest_geometrical.h
@@ -52,7 +52,7 @@ t8_forest_get_dimension (const t8_forest_t forest);
  *                             the x, y and z coordinates of the vertex.
  */
 void
-t8_forest_element_coordinate (t8_forest_t forest, t8_locidx_t ltree_id, const t8_element_t *element, int corner_number,
+t8_forest_element_coordinate_from_corner_number (t8_forest_t forest, t8_locidx_t ltree_id, const t8_element_t *element, int corner_number,
                               double *coordinates);
 
 /** Compute the coordinates of a point inside an element inside a tree.

--- a/src/t8_forest/t8_forest_geometrical.h
+++ b/src/t8_forest/t8_forest_geometrical.h
@@ -73,7 +73,7 @@ t8_forest_element_coordinate (t8_forest_t forest, t8_locidx_t ltree_id, const t8
  */
 
 void
-t8_forest_element_from_ref_coords_ext (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
+t8_forest_element_coordinate_from_ref_coords_ext (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
                                        const double *ref_coords, const size_t num_coords, double *coords_out,
                                        const double *stretch_factors);
 
@@ -90,7 +90,7 @@ t8_forest_element_from_ref_coords_ext (t8_forest_t forest, t8_locidx_t ltreeid, 
  *                                    the x, y and z coordinates of the point inside the domain.
  */
 void
-t8_forest_element_from_ref_coords (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
+t8_forest_element_coordinate_from_ref_coords (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
                                    const double *ref_coords, const size_t num_coords, double *coords_out);
 
 /** Compute the coordinates of the centroid of an element if a geometry

--- a/src/t8_forest/t8_forest_netcdf.cxx
+++ b/src/t8_forest/t8_forest_netcdf.cxx
@@ -750,7 +750,7 @@ t8_forest_write_netcdf_coordinate_data (t8_forest_t forest, t8_forest_netcdf_con
       number_nodes = t8_element_shape_num_vertices (element_shape);
       i = 0;
       for (; i < number_nodes; i++) {
-        t8_forest_element_coordinate (forest, ltree_id, element,
+        t8_forest_element_coordinate_from_corner_number (forest, ltree_id, element,
                                       t8_element_shape_vtk_corner_number ((int) element_shape, i), vertex_coords);
         /* Stores the x-, y- and z- coordinate of the nodes */
         Mesh_node_x[num_it] = vertex_coords[0];

--- a/src/t8_forest/t8_forest_vtk.cxx
+++ b/src/t8_forest/t8_forest_vtk.cxx
@@ -185,7 +185,7 @@ t8_forest_vtk_get_element_nodes (t8_forest_t forest, t8_locidx_t ltreeid, const 
   const t8_element_shape_t element_shape = scheme->t8_element_shape (element);
   const double *ref_coords = t8_forest_vtk_point_to_element_ref_coords[element_shape][vertex];
   const int num_node = t8_get_number_of_vtk_nodes (element_shape, curved_flag);
-  t8_forest_element_from_ref_coords (forest, ltreeid, element, ref_coords, num_node, out_coords);
+  t8_forest_element_coordinate_from_ref_coords (forest, ltreeid, element, ref_coords, num_node, out_coords);
 }
 
 /**
@@ -623,7 +623,7 @@ t8_forest_vtk_cells_vertices_kernel (t8_forest_t forest, const t8_locidx_t ltree
   num_el_vertices = t8_eclass_num_vertices[element_shape];
   for (ivertex = 0; ivertex < num_el_vertices; ivertex++) {
     const double *ref_coords = t8_forest_vtk_point_to_element_ref_coords[element_shape][ivertex];
-    t8_forest_element_from_ref_coords (forest, ltree_id, element, ref_coords, 1, element_coordinates);
+    t8_forest_element_coordinate_from_ref_coords (forest, ltree_id, element, ref_coords, 1, element_coordinates);
     freturn = fprintf (vtufile, "         ");
     if (freturn <= 0) {
       return 0;

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.cxx
@@ -109,7 +109,7 @@ t8_geometry_linear::t8_geom_point_batch_inside_element (t8_forest_t forest, t8_l
     /* A point is 'inside' a vertex if they have the same coordinates */
     double vertex_coords[3];
     /* Get the vertex coordinates */
-    t8_forest_element_coordinate (forest, ltreeid, element, 0, vertex_coords);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, vertex_coords);
     /* Check whether the point and the vertex are within tolerance distance
        * to each other */
     for (int ipoint = 0; ipoint < num_points; ipoint++) {
@@ -127,9 +127,9 @@ t8_geometry_linear::t8_geom_point_batch_inside_element (t8_forest_t forest, t8_l
     double p_0[3], v[3];
 
     /* Compute the vertex coordinates of the line */
-    t8_forest_element_coordinate (forest, ltreeid, element, 0, p_0);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, p_0);
     /* v = p_1 */
-    t8_forest_element_coordinate (forest, ltreeid, element, 1, v);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 1, v);
     /* v = p_1 - p_0 */
     t8_vec_axpy (p_0, v, -1);
     for (int ipoint = 0; ipoint < num_points; ipoint++) {
@@ -141,10 +141,10 @@ t8_geometry_linear::t8_geom_point_batch_inside_element (t8_forest_t forest, t8_l
     /* We divide the quad in two triangles and use the triangle check. */
     double p_0[3], p_1[3], p_2[3], p_3[3];
     /* Compute the vertex coordinates of the quad */
-    t8_forest_element_coordinate (forest, ltreeid, element, 0, p_0);
-    t8_forest_element_coordinate (forest, ltreeid, element, 1, p_1);
-    t8_forest_element_coordinate (forest, ltreeid, element, 2, p_2);
-    t8_forest_element_coordinate (forest, ltreeid, element, 3, p_3);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, p_0);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 1, p_1);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 2, p_2);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 3, p_3);
 
 #if T8_ENABLE_DEBUG
     /* Issue a warning if the points of the quad do not lie in the same plane */
@@ -179,9 +179,9 @@ t8_geometry_linear::t8_geom_point_batch_inside_element (t8_forest_t forest, t8_l
     double p_0[3], p_1[3], p_2[3];
 
     /* Compute the vertex coordinates of the triangle */
-    t8_forest_element_coordinate (forest, ltreeid, element, 0, p_0);
-    t8_forest_element_coordinate (forest, ltreeid, element, 1, p_1);
-    t8_forest_element_coordinate (forest, ltreeid, element, 2, p_2);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, p_0);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 1, p_1);
+    t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 2, p_2);
     double v[3];
     double w[3];
     /* v = v - p_0 = p_1 - p_0 */
@@ -223,7 +223,7 @@ t8_geometry_linear::t8_geom_point_batch_inside_element (t8_forest_t forest, t8_l
       /* Compute a point x on the face */
       const int afacecorner = ts->t8_element_get_face_corner (element, iface, 0);
       double point_on_face[3];
-      t8_forest_element_coordinate (forest, ltreeid, element, afacecorner, point_on_face);
+      t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, afacecorner, point_on_face);
       for (int ipoint = 0; ipoint < num_points; ipoint++) {
         const int is_inside_iface = t8_plane_point_inside (point_on_face, face_normal, &points[ipoint * 3]);
         if (is_inside_iface == 0) {

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_linear_axis_aligned.cxx
@@ -83,8 +83,8 @@ t8_geometry_linear_axis_aligned::t8_geom_point_batch_inside_element (t8_forest_t
   const int max_corner_id = (elem_class == T8_ECLASS_LINE) ? 1 : (elem_class == T8_ECLASS_QUAD) ? 3 : 7;
 
   /*Geometry is fully described by v_min and v_max*/
-  t8_forest_element_coordinate (forest, ltreeid, element, 0, v_min);
-  t8_forest_element_coordinate (forest, ltreeid, element, max_corner_id, v_max);
+  t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, 0, v_min);
+  t8_forest_element_coordinate_from_corner_number (forest, ltreeid, element, max_corner_id, v_max);
 #if T8_ENABLE_DEBUG
   const double coords[6] = { v_min[0], v_min[1], v_min[2], v_max[0], v_max[1], v_max[2] };
   T8_ASSERT (correct_point_order (coords));

--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common.hxx
@@ -105,12 +105,17 @@ class t8_default_scheme_common_c: public t8_eclass_scheme_c {
    * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
    *                          in the reference space of the element.
    * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [in] padding      Only used if \a num_coords > 1.
+   *                          The amount of padding in \a ref_coords between array elements:
+   *                          For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+   *                          For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+   *                          For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
    * \param [out] out_coords  The coordinates of the points in the
    *                          reference space of the tree.
    */
   virtual void
   t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords, const size_t num_coords,
-                               double *out_coords) const
+                               const size_t padding, double *out_coords) const
     = 0;
 
   /** Get the integer coordinates of the anchor node of an element.

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
@@ -567,10 +567,11 @@ t8_default_scheme_hex_c::t8_element_vertex_reference_coords (const t8_element_t 
 
 void
 t8_default_scheme_hex_c::t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords,
-                                                      const size_t num_coords, double *out_coords) const
+                                                      const size_t num_coords, const size_t padding,
+                                                      double *out_coords) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_dhex_compute_reference_coords ((const t8_dhex_t *) elem, ref_coords, num_coords, out_coords);
+  t8_dhex_compute_reference_coords ((const t8_dhex_t *) elem, ref_coords, num_coords, padding, out_coords);
 }
 
 int

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.hxx
@@ -542,12 +542,17 @@ struct t8_default_scheme_hex_c: public t8_default_scheme_common_c
    * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
    *                          in the reference space of the element.
    * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [in] padding      Only used if \a num_coords > 1.
+   *                          The amount of padding in \a ref_coords between array elements:
+   *                          For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+   *                          For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+   *                          For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
    * \param [out] out_coords  The coordinates of the points in the
    *                          reference space of the tree.
    */
   virtual void
   t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords, const size_t num_coords,
-                               double *out_coords) const;
+                               const size_t padding, double *out_coords) const;
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
@@ -25,7 +25,7 @@
 
 void
 t8_dhex_compute_reference_coords (const t8_dhex_t *elem, const double *ref_coords, const size_t num_coords,
-                                  double *out_coords)
+                                  const size_t padding, double *out_coords)
 {
   const p8est_quadrant_t *q1 = (const p8est_quadrant_t *) elem;
 
@@ -33,17 +33,18 @@ t8_dhex_compute_reference_coords (const t8_dhex_t *elem, const double *ref_coord
   const p4est_qcoord_t len = P8EST_QUADRANT_LEN (q1->level);
 
   for (size_t coord = 0; coord < num_coords; ++coord) {
-    const size_t offset = 3 * coord;
+    const size_t offset_ref = (t8_eclass_to_dimension[T8_ECLASS_HEX] + padding) * coord;
+    const size_t offset_out = t8_eclass_to_dimension[T8_ECLASS_HEX] * coord;
     /* Compute the x, y and z coordinates of the point depending on the
      * reference coordinates */
-    out_coords[offset + 0] = q1->x + ref_coords[offset + 0] * len;
-    out_coords[offset + 1] = q1->y + ref_coords[offset + 1] * len;
-    out_coords[offset + 2] = q1->z + ref_coords[offset + 2] * len;
+    out_coords[offset_out + 0] = q1->x + ref_coords[offset_ref + 0] * len;
+    out_coords[offset_out + 1] = q1->y + ref_coords[offset_ref + 1] * len;
+    out_coords[offset_out + 2] = q1->z + ref_coords[offset_ref + 2] * len;
 
     /* We divide the integer coordinates by the root length of the hex
      * to obtain the reference coordinates. */
-    out_coords[offset + 0] /= (double) P8EST_ROOT_LEN;
-    out_coords[offset + 1] /= (double) P8EST_ROOT_LEN;
-    out_coords[offset + 2] /= (double) P8EST_ROOT_LEN;
+    out_coords[offset_out + 0] /= (double) P8EST_ROOT_LEN;
+    out_coords[offset_out + 1] /= (double) P8EST_ROOT_LEN;
+    out_coords[offset_out + 2] /= (double) P8EST_ROOT_LEN;
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
@@ -38,13 +38,18 @@ T8_EXTERN_C_BEGIN ();
  * \param [in]  ref_coords The reference coordinates in the hex
  *                         (\a num_coords times \f$ [0,1]^3 \f$)
  * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [in]  padding    Only used if \a num_coords > 1.
+ *                         The amount of padding in \a ref_coords between array elements:
+ *                         For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+ *                         For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+ *                         For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
  * \param [out] out_coords An array of \a num_coords x 3 x double that
  * 		                     will be filled with the reference coordinates
  *                         of the points on the hex.
  */
 void
 t8_dhex_compute_reference_coords (const t8_dhex_t *elem, const double *ref_coords, const size_t num_coords,
-                                  double *out_coords);
+                                  const size_t padding, double *out_coords);
 
 T8_EXTERN_C_END ();
 

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
@@ -303,11 +303,12 @@ t8_default_scheme_line_c::t8_element_vertex_reference_coords (const t8_element_t
 
 void
 t8_default_scheme_line_c::t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords,
-                                                       const size_t num_coords, double *out_coords) const
+                                                       const size_t num_coords, const size_t padding,
+                                                       double *out_coords) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (ref_coords != NULL);
-  t8_dline_compute_reference_coords ((const t8_dline_t *) elem, ref_coords, num_coords, 0, out_coords);
+  t8_dline_compute_reference_coords ((const t8_dline_t *) elem, ref_coords, num_coords, padding, 0, out_coords);
 }
 
 t8_linearidx_t

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.hxx
@@ -549,12 +549,17 @@ struct t8_default_scheme_line_c: public t8_default_scheme_common_c
    * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
    *                          in the reference space of the element.
    * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [in] padding      Only used if \a num_coords > 1.
+   *                          The amount of padding in \a ref_coords between array elements:
+   *                          For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+   *                          For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+   *                          For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
    * \param [out] out_coords  The coordinates of the points in the
    *                          reference space of the tree.
    */
   virtual void
   t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords, const size_t num_coords,
-                               double *out_coords) const;
+                               const size_t padding, double *out_coords) const;
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
@@ -347,15 +347,15 @@ t8_dline_vertex_ref_coords (const t8_dline_t *elem, const int vertex, double coo
 
 void
 t8_dline_compute_reference_coords (const t8_dline_t *elem, const double *ref_coords, const size_t num_coords,
-                                   const size_t skip_coords, double *out_coords)
+                                   const size_t padding, const size_t skip_coords, double *out_coords)
 {
   T8_ASSERT (t8_dline_is_valid (elem));
   for (size_t coord = 0; coord < num_coords; ++coord) {
-    const size_t offset = coord * (1 + skip_coords);
-    const size_t offset_3d = coord * 3;
-    out_coords[offset] = elem->x;
-    out_coords[offset] += T8_DLINE_LEN (elem->level) * ref_coords[offset_3d];
-    out_coords[offset] /= (double) T8_DLINE_ROOT_LEN;
+    const size_t offset_ref = (t8_eclass_to_dimension[T8_ECLASS_LINE] + padding + skip_coords) * coord;
+    const size_t offset_out = coord * (1 + skip_coords);
+    out_coords[offset_out] = elem->x;
+    out_coords[offset_out] += T8_DLINE_LEN (elem->level) * ref_coords[offset_ref];
+    out_coords[offset_out] /= (double) T8_DLINE_ROOT_LEN;
   }
 }
 

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
@@ -257,21 +257,26 @@ t8_dline_vertex_ref_coords (const t8_dline_t *elem, const int vertex, double coo
 
 /** Convert points in the reference space of a line element to points in the
  *  reference space of the tree (level 0) embedded in [0,1]^1.
- * \param [in]  elem       Input line.
- * \param [in]  ref_coords The reference coordinates in the line
- *                         (\a num_coords times \f$ [0,1]^1 \f$)
- * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [in]  elem        Input line.
+ * \param [in]  ref_coords  The reference coordinates in the line
+ *                          (\a num_coords times \f$ [0,1]^1 \f$)
+ * \param [in]  num_coords  Number of coordinates to evaluate
+ * \param [in]  padding     Only used if \a num_coords > 1.
+ *                          The amount of padding in \a ref_coords between array elements:
+ *                          For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+ *                          For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+ *                          For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
  * \param [in]  skip_coords Only used for batch computation of prisms.
  *                          In all other cases 0.
  *                          Skip coordinates in the \a ref_coords and
  *                          \a out_coords array.
- * \param [out] out_coords An array of \a num_coords x 1 x double that
- * 		                     will be filled with the reference coordinates
- *                         of the points on the line.
+ * \param [out] out_coords  An array of \a num_coords x 1 x double that
+ * 		                      will be filled with the reference coordinates
+ *                          of the points on the line.
  */
 void
 t8_dline_compute_reference_coords (const t8_dline_t *elem, const double *ref_coords, const size_t num_coords,
-                                   const size_t skip_coords, double *out_coords);
+                                   const size_t padding, const size_t skip_coords, double *out_coords);
 
 /** Computes the linear position of a line in an uniform grid.
  * \param [in] line  Line whose id will be computed.

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
@@ -404,10 +404,11 @@ t8_default_scheme_prism_c::t8_element_vertex_reference_coords (const t8_element_
 
 void
 t8_default_scheme_prism_c::t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords,
-                                                        const size_t num_coords, double *out_coords) const
+                                                        const size_t num_coords, const size_t padding,
+                                                        double *out_coords) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_dprism_compute_reference_coords ((const t8_dprism_t *) elem, ref_coords, num_coords, out_coords);
+  t8_dprism_compute_reference_coords ((const t8_dprism_t *) elem, ref_coords, num_coords, padding, out_coords);
 }
 
 t8_linearidx_t

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.hxx
@@ -518,12 +518,17 @@ struct t8_default_scheme_prism_c: public t8_default_scheme_common_c
    * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
    *                          in the reference space of the element.
    * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [in] padding      Only used if \a num_coords > 1.
+   *                          The amount of padding in \a ref_coords between array elements:
+   *                          For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+   *                          For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+   *                          For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
    * \param [out] out_coords  The coordinates of the points in the
    *                          reference space of the tree.
    */
   virtual void
   t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords, const size_t num_coords,
-                               double *out_coords) const;
+                               const size_t padding, double *out_coords) const;
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -561,14 +561,14 @@ t8_dprism_vertex_ref_coords (const t8_dprism_t *elem, const int vertex, double c
 
 void
 t8_dprism_compute_reference_coords (const t8_dprism_t *elem, const double *ref_coords, const size_t num_coords,
-                                    double *out_coords)
+                                    const size_t padding, double *out_coords)
 {
   T8_ASSERT (t8_dprism_is_valid (elem));
   T8_ASSERT (elem->line.level == elem->tri.level);
-  /*Compute x and y coordinate */
-  t8_dtri_compute_reference_coords (&elem->tri, ref_coords, num_coords, 1, out_coords);
-  /*Compute z coordinate */
-  t8_dline_compute_reference_coords (&elem->line, ref_coords + 2, num_coords, 2, out_coords + 2);
+  /*Compute x and y coordinate, has to skip 1 z coordinate */
+  t8_dtri_compute_reference_coords (&elem->tri, ref_coords, num_coords, padding, 1, out_coords);
+  /*Compute z coordinate, has to skip 2 coords (x and y). Also has to shift to leave out first x and y. */
+  t8_dline_compute_reference_coords (&elem->line, ref_coords + 2, num_coords, padding, 2, out_coords + 2);
 }
 
 t8_linearidx_t

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
@@ -301,13 +301,18 @@ t8_dprism_vertex_ref_coords (const t8_dprism_t *elem, int vertex, double coords[
  * \param [in]  ref_coords The reference coordinates in the prism
  *                         (\a num_coords times \f$ [0,1]^3 \f$)
  * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [in]  padding    Only used if \a num_coords > 1.
+ *                         The amount of padding in \a ref_coords between array elements:
+ *                         For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+ *                         For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+ *                         For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
  * \param [out] out_coords An array of \a num_coords x 3 x double that
  * 		                     will be filled with the reference coordinates
  *                         of the points on the prism.
  */
 void
 t8_dprism_compute_reference_coords (const t8_dprism_t *elem, const double *ref_coords, const size_t num_coords,
-                                    double *out_coords);
+                                    const size_t padding, double *out_coords);
 
 /** Computes the linear position of a prism in an uniform grid.
  * \param [in] p  Prism whose id will be computed.

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
@@ -380,10 +380,11 @@ t8_default_scheme_pyramid_c::t8_element_vertex_reference_coords (const t8_elemen
 
 void
 t8_default_scheme_pyramid_c::t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords,
-                                                          const size_t num_coords, double *out_coords) const
+                                                          const size_t num_coords, const size_t padding,
+                                                          double *out_coords) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_dpyramid_compute_reference_coords ((const t8_dpyramid_t *) elem, ref_coords, num_coords, out_coords);
+  t8_dpyramid_compute_reference_coords ((const t8_dpyramid_t *) elem, ref_coords, num_coords, padding, out_coords);
 }
 
 int

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.hxx
@@ -510,12 +510,17 @@ struct t8_default_scheme_pyramid_c: public t8_default_scheme_common_c
    * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
    *                          in the reference space of the element.
    * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [in] padding      Only used if \a num_coords > 1.
+   *                          The amount of padding in \a ref_coords between array elements:
+   *                          For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+   *                          For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+   *                          For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
    * \param [out] out_coords  The coordinates of the points in the
    *                          reference space of the tree.
    */
   virtual void
   t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords, const size_t num_coords,
-                               double *out_coords) const;
+                               const size_t padding, double *out_coords) const;
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -1559,7 +1559,7 @@ t8_dpyramid_vertex_reference_coords (const t8_dpyramid_t *elem, const int vertex
 
 void
 t8_dpyramid_compute_reference_coords (const t8_dpyramid_t *elem, const double *ref_coords, const size_t num_coords,
-                                      double *out_coords)
+                                      const size_t padding, double *out_coords)
 {
   T8_ASSERT (ref_coords != NULL);
   T8_ASSERT (t8_dpyramid_is_valid (elem));
@@ -1567,33 +1567,35 @@ t8_dpyramid_compute_reference_coords (const t8_dpyramid_t *elem, const double *r
     const t8_dpyramid_coord_t length = T8_DPYRAMID_LEN (elem->pyramid.level);
     size_t coord;
     for (coord = 0; coord < num_coords; ++coord) {
-      const size_t offset = coord * 3;
-      out_coords[offset + 0] = elem->pyramid.x;
-      out_coords[offset + 1] = elem->pyramid.y;
-      out_coords[offset + 2] = elem->pyramid.z;
+      const size_t offset_ref = coord * (t8_eclass_to_dimension[T8_ECLASS_PYRAMID] + padding);
+      const size_t offset_out = coord * t8_eclass_to_dimension[T8_ECLASS_PYRAMID];
+      out_coords[offset_out + 0] = elem->pyramid.x;
+      out_coords[offset_out + 1] = elem->pyramid.y;
+      out_coords[offset_out + 2] = elem->pyramid.z;
 
-      out_coords[offset + 0] += ref_coords[offset + 0] * length;
-      out_coords[offset + 1] += ref_coords[offset + 1] * length;
-      out_coords[offset + 2] += ref_coords[offset + 2] * length;
+      out_coords[offset_out + 0] += ref_coords[offset_ref + 0] * length;
+      out_coords[offset_out + 1] += ref_coords[offset_ref + 1] * length;
+      out_coords[offset_out + 2] += ref_coords[offset_ref + 2] * length;
     }
     if (elem->pyramid.type == T8_DPYRAMID_SECOND_TYPE) {
       for (coord = 0; coord < num_coords; ++coord) {
-        const size_t offset = coord * 3;
-        out_coords[offset + 0] -= ref_coords[offset + 2] * length;
-        out_coords[offset + 1] -= ref_coords[offset + 2] * length;
-        out_coords[offset + 2] += (1 - 2 * ref_coords[offset + 2]) * length;
+        const size_t offset_ref = coord * (t8_eclass_to_dimension[T8_ECLASS_PYRAMID] + padding);
+        const size_t offset_out = coord * t8_eclass_to_dimension[T8_ECLASS_PYRAMID];
+        out_coords[offset_out + 0] -= ref_coords[offset_ref + 2] * length;
+        out_coords[offset_out + 1] -= ref_coords[offset_ref + 2] * length;
+        out_coords[offset_out + 2] += (1 - 2 * ref_coords[offset_ref + 2]) * length;
       }
     }
     for (coord = 0; coord < num_coords; ++coord) {
-      const size_t offset = coord * 3;
+      const size_t offset_out = coord * t8_eclass_to_dimension[T8_ECLASS_PYRAMID];
       /* Scale the coordinates onto the reference cube */
-      out_coords[offset + 0] /= (double) T8_DPYRAMID_ROOT_LEN;
-      out_coords[offset + 1] /= (double) T8_DPYRAMID_ROOT_LEN;
-      out_coords[offset + 2] /= (double) T8_DPYRAMID_ROOT_LEN;
+      out_coords[offset_out + 0] /= (double) T8_DPYRAMID_ROOT_LEN;
+      out_coords[offset_out + 1] /= (double) T8_DPYRAMID_ROOT_LEN;
+      out_coords[offset_out + 2] /= (double) T8_DPYRAMID_ROOT_LEN;
     }
   }
   else {
-    t8_dtet_compute_reference_coords (&(elem->pyramid), ref_coords, num_coords, out_coords);
+    t8_dtet_compute_reference_coords (&(elem->pyramid), ref_coords, num_coords, padding, out_coords);
   }
 }
 

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.h
@@ -359,13 +359,18 @@ t8_dpyramid_vertex_reference_coords (const t8_dpyramid_t *elem, const int vertex
  * \param [in]  ref_coords The reference coordinates in the pyramid
  *                         (\a num_coords times \f$ [0,1]^3 \f$)
  * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [in]  padding    Only used if \a num_coords > 1.
+ *                         The amount of padding in \a ref_coords between array elements:
+ *                         For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+ *                         For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+ *                         For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
  * \param [out] out_coords An array of \a num_coords x 3 x double that
  * 		                     will be filled with the reference coordinates
  *                         of the points on the pyramid.
  */
 void
 t8_dpyramid_compute_reference_coords (const t8_dpyramid_t *elem, const double *ref_coords, const size_t num_coords,
-                                      double *out_coords);
+                                      const size_t padding, double *out_coords);
 
 /**
  * Compute the nearest common ancestor of two elements

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
@@ -697,10 +697,11 @@ t8_default_scheme_quad_c::t8_element_vertex_reference_coords (const t8_element_t
 
 void
 t8_default_scheme_quad_c::t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords,
-                                                       const size_t num_coords, double *out_coords) const
+                                                       const size_t num_coords, const size_t padding,
+                                                       double *out_coords) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_dquad_compute_reference_coords ((const t8_dquad_t *) elem, ref_coords, num_coords, out_coords);
+  t8_dquad_compute_reference_coords ((const t8_dquad_t *) elem, ref_coords, num_coords, padding, out_coords);
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
@@ -573,12 +573,17 @@ struct t8_default_scheme_quad_c: public t8_default_scheme_common_c
    * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
    *                          in the reference space of the element.
    * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [in] padding      Only used if \a num_coords > 1.
+   *                          The amount of padding in \a ref_coords between array elements:
+   *                          For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+   *                          For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+   *                          For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
    * \param [out] out_coords  The coordinates of the points in the
    *                          reference space of the tree.
    */
   virtual void
   t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords, const size_t num_coords,
-                               double *out_coords) const;
+                               const size_t padding, double *out_coords) const;
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c
@@ -25,19 +25,19 @@
 
 void
 t8_dquad_compute_reference_coords (const t8_dquad_t *elem, const double *ref_coords, const size_t num_coords,
-                                   double *out_coords)
+                                   const size_t padding, double *out_coords)
 {
   const p4est_quadrant_t *q1 = (const p4est_quadrant_t *) elem;
 
   const p4est_qcoord_t h = P4EST_QUADRANT_LEN (q1->level);
 
   for (size_t icoord = 0; icoord < num_coords; ++icoord) {
-    const size_t offset_2d = icoord * 2;
-    const size_t offset_3d = icoord * 3;
-    out_coords[offset_2d + 0] = q1->x + ref_coords[offset_3d + 0] * h;
-    out_coords[offset_2d + 1] = q1->y + ref_coords[offset_3d + 1] * h;
+    const size_t offset_ref = icoord * (t8_eclass_to_dimension[T8_ECLASS_QUAD] + padding);
+    const size_t offset_out = icoord * t8_eclass_to_dimension[T8_ECLASS_QUAD];
+    out_coords[offset_out + 0] = q1->x + ref_coords[offset_ref + 0] * h;
+    out_coords[offset_out + 1] = q1->y + ref_coords[offset_ref + 1] * h;
 
-    out_coords[offset_2d + 0] /= (double) P4EST_ROOT_LEN;
-    out_coords[offset_2d + 1] /= (double) P4EST_ROOT_LEN;
+    out_coords[offset_out + 0] /= (double) P4EST_ROOT_LEN;
+    out_coords[offset_out + 1] /= (double) P4EST_ROOT_LEN;
   }
 }

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
@@ -38,13 +38,18 @@ T8_EXTERN_C_BEGIN ();
  * \param [in]  ref_coords The reference coordinates in the quad
  *                         (\a num_coords times \f$ [0,1]^2 \f$)
  * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [in]  padding    Only used if \a num_coords > 1.
+ *                         The amount of padding in \a ref_coords between array elements:
+ *                         For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+ *                         For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+ *                         For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
  * \param [out] out_coords An array of \a num_coords x 2 x double that
  * 		                     will be filled with the reference coordinates
  *                         of the points on the quad.
  */
 void
 t8_dquad_compute_reference_coords (const t8_dquad_t *elem, const double *ref_coords, const size_t num_coords,
-                                   double *out_coords);
+                                   const size_t padding, double *out_coords);
 
 T8_EXTERN_C_END ();
 

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.cxx
@@ -467,10 +467,11 @@ t8_default_scheme_tet_c::t8_element_vertex_reference_coords (const t8_element_t 
 
 void
 t8_default_scheme_tet_c::t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords,
-                                                      const size_t num_coords, double *out_coords) const
+                                                      const size_t num_coords, const size_t padding,
+                                                      double *out_coords) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_dtet_compute_reference_coords ((const t8_dtet_t *) elem, ref_coords, num_coords, out_coords);
+  t8_dtet_compute_reference_coords ((const t8_dtet_t *) elem, ref_coords, num_coords, padding, out_coords);
 }
 
 /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.hxx
@@ -481,12 +481,17 @@ struct t8_default_scheme_tet_c: public t8_default_scheme_common_c
    * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
    *                          in the reference space of the element.
    * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [in] padding      Only used if \a num_coords > 1.
+   *                          The amount of padding in \a ref_coords between array elements:
+   *                          For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+   *                          For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+   *                          For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
    * \param [out] out_coords  The coordinates of the points in the
    *                          reference space of the tree.
    */
   virtual void
   t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords, const size_t num_coords,
-                               double *out_coords) const;
+                               const size_t padding, double *out_coords) const;
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
@@ -58,13 +58,18 @@ t8_dtet_compute_vertex_ref_coords (const t8_dtet_t *elem, int vertex, double coo
  * \param [in]  ref_coords The reference coordinates in the tet
  *                         (\a num_coords times \f$ [0,1]^3 \f$)
  * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [in]  padding    Only used if \a num_coords > 1.
+ *                         The amount of padding in \a ref_coords between array elements:
+ *                         For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+ *                         For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+ *                         For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
  * \param [out] out_coords An array of \a num_coords x 3 x double that
  * 		                     will be filled with the reference coordinates
  *                         of the points on the tet.
  */
 void
 t8_dtet_compute_reference_coords (const t8_dtet_t *elem, const double *ref_coords, const size_t num_coords,
-                                  double *out_coords);
+                                  const size_t padding, double *out_coords);
 
 /** Compute the coordinates of the four vertices of a tetrahedron.
  * \param [in] elem         Input tetrahedron.

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.cxx
@@ -484,10 +484,11 @@ t8_default_scheme_tri_c::t8_element_vertex_reference_coords (const t8_element_t 
 
 void
 t8_default_scheme_tri_c::t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords,
-                                                      const size_t num_coords, double *out_coords) const
+                                                      const size_t num_coords, const size_t padding,
+                                                      double *out_coords) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_dtri_compute_reference_coords ((const t8_dtri_t *) elem, ref_coords, num_coords, 0, out_coords);
+  t8_dtri_compute_reference_coords ((const t8_dtri_t *) elem, ref_coords, num_coords, padding, 0, out_coords);
 }
 
 int

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.hxx
@@ -475,12 +475,17 @@ struct t8_default_scheme_tri_c: public t8_default_scheme_common_c
    * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
    *                          in the reference space of the element.
    * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [in] padding      Only used if \a num_coords > 1.
+   *                          The amount of padding in \a ref_coords between array elements:
+   *                          For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+   *                          For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+   *                          For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
    * \param [out] out_coords  The coordinates of the points in the
    *                          reference space of the tree.
    */
   virtual void
   t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords, const size_t num_coords,
-                               double *out_coords) const;
+                               const size_t padding, double *out_coords) const;
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
@@ -97,6 +97,11 @@ t8_dtri_compute_vertex_ref_coords (const t8_dtri_t *elem, const int vertex, doub
  * \param [in]  ref_coords The reference coordinates in the triangle
  *                         (\a num_coords times \f$ [0,1]^2 \f$)
  * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [in]  padding    Only used if \a num_coords > 1.
+ *                         The amount of padding in \a ref_coords between array elements:
+ *                         For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+ *                         For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+ *                         For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
  * \param [in]  skip_coords Only used for batch computation of prisms.
  *                          In all other cases 0.
  *                          Skip coordinates in the \a ref_coords and
@@ -107,7 +112,7 @@ t8_dtri_compute_vertex_ref_coords (const t8_dtri_t *elem, const int vertex, doub
  */
 void
 t8_dtri_compute_reference_coords (const t8_dtri_t *elem, const double *ref_coords, const size_t num_coords,
-                                  const size_t skip_coords, double *out_coords);
+                                  const size_t padding, const size_t skip_coords, double *out_coords);
 
 /** Compute the coordinates of the four vertices of a triangle.
  * \param [in] elem         Input triangle.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
@@ -260,10 +260,11 @@ t8_default_scheme_vertex_c::t8_element_vertex_reference_coords (const t8_element
 
 void
 t8_default_scheme_vertex_c::t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords,
-                                                         const size_t num_coords, double *out_coords) const
+                                                         const size_t num_coords, const size_t padding,
+                                                         double *out_coords) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_dvertex_compute_reference_coords ((const t8_dvertex_t *) elem, ref_coords, num_coords, out_coords);
+  t8_dvertex_compute_reference_coords ((const t8_dvertex_t *) elem, ref_coords, num_coords, padding, out_coords);
 }
 
 #ifdef T8_ENABLE_DEBUG

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.hxx
@@ -579,12 +579,17 @@ struct t8_default_scheme_vertex_c: public t8_default_scheme_common_c
    * \param [in] coords_input The coordinates \f$ [0,1]^\mathrm{dim} \f$ of the point
    *                          in the reference space of the element.
    * \param [in] num_coords   Number of \f$ dim\f$-sized coordinates to evaluate.
+   * \param [in] padding      Only used if \a num_coords > 1.
+   *                          The amount of padding in \a ref_coords between array elements:
+   *                          For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+   *                          For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+   *                          For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
    * \param [out] out_coords  The coordinates of the points in the
    *                          reference space of the tree.
    */
   virtual void
   t8_element_reference_coords (const t8_element_t *elem, const double *ref_coords, const size_t num_coords,
-                               double *out_coords) const;
+                               const size_t padding, double *out_coords) const;
 
   /** Returns true, if there is one element in the tree, that does not refine into 2^dim children.
    * Returns false otherwise.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.c
@@ -176,12 +176,13 @@ t8_dvertex_vertex_ref_coords (const t8_dvertex_t *elem, const int vertex, double
 
 void
 t8_dvertex_compute_reference_coords (const t8_dvertex_t *elem, const double *ref_coords, const size_t num_coords,
-                                     double *out_coords)
+                                     const size_t padding, double *out_coords)
 {
   T8_ASSERT (fabs (ref_coords[0]) <= T8_PRECISION_EPS);
   T8_ASSERT (t8_dvertex_is_valid (elem));
   for (size_t coord = 0; coord < num_coords; ++coord) {
-    out_coords[coord] = 0;
+    const size_t offset_out = coord * (1 + padding);
+    out_coords[offset_out] = 0;
   }
 }
 

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.h
@@ -210,13 +210,18 @@ t8_dvertex_vertex_ref_coords (const t8_dvertex_t *elem, int vertex, double coord
  * \param [in]  ref_coords The reference coordinates in the vertex
  *                         (\a num_coords times \f$ [0,1]^1 \f$)
  * \param [in]  num_coords Number of coordinates to evaluate
+ * \param [in]  padding    Only used if \a num_coords > 1.
+ *                         The amount of padding in \a ref_coords between array elements:
+ *                         For elem dim 2 and input {x1, y1, x2, y2, ...} padding is 0.
+ *                         For elem dim 2 and input {x1, y1, z1, x2, y2, z2, ...} padding is 1.
+ *                         For elem dim 3 and input {x1, y1, z1, x2, y2, z2, ...} padding is 0.
  * \param [out] out_coords An array of \a num_coords x 1 x double that
  * 		                     will be filled with the reference coordinates
  *                         of the points on the vertex (will be set to 0).
  */
 void
 t8_dvertex_compute_reference_coords (const t8_dvertex_t *elem, const double *ref_coords, const size_t num_coords,
-                                     double *out_coords);
+                                     const size_t padding, double *out_coords);
 
 /** Computes the linear position of a vertex in an uniform grid.
  * \param [in] vertex  vertex whose id will be computed.

--- a/src/t8_vtk/t8_vtk_writer_helper.hxx
+++ b/src/t8_vtk/t8_vtk_writer_helper.hxx
@@ -102,15 +102,18 @@ t8_get_number_of_vtk_nodes (const t8_element_shape_t eclass, const int curved_fl
  * \param[in, out] out_coords An array to fill with the coordinates of the vertex.
  */
 static void
-t8_forest_vtk_get_element_nodes (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element, const int vertex,
+t8_forest_vtk_get_element_nodes (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
                                  const int curved_flag, double *out_coords)
 {
   const t8_eclass_t tree_class = t8_forest_get_tree_class (forest, ltreeid);
   const t8_eclass_scheme_c *scheme = t8_forest_get_eclass_scheme (forest, tree_class);
   const t8_element_shape_t element_shape = scheme->t8_element_shape (element);
-  const double *ref_coords = t8_forest_vtk_point_to_element_ref_coords[element_shape][vertex];
+  const int elem_dim = t8_eclass_to_dimension[element_shape];
+  /* Even though a vertex has dim 0 it still has one coordinate. */
+  const int padding = elem_dim != 0 ? 3 - elem_dim : 2;
+  const double *ref_coords = t8_forest_vtk_point_to_element_ref_coords[element_shape][0];
   const int num_node = t8_get_number_of_vtk_nodes (element_shape, curved_flag);
-  t8_forest_element_coordinate_from_ref_coords (forest, ltreeid, element, ref_coords, num_node, out_coords);
+  t8_forest_element_coordinate_from_ref_coords (forest, ltreeid, element, ref_coords, num_node, padding, out_coords);
 }
 
 /**
@@ -356,7 +359,7 @@ grid_element_to_coords<t8_forest_t> (const t8_forest_t grid, const t8_locidx_t i
                                      const int curved_flag, double *coordinates, const int num_node,
                                      const t8_element_shape_t shape)
 {
-  t8_forest_vtk_get_element_nodes (grid, itree, element, 0, curved_flag, coordinates);
+  t8_forest_vtk_get_element_nodes (grid, itree, element, curved_flag, coordinates);
 }
 
 template <>

--- a/src/t8_vtk/t8_vtk_writer_helper.hxx
+++ b/src/t8_vtk/t8_vtk_writer_helper.hxx
@@ -110,7 +110,7 @@ t8_forest_vtk_get_element_nodes (t8_forest_t forest, t8_locidx_t ltreeid, const 
   const t8_element_shape_t element_shape = scheme->t8_element_shape (element);
   const double *ref_coords = t8_forest_vtk_point_to_element_ref_coords[element_shape][vertex];
   const int num_node = t8_get_number_of_vtk_nodes (element_shape, curved_flag);
-  t8_forest_element_from_ref_coords (forest, ltreeid, element, ref_coords, num_node, out_coords);
+  t8_forest_element_coordinate_from_ref_coords (forest, ltreeid, element, ref_coords, num_node, out_coords);
 }
 
 /**

--- a/test/t8_forest/t8_gtest_ghost_delete.cxx
+++ b/test/t8_forest/t8_gtest_ghost_delete.cxx
@@ -45,7 +45,7 @@ test_adapt_holes (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which
                   t8_eclass_scheme_c *ts, const int is_family, const int num_elements, t8_element_t *elements[])
 {
   double coordinates[3];
-  t8_forest_element_coordinate (forest_from, which_tree, elements[0], 0, coordinates);
+  t8_forest_element_coordinate_from_corner_number (forest_from, which_tree, elements[0], 0, coordinates);
   if (fabs (coordinates[1]) < T8_PRECISION_EPS)
     return 1;  // refine the lowest row
   if (fabs (coordinates[1] - 0.25) < T8_PRECISION_EPS)

--- a/test/t8_geometry/t8_gtest_point_inside.cxx
+++ b/test/t8_geometry/t8_gtest_point_inside.cxx
@@ -214,7 +214,7 @@ TEST_P (geometry_point_inside, test_point_inside)
       const int num_corners = eclass_scheme->t8_element_num_corners (element);
       /* For each corner get its coordinates */
       for (int icorner = 0; icorner < num_corners; ++icorner) {
-        t8_forest_element_coordinate (forest, itree, element, icorner, element_vertices[icorner]);
+        t8_forest_element_coordinate_from_corner_number (forest, itree, element, icorner, element_vertices[icorner]);
       }
 
       /* Allocate the barycentric coordinates */


### PR DESCRIPTION
**_Describe your changes here:_**
This PR introduces a padding to the reference coords. This way the element ref coords becomes consistend with the geometries and the element_from_ref_coord_function.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### Licence

- [ ] The author added a BSD statement to `doc/` (or already has one)
