### PR TITLE
add placeholder for internal data handling

### DIFF
--- a/example/version/t8_version.cxx
+++ b/example/version/t8_version.cxx
@@ -66,7 +66,7 @@ main (int argc, char **argv)
   opt = sc_options_new (argv[0]);
   sc_options_add_switch (opt, 'h', "help", &helpme, "Display a short help message.");
   sc_options_add_switch (opt, 'v', "verbose", &verbose,
-                         "Print more information. In particual major, minor and patch version.");
+                         "Print more information. In particular major, minor and patch version.");
 
   int parsed = sc_options_parse (t8_get_package_id (), SC_LP_ERROR, opt, argc, argv);
 

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -1522,7 +1522,7 @@ die_ele:
 typedef struct
 {
   t8_locidx_t ltree_id; /* The local id of the tree this face belongs to */
-  int8_t face_number;   /* The number of that face whitin the tree */
+  int8_t face_number;   /* The number of that face within the tree */
   int num_vertices;     /* The number of vertices of this face. */
   long *vertices;       /* The indices of these vertices. */
 } t8_msh_file_face_t;

--- a/src/t8_data/t8_data_handler.hxx
+++ b/src/t8_data/t8_data_handler.hxx
@@ -248,6 +248,16 @@ class t8_data_handler: public t8_abstract_data_handler {
     return single_handler.type ();
   }
 
+  bool
+  create_handle_for_internal_data (auto &ihandler, type)
+  {
+    switch (type) {
+    // Placeholder for future internal data, which is handled here.
+    default:
+      return false;
+    }
+  }
+
  private:
   /**
   * \brief A shared pointer to a vector of data. 

--- a/src/t8_data/t8_data_handler.hxx
+++ b/src/t8_data/t8_data_handler.hxx
@@ -249,7 +249,7 @@ class t8_data_handler: public t8_abstract_data_handler {
   }
 
   bool
-  create_handle_for_internal_data (auto &ihandler, type)
+  create_handle_for_internal_data (t8_abstract_data_handler * const handler, const int type)
   {
     switch (type) {
     // Placeholder for future internal data, which is handled here.

--- a/src/t8_data/t8_data_handler.hxx
+++ b/src/t8_data/t8_data_handler.hxx
@@ -123,6 +123,10 @@ class t8_abstract_data_handler {
   type ()
     = 0;
 
+  virtual bool
+  create_handle_for_internal_data (t8_abstract_data_handler *const handler, const int type)
+    = 0;
+
   virtual ~t8_abstract_data_handler () {};
 };
 
@@ -249,7 +253,7 @@ class t8_data_handler: public t8_abstract_data_handler {
   }
 
   bool
-  create_handle_for_internal_data (t8_abstract_data_handler * const handler, const int type)
+  create_handle_for_internal_data (t8_abstract_data_handler *const handler, const int type) override
   {
     switch (type) {
     // Placeholder for future internal data, which is handled here.

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_examples.cxx
@@ -97,7 +97,7 @@ t8_geom_evaluate_sphere_tri_prism (const double *active_tree_vertices, const t8_
 {
   // All elements are aligned such that the reference z-direction follows the
   // outward radial direction of the sphere. Hence the inner radius is equal to
-  // the norm of the first positition vector of `active_tree_vertices`.
+  // the norm of the first position vector of `active_tree_vertices`.
   const double inner_radius = t8_vec_norm (active_tree_vertices);
 
   t8_geom_compute_linear_geometry (eclass, active_tree_vertices, ref_coords, num_coords, out_coords);

--- a/test/t8_data/t8_pseudo_trees.hxx
+++ b/test/t8_data/t8_pseudo_trees.hxx
@@ -125,6 +125,7 @@ class t8_single_data_handler<pseudo_tree> {
 
       if (!create_handle_for_internal_data (ihandler, type)) {
 
+/* TODO: This is currently only a placeholder for actual internal data types. */
         if (type == 0) {
           ihandler = std::make_shared<t8_data_handler<enlarged_data<int>>> ();
         }

--- a/test/t8_data/t8_pseudo_trees.hxx
+++ b/test/t8_data/t8_pseudo_trees.hxx
@@ -123,18 +123,21 @@ class t8_single_data_handler<pseudo_tree> {
       mpiret = sc_MPI_Unpack (buffer, num_bytes, &pos, &type, 1, sc_MPI_INT, comm);
       SC_CHECK_MPI (mpiret);
 
-      if (type == 0) {
-        ihandler = std::make_shared<t8_data_handler<enlarged_data<int>>> ();
-      }
-      else if (type == 1) {
-        ihandler = std::make_shared<t8_data_handler<enlarged_data<double>>> ();
-      }
-      else {
-        SC_ABORT_NOT_REACHED ();
-      }
+      if (!create_handle_for_internal_data (ihandler, type)) {
 
-      int outcount = 0;
-      ihandler->unpack_vector_prefix (buffer, num_bytes, pos, outcount, comm);
+        if (type == 0) {
+          ihandler = std::make_shared<t8_data_handler<enlarged_data<int>>> ();
+        }
+        else if (type == 1) {
+          ihandler = std::make_shared<t8_data_handler<enlarged_data<double>>> ();
+        }
+        else {
+          SC_ABORT_NOT_REACHED ();
+        }
+
+        int outcount = 0;
+        ihandler->unpack_vector_prefix (buffer, num_bytes, pos, outcount, comm);
+      }
     }
   }
 


### PR DESCRIPTION
**_Describe your changes here:_**
Internal data is processed in the background without the user noticing or being restricted.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)
