### PR TITLE
add assertion with error message

### DIFF
--- a/src/t8.h
+++ b/src/t8.h
@@ -73,6 +73,25 @@ T8_EXTERN_C_BEGIN ();
 #define T8_ASSERT(c) SC_NOOP ()
 #endif
 
+/** Extended assertion with detailed error message (including the condition, file, function, 
+ * and line number) along with a custom user-specified message. Only active in debug-mode.
+ * \param cond     The condition to check.
+ * \param msg      A custom message to display if the assertion fails.
+ * \param ...      Optional additional arguments to format the message.
+  */
+#ifdef T8_ENABLE_DEBUG
+#define T8_ASSERTF(cond, msg, ...) \
+  do { \
+    if (!(cond)) { \
+      fprintf (stderr, "Assertion failed: (%s), function %s, file %s, line %d.\nMessage: " msg "\n", #cond, \
+               __FUNCTION__, __FILE__, __LINE__, ##__VA_ARGS__); \
+      abort (); \
+    } \
+  } while (0)
+#else
+#define T8_ASSERTF(cond, msg, ...) SC_NOOP ()
+#endif
+
 /** Allocate a \a t-array with \a n elements. */
 #define T8_ALLOC(t, n) (t *) sc_malloc (t8_get_package_id (), (n) * sizeof (t))
 


### PR DESCRIPTION
**_Describe your changes here:_**
Add the macro `T8_ASSERTF` to allow outputting an error message alongside the assertion in debug mode.

Closes #1213 


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)
