### PR TITLE
Cleanup tutorial build cmesh

### DIFF
--- a/doc/author_albers.txt
+++ b/doc/author_albers.txt
@@ -1,0 +1,1 @@
+I place my contributions to t8code under the FreeBSD license. Ole Albers (ole.albers@arcor.de).

--- a/tutorials/general/t8_tutorial_build_cmesh.cxx
+++ b/tutorials/general/t8_tutorial_build_cmesh.cxx
@@ -457,8 +457,8 @@ int
 t8_tutorial_build_cmesh_main (int argc, char **argv)
 {
   /* The prefix for our output files. */
-  const char *prefix_2D = "t8_step8_user_defined_mesh_2D";
-  const char *prefix_3D = "t8_step8_user_defined_mesh_3D";
+  const char *prefix_2D = "t8_user_defined_mesh_2D";
+  const char *prefix_3D = "t8_user_defined_mesh_3D";
 
   /*
    * Initialization.


### PR DESCRIPTION
**_Describe your changes here:_**
The tutorial isn't included in the numbering, therefore the output-file should not be numbered as well. 
The prefix of the output was changed from "t8_step8_user_defined_mesh_..." to "t8_user_defined_mesh_...".


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [x] The author added a BSD statement to `doc/` (or already has one)
