### PR TITLE
Add ad t8_element_is_ghost function

### DIFF
--- a/src/t8_forest/t8_forest.cxx
+++ b/src/t8_forest/t8_forest.cxx
@@ -2035,13 +2035,24 @@ t8_forest_tree_is_local (const t8_forest_t forest, const t8_locidx_t local_tree)
 int
 t8_forest_element_is_leaf (const t8_forest_t forest, const t8_element_t *element, const t8_locidx_t local_tree)
 {
+  bool check_ghost = false;
+  T8_ASSERT (t8_forest_tree_is_local (forest, local_tree));
+  return t8_forest_element_is_leaf_or_ghost (forest, element, local_tree, check_ghost);
+}
+
+int
+t8_forest_element_is_leaf_or_ghost (const t8_forest_t forest, const t8_element_t *element, const t8_locidx_t local_tree,
+                                    const int check_ghost)
+{
   T8_ASSERT (t8_forest_is_committed (forest));
   T8_ASSERT (t8_forest_tree_is_local (forest, local_tree));
 
   /* We get the array of the tree's elements and then search in the array of elements for our 
    * element candidate. */
   /* Get the array */
-  const t8_element_array_t *elements = t8_forest_get_tree_element_array (forest, local_tree);
+  const t8_element_array_t *elements = !check_ghost ? t8_forest_tree_get_leaves (forest, local_tree)
+                                                    : t8_forest_ghost_get_tree_elements (forest, local_tree);
+
   T8_ASSERT (elements != NULL);
 
   /* In order to find the element, we need to compute its linear id.

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -517,6 +517,25 @@ t8_forest_get_coarse_tree (t8_forest_t forest, t8_locidx_t ltreeid);
 int
 t8_forest_element_is_leaf (const t8_forest_t forest, const t8_element_t *element, const t8_locidx_t local_tree);
 
+/**
+ * Query whether a given element or a ghost is a leaf of a local or ghost tree in a forest.
+ * 
+ * \param [in]  forest    The forest.
+ * \param [in]  element   An element of a local tree in \a forest.
+ * \param [in]  local_tree A local tree id of \a forest or a ghost tree id
+ * \param [in]  check_ghost If true \a element is interpreted as a ghost element and
+ *                         \a local_tree as the id of a ghost tree (0 <= \a local_tree < num_ghost_trees).
+ *                         If false \a element is interpreted as an element and \a local_tree as
+ *                         the id of a local tree (0 <= \a local_tree < num_local_trees).
+ * \return True (non-zero) if and only if \a element is a leaf (or ghost) in \a local_tree of \a forest.
+ * \note \a forest must be committed before calling this function.
+ * \ref t8_forest_element_is_leaf
+ * \ref t8_forest_element_is_ghost
+ */
+int
+t8_forest_element_is_leaf_or_ghost (const t8_forest_t forest, const t8_element_t *element, const t8_locidx_t local_tree,
+                                    const int check_ghost);
+
 /** Compute the leaf face orientation at given face in a forest.
  * \param [in]    forest  The forest. Must have a valid ghost layer.
  * \param [in]    ltreeid A local tree id.

--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -263,6 +263,14 @@ t8_forest_ghost_num_trees (const t8_forest_t forest)
   return forest->ghosts->ghost_trees->elem_count;
 }
 
+static bool
+t8_forest_tree_is_ghost (const t8_forest_t forest, const t8_locidx_t lghost_tree)
+{
+  T8_ASSERT (t8_forest_is_committed (forest));
+
+  return 0 <= lghost_tree && lghost_tree < t8_forest_get_num_ghost_trees (forest);
+}
+
 /* Given an index into the ghost_trees array return the ghost tree */
 static t8_ghost_tree_t *
 t8_forest_ghost_get_tree (const t8_forest_t forest, const t8_locidx_t lghost_tree)
@@ -274,7 +282,7 @@ t8_forest_ghost_get_tree (const t8_forest_t forest, const t8_locidx_t lghost_tre
   ghost = forest->ghosts;
   T8_ASSERT (ghost != NULL);
   T8_ASSERT (ghost->ghost_trees != NULL);
-  T8_ASSERT (0 <= lghost_tree && lghost_tree < t8_forest_ghost_num_trees (forest));
+  T8_ASSERT (t8_forest_tree_is_ghost (forest, lghost_tree));
 
   ghost_tree = (t8_ghost_tree_t *) t8_sc_array_index_locidx (ghost->ghost_trees, lghost_tree);
   return ghost_tree;
@@ -363,6 +371,14 @@ t8_forest_ghost_get_element (t8_forest_t forest, t8_locidx_t lghost_tree, t8_loc
   T8_ASSERT (0 <= lelement && lelement < t8_forest_ghost_tree_num_elements (forest, lghost_tree));
   /* TODO: In future, make return type const (and offer additional mutable version) and call t8_element_array_index_locidx (the const version). */
   return t8_element_array_index_locidx_mutable (&ghost_tree->elements, lelement);
+}
+
+int
+t8_forest_element_is_ghost (const t8_forest_t forest, const t8_element_t *element, const t8_locidx_t lghost_tree)
+{
+  bool check_ghost = true;
+  T8_ASSERT (t8_forest_tree_is_ghost (forest, lghost_tree));
+  return t8_forest_element_is_leaf_or_ghost (forest, element, lghost_tree, check_ghost);
 }
 
 /* Initialize a t8_ghost_remote_tree_t */

--- a/src/t8_forest/t8_forest_ghost.h
+++ b/src/t8_forest/t8_forest_ghost.h
@@ -108,6 +108,20 @@ t8_forest_ghost_get_global_treeid (const t8_forest_t forest, const t8_locidx_t l
 t8_element_t *
 t8_forest_ghost_get_element (t8_forest_t forest, t8_locidx_t lghost_tree, t8_locidx_t lelement);
 
+
+/**
+ * Query whether a given element is a ghost of a certrain tree in a forest.
+ * 
+ * \param [in]  forest    The forest.
+ * \param [in]  element   An element of a ghost tree in \a forest.
+ * \param [in]  lghost_tree A local ghost tree id of \a forest. (0 <= \a lghost_tree < num_ghost_trees)
+ * \return True (non-zero) if and only if \a element is a ghost in \a lghost_tree of \a forest.
+ * \note \a forest must be committed before calling this function.
+ */
+int
+t8_forest_element_is_ghost (const t8_forest_t forest, const t8_element_t *element, const t8_locidx_t lghost_tree);
+
+
 /** Return the array of remote ranks.
  * \param [in] forest   A forest with constructed ghost layer.
  * \param [in,out] num_remotes On output the number of remote ranks is stored here.

--- a/src/t8_forest/t8_forest_ghost.h
+++ b/src/t8_forest/t8_forest_ghost.h
@@ -96,7 +96,7 @@ t8_forest_ghost_get_tree_class (const t8_forest_t forest, const t8_locidx_t lgho
 
 /** Given a local ghost tree compute the global tree id of it.
  * \param [in]  forest    The forest. Ghost layer must exist.
- * \param [in]  lghost_tree The ghost tree id of a ghost tree.
+ * \param [in]  lghost_tree The ghost tree id of a ghost tree. (0 <= \a lghost_tree < num_ghost_trees)
  * \return                The global id of the local ghost tree \a lghost_tree.
  * \a forest must be committed before calling this function.
  * \see https://github.com/DLR-AMR/t8code/wiki/Tree-indexing for more details about tree indexing.
@@ -107,7 +107,6 @@ t8_forest_ghost_get_global_treeid (const t8_forest_t forest, const t8_locidx_t l
 /* TODO: document */
 t8_element_t *
 t8_forest_ghost_get_element (t8_forest_t forest, t8_locidx_t lghost_tree, t8_locidx_t lelement);
-
 
 /**
  * Query whether a given element is a ghost of a certrain tree in a forest.
@@ -120,7 +119,6 @@ t8_forest_ghost_get_element (t8_forest_t forest, t8_locidx_t lghost_tree, t8_loc
  */
 int
 t8_forest_element_is_ghost (const t8_forest_t forest, const t8_element_t *element, const t8_locidx_t lghost_tree);
-
 
 /** Return the array of remote ranks.
  * \param [in] forest   A forest with constructed ghost layer.


### PR DESCRIPTION
**_Describe your changes here:_**

Extend the t8_element_is_leaf functionality with t8_element_is_ghost and t8_element_is_leaf_or_ghost.
Given a ghost tree and an element this function returns true if and only if the element is a ghost element of that ghost tree.

Extended the test cases as well. 


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [x] The author added a BSD statement to `doc/` (or already has one)
