### PR TITLE
Fix const expr compilation errors

### DIFF
--- a/src/t8_cmesh/t8_cmesh_examples.cxx
+++ b/src/t8_cmesh/t8_cmesh_examples.cxx
@@ -3128,7 +3128,7 @@ t8_cmesh_new_triangulated_spherical_surface_cube (const double radius, sc_MPI_Co
   const int ncube_rot = 6;  // Six rotations of the four triangles to the six cube's faces.
 
   const int ntrees = nface_rot * ncube_rot;  // Number of cmesh elements resp. trees.
-  const int nverts = 3;                          // Number of cmesh element (triangle) vertices.
+  const int nverts = 3;                      // Number of cmesh element (triangle) vertices.
 
   // Arrays for the face connectivity computations via vertices.
   double all_verts[ntrees * T8_ECLASS_MAX_CORNERS * T8_ECLASS_MAX_DIM];

--- a/src/t8_cmesh/t8_cmesh_examples.cxx
+++ b/src/t8_cmesh/t8_cmesh_examples.cxx
@@ -20,6 +20,7 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
+#include <cmath>
 #include <t8_cmesh.hxx>
 #include <t8_cmesh/t8_cmesh_examples.h>
 #include <t8_cmesh/t8_cmesh_helpers.h>

--- a/src/t8_cmesh/t8_cmesh_examples.cxx
+++ b/src/t8_cmesh/t8_cmesh_examples.cxx
@@ -3126,7 +3126,7 @@ t8_cmesh_new_triangulated_spherical_surface_cube (const double radius, sc_MPI_Co
   const int nface_rot = 4;  // Four triangles create a cube's face.
   const int ncube_rot = 6;  // Six rotations of the four triangles to the six cube's faces.
 
-  constexpr int ntrees = nface_rot * ncube_rot;  // Number of cmesh elements resp. trees.
+  const int ntrees = nface_rot * ncube_rot;  // Number of cmesh elements resp. trees.
   const int nverts = 3;                          // Number of cmesh element (triangle) vertices.
 
   // Arrays for the face connectivity computations via vertices.
@@ -3139,7 +3139,7 @@ t8_cmesh_new_triangulated_spherical_surface_cube (const double radius, sc_MPI_Co
     all_eclasses[itree] = T8_ECLASS_TRIANGLE;
   }
 
-  constexpr double _CBRT = std::cbrt (1.0);
+  const double _CBRT = std::cbrt (1.0);
   const double r = radius / _CBRT;
 
   const double vertices[3][3] = { { -r, -r, r }, { r, -r, r }, { 0.0, 0.0, r } };
@@ -3220,7 +3220,7 @@ t8_cmesh_new_quadrangulated_spherical_surface (const double radius, sc_MPI_Comm 
     all_eclasses[itree] = T8_ECLASS_QUAD;
   }
 
-  constexpr double _CBRT = std::cbrt (1.0);
+  const double _CBRT = std::cbrt (1.0);
   const double r = radius / _CBRT;
 
   const double vertices[4][3] = { { -r, -r, r }, { r, -r, r }, { -r, r, r }, { r, r, r } };
@@ -3514,7 +3514,7 @@ t8_cmesh_new_cubed_sphere (const double radius, sc_MPI_Comm comm)
   const double inner_radius = 0.6 * radius;
   const double outer_radius = radius;
 
-  constexpr double _CBRT = std::cbrt(1.0);
+  const double _CBRT = std::cbrt(1.0);
 
   const double inner_x = inner_radius / _CBRT;
   const double inner_y = inner_x;

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.cxx
@@ -20,6 +20,7 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
+#include <cmath>
 #include <t8_geometry/t8_geometry_implementations/t8_geometry_examples.hxx>
 #include <t8_geometry/t8_geometry_helpers.h>
 #include <t8_vec.h>

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.cxx
@@ -211,7 +211,7 @@ t8_geometry_cubed_spherical_shell::t8_geom_evaluate (t8_cmesh_t cmesh, t8_gloidx
   const double distance = std::abs (t8_vec_dot (active_tree_vertices, normal));
 
   // Compute actual radius of the sphere.
-  constexpr double CBRT = std::cbrt (1.0);
+  const double CBRT = std::cbrt (1.0);
   const double inner_radius = distance * CBRT;
   const double shell_thickness
     = std::abs (t8_vec_dot (active_tree_vertices + t8_eclass_num_vertices[active_tree_class] * 3 / 2, normal)) * CBRT

--- a/src/t8_vtk/t8_vtk_write_ASCII.cxx
+++ b/src/t8_vtk/t8_vtk_write_ASCII.cxx
@@ -1114,7 +1114,7 @@ t8_cmesh_vtk_write_file_ext (const t8_cmesh_t cmesh, const char *fileprefix, con
       /* TODO: We switched to 32 Bit because Paraview could not handle 64 well enough.
        */
       T8_ASSERT (tree->treeid + cmesh->first_tree == (t8_gloidx_t) ((long) tree->treeid + cmesh->first_tree));
-      fprintf (vtufile, " %ld", (long) tree->treeid + cmesh->first_tree);
+      fprintf (vtufile, " %lld", (long) tree->treeid + cmesh->first_tree);
       if (!(sk % 8))
         fprintf (vtufile, "\n         ");
     }

--- a/src/t8_vtk/t8_vtk_write_ASCII.cxx
+++ b/src/t8_vtk/t8_vtk_write_ASCII.cxx
@@ -1114,7 +1114,7 @@ t8_cmesh_vtk_write_file_ext (const t8_cmesh_t cmesh, const char *fileprefix, con
       /* TODO: We switched to 32 Bit because Paraview could not handle 64 well enough.
        */
       T8_ASSERT (tree->treeid + cmesh->first_tree == (t8_gloidx_t) ((long) tree->treeid + cmesh->first_tree));
-      fprintf (vtufile, " %lld", (long) tree->treeid + cmesh->first_tree);
+      fprintf (vtufile, " %ld", (long) tree->treeid + cmesh->first_tree);
       if (!(sk % 8))
         fprintf (vtufile, "\n         ");
     }


### PR DESCRIPTION
**_Describe your changes here:_**

This is a litte PR to fix some compiler errors regarding the misuse of `constexpr` ~and also a small format string error/warning~.

Closes https://github.com/DLR-AMR/t8code/issues/1240.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)
