### PR TITLE
fixed missing Assertion

### DIFF
--- a/test/t8_gtest_custom_assertion.hxx
+++ b/test/t8_gtest_custom_assertion.hxx
@@ -73,6 +73,9 @@ element_equality (const char *ts_expr, const char *tree_class_expr, const char *
 #define EXPECT_ELEM_EQ(scheme, tree_class, elem1, elem2) \
   EXPECT_PRED_FORMAT4 (element_equality, (scheme), (tree_class), (elem1), (elem2))
 
+#define ASSERT_ELEM_EQ(scheme, tree_class, elem1, elem2) \
+  ASSERT_PRED_FORMAT4 (element_equality, (scheme), (tree_class), (elem1), (elem2))
+
 /**
  * \brief Test if two 3D vectors are equal with respect to a given precision
  * 

--- a/test/t8_schemes/t8_gtest_face_neigh.cxx
+++ b/test/t8_schemes/t8_gtest_face_neigh.cxx
@@ -75,8 +75,7 @@ t8_test_face_neighbor_inside (int num_faces, t8_element_t *element, t8_element_t
     scheme->element_get_face_neighbor_inside (tree_class, child, neigh, iface, &face_num);
     scheme->element_get_face_neighbor_inside (tree_class, neigh, element, face_num, &check);
 
-    EXPECT_TRUE (scheme->element_is_equal (tree_class, child, element)) << "Got a false neighbor.";
-    EXPECT_ELEM_EQ (scheme, tree_class, child, element);
+    EXPECT_ELEM_EQ (scheme, tree_class, child, element) << "Got a false neighbor.";
   }
 }
 

--- a/test/t8_schemes/t8_gtest_successor.cxx
+++ b/test/t8_schemes/t8_gtest_successor.cxx
@@ -122,7 +122,7 @@ t8_deep_successor (t8_element_t *element, t8_element_t *successor, t8_element_t 
     for (int jchild = 0; jchild < num_children_child; jchild++) {
       scheme->element_get_child (tree_class, child, jchild, element);
       /* Check the computation of the successor. */
-      ASSERT_TRUE (scheme->element_is_equal (tree_class, element, successor)) << "Wrong Successor at Maxlvl.\n";
+      ASSERT_ELEM_EQ (scheme, tree_class, element, successor) << "Wrong Successor at Maxlvl.\n";
       /* Compute the next successor. */
       EXPECT_EQ (scheme->element_get_level (tree_class, successor), maxlvl);
       scheme->element_construct_successor (tree_class, successor, successor);


### PR DESCRIPTION
Found some places where we used the old ASSERT_TRUE(scheme->elem_eq)


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
