### PR TITLE
create hex copy function

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
@@ -51,7 +51,7 @@ t8_default_scheme_hex_c::t8_element_copy (const t8_element_t *source, t8_element
 {
   T8_ASSERT (t8_element_is_valid (source));
   T8_ASSERT (t8_element_is_valid (dest));
-  *(p8est_quadrant_t *) dest = *(const p8est_quadrant_t *) source;
+  t8_dhex_copy ((const t8_dhex_t *) source, (t8_dhex_t *) dest);
 }
 
 int

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
@@ -47,3 +47,14 @@ t8_dhex_compute_reference_coords (const t8_dhex_t *elem, const double *ref_coord
     out_coords[offset + 2] /= (double) P8EST_ROOT_LEN;
   }
 }
+
+/*Copies a hexahedra from source to dest*/
+void
+t8_dhex_copy (const t8_dhex_t *source, t8_dhex_t *dest)
+{
+  T8_ASSERT (source != NULL && dest != NULL);
+  if (source == dest) {
+    return;
+  }
+  memcpy (dest, source, sizeof (t8_dhex_t));
+}

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
@@ -46,6 +46,13 @@ void
 t8_dhex_compute_reference_coords (const t8_dhex_t *elem, const double *ref_coords, const size_t num_coords,
                                   double *out_coords);
 
+/** Copy the data from source to dest
+ * \param[in] source    The source-hex
+ * \param[in,out] dest  The destination
+ */
+void
+t8_dhex_copy (const t8_dhex_t *source, t8_dhex_t *dest);
+
 T8_EXTERN_C_END ();
 
 #endif /* T8_DHEX_BITS_H */


### PR DESCRIPTION
**_Describe your changes here:_**
Replace p4est copy function for hexahedra by newly created t8_dhex_copy function. 


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)
