### PR TITLE
Revert "Enable parallel tests in cmake ci"

### DIFF
--- a/.github/workflows/tests_cmake_sc_p4est.yml
+++ b/.github/workflows/tests_cmake_sc_p4est.yml
@@ -82,7 +82,7 @@ jobs:
         && echo P4EST_RELEASE="$P4EST_RELEASE" >> $GITHUB_ENV
     ## sc debug
     - name: sc debug check
-      run: cd $SC_DEBUG && ctest $MAKEFLAGS
+      run: cd $SC_DEBUG && ninja test $MAKEFLAGS
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4
@@ -91,7 +91,7 @@ jobs:
         path: $SC_DEBUG/Testing/Temporary/LastTest.log
       ## sc release
     - name: sc release check
-      run: cd $SC_RELEASE && ctest $MAKEFLAGS
+      run: cd $SC_RELEASE && ninja test $MAKEFLAGS
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4
@@ -103,7 +103,7 @@ jobs:
 #
       ## p4est debug
     - name: p4est debug check
-      run: cd $P4EST_DEBUG && ctest $MAKEFLAGS
+      run: cd $P4EST_DEBUG && ninja test $MAKEFLAGS
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4
@@ -112,7 +112,7 @@ jobs:
         path: $P4EST_DEBUG/Testing/Temporary/LastTest.log
       ## p4est release
     - name: p4est release check
-      run: cd $P4EST_RELEASE && ctest $MAKEFLAGS
+      run: cd $P4EST_RELEASE && ninja test $MAKEFLAGS
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tests_cmake_sc_p4est.yml
+++ b/.github/workflows/tests_cmake_sc_p4est.yml
@@ -82,7 +82,7 @@ jobs:
         && echo P4EST_RELEASE="$P4EST_RELEASE" >> $GITHUB_ENV
     ## sc debug
     - name: sc debug check
-      run: cd $SC_DEBUG && ninja test $MAKEFLAGS
+      run: cd $SC_DEBUG && ninja test
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4
@@ -91,7 +91,7 @@ jobs:
         path: $SC_DEBUG/Testing/Temporary/LastTest.log
       ## sc release
     - name: sc release check
-      run: cd $SC_RELEASE && ninja test $MAKEFLAGS
+      run: cd $SC_RELEASE && ninja test
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4
@@ -103,7 +103,7 @@ jobs:
 #
       ## p4est debug
     - name: p4est debug check
-      run: cd $P4EST_DEBUG && ninja test $MAKEFLAGS
+      run: cd $P4EST_DEBUG && ninja test
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4
@@ -112,7 +112,7 @@ jobs:
         path: $P4EST_DEBUG/Testing/Temporary/LastTest.log
       ## p4est release
     - name: p4est release check
-      run: cd $P4EST_RELEASE && ninja test $MAKEFLAGS
+      run: cd $P4EST_RELEASE && ninja test
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tests_cmake_t8code.yml
+++ b/.github/workflows/tests_cmake_t8code.yml
@@ -102,8 +102,8 @@ jobs:
       run: cd build && ninja $MAKEFLAGS
     - name: ninja install
       run: cd build && ninja install $MAKEFLAGS
-    - name: ctest
-      run: cd build && ctest $MAKEFLAGS
+    - name: ninja test
+      run: cd build && ninja test $MAKEFLAGS
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tests_cmake_t8code.yml
+++ b/.github/workflows/tests_cmake_t8code.yml
@@ -103,7 +103,7 @@ jobs:
     - name: ninja install
       run: cd build && ninja install $MAKEFLAGS
     - name: ninja test
-      run: cd build && ninja test $MAKEFLAGS
+      run: cd build && ninja test
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tests_cmake_t8code_linkage.yml
+++ b/.github/workflows/tests_cmake_t8code_linkage.yml
@@ -101,8 +101,8 @@ jobs:
       run: cd build_netcdf && ninja $MAKEFLAGS
     - name: ninja install
       run: cd build_netcdf && ninja install $MAKEFLAGS
-    - name: ctest
-      run: cd build_netcdf && ctest $MAKEFLAGS
+    - name: ninja test
+      run: cd build_netcdf && ninja test $MAKEFLAGS
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4
@@ -126,8 +126,8 @@ jobs:
       run: cd build_occ && ninja $MAKEFLAGS
     - name: ninja install
       run: cd build_occ && ninja install $MAKEFLAGS
-    - name: ctest
-      run: cd build_occ && ctest $MAKEFLAGS
+    - name: ninja test
+      run: cd build_occ && ninja test $MAKEFLAGS
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4
@@ -151,8 +151,8 @@ jobs:
       run: cd build_vtk && ninja $MAKEFLAGS
     - name: ninja install
       run: cd build_vtk && ninja install $MAKEFLAGS
-    - name: ctest
-      run: cd build_vtk && ctest $MAKEFLAGS
+    - name: ninja test
+      run: cd build_vtk && ninja test $MAKEFLAGS
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tests_cmake_t8code_linkage.yml
+++ b/.github/workflows/tests_cmake_t8code_linkage.yml
@@ -102,7 +102,7 @@ jobs:
     - name: ninja install
       run: cd build_netcdf && ninja install $MAKEFLAGS
     - name: ninja test
-      run: cd build_netcdf && ninja test $MAKEFLAGS
+      run: cd build_netcdf && ninja test
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4
@@ -127,7 +127,7 @@ jobs:
     - name: ninja install
       run: cd build_occ && ninja install $MAKEFLAGS
     - name: ninja test
-      run: cd build_occ && ninja test $MAKEFLAGS
+      run: cd build_occ && ninja test
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4
@@ -152,7 +152,7 @@ jobs:
     - name: ninja install
       run: cd build_vtk && ninja install $MAKEFLAGS
     - name: ninja test
-      run: cd build_vtk && ninja test $MAKEFLAGS
+      run: cd build_vtk && ninja test
     - name: OnFailUploadLog
       if: failure()
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Somehow this makes the tests slower.
Local testing resulted that parallel execution of tests is orders of magnitudes slower than serial test runs.

```
ctest
ctest -j
ninja test
ninja test -j
ninja test -j<N>
```
execute each test after the previous one and are significantly faster than `ctest -j<N>`. Removed the $MAKEFLAGS from the test so there is no confusion that this executes the tests in parallel

Reverts DLR-AMR/t8code#1226