### PR TITLE
more const for split_array functions

### DIFF
--- a/src/t8_data/t8_containers.cxx
+++ b/src/t8_data/t8_containers.cxx
@@ -114,12 +114,12 @@ t8_element_array_init_size (t8_element_array_t *element_array, t8_eclass_scheme_
 }
 
 void
-t8_element_array_init_view (t8_element_array_t *view, t8_element_array_t *array, size_t offset, size_t length)
+t8_element_array_init_view (t8_element_array_t *view, const t8_element_array_t *array, size_t offset, size_t length)
 {
   T8_ASSERT (t8_element_array_is_valid (array));
 
   /* Initialize the element array */
-  sc_array_init_view (&view->array, &array->array, offset, length);
+  sc_array_init_view (&view->array, &((t8_element_array_t *) array)->array, offset, length);
   /* Set the scheme */
   view->scheme = array->scheme;
   T8_ASSERT (t8_element_array_is_valid (view));

--- a/src/t8_data/t8_containers.h
+++ b/src/t8_data/t8_containers.h
@@ -91,7 +91,7 @@ t8_element_array_init_size (t8_element_array_t *element_array, t8_eclass_scheme_
  *                       It is not necessary to call sc_array_reset later.
  */
 void
-t8_element_array_init_view (t8_element_array_t *view, t8_element_array_t *array, size_t offset, size_t length);
+t8_element_array_init_view (t8_element_array_t *view, const t8_element_array_t *array, size_t offset, size_t length);
 
 /** Initializes an already allocated (or static) view from given plain C data
  * (array of t8_element_t).

--- a/src/t8_forest/t8_forest_iterate.cxx
+++ b/src/t8_forest/t8_forest_iterate.cxx
@@ -51,7 +51,7 @@ t8_forest_determine_child_type (sc_array_t *leaf_elements, size_t index, void *d
 }
 
 void
-t8_forest_split_array (const t8_element_t *element, t8_element_array_t *leaf_elements, size_t *offsets)
+t8_forest_split_array (const t8_element_t *element, const t8_element_array_t *leaf_elements, size_t *offsets)
 {
   sc_array_t offset_view;
   t8_forest_child_type_query_t query_data;
@@ -62,20 +62,20 @@ t8_forest_split_array (const t8_element_t *element, t8_element_array_t *leaf_ele
   query_data.level = ts->t8_element_level (element);
   query_data.ts = ts;
 
-  sc_array_t *element_array = t8_element_array_get_array_mutable (leaf_elements);
+  const sc_array_t *element_array = t8_element_array_get_array (leaf_elements);
   /* Split the elements array according to the elements' ancestor id at
    * the given level. In other words for each child C of element, find
    * the indices i, j such that all descendants of C are
    * elements[i], ..., elements[j-1]
    */
   sc_array_init_data (&offset_view, offsets, sizeof (size_t), query_data.num_children + 1);
-  sc_array_split (element_array, &offset_view, query_data.num_children, t8_forest_determine_child_type,
+  sc_array_split ((sc_array_t *) element_array, &offset_view, query_data.num_children, t8_forest_determine_child_type,
                   (void *) &query_data);
 }
 
 void
 t8_forest_iterate_faces (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element, int face,
-                         t8_element_array_t *leaf_elements, void *user_data, t8_locidx_t tree_lindex_of_first_leaf,
+                         const t8_element_array_t *leaf_elements, void *user_data, t8_locidx_t tree_lindex_of_first_leaf,
                          t8_forest_iterate_face_fn callback)
 {
   t8_eclass_scheme_c *ts;

--- a/src/t8_forest/t8_forest_iterate.h
+++ b/src/t8_forest/t8_forest_iterate.h
@@ -84,7 +84,7 @@ T8_EXTERN_C_BEGIN ();
 
 /* TODO: Document */
 void
-t8_forest_split_array (const t8_element_t *element, t8_element_array_t *leaf_elements, size_t *offsets);
+t8_forest_split_array (const t8_element_t *element, const t8_element_array_t *leaf_elements, size_t *offsets);
 
 /* TODO: comment */
 /* Iterate over all leaves of an element that touch a given face of the element */


### PR DESCRIPTION
**_Describe your changes here:_**

The array parameter of the split array functions is now constant since it is not modified.
Unfortunately, we still have to cast away constness when passing to sc internal functions.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [x] The author added a BSD statement to `doc/` (or already has one)
