### PR TITLE
Fix dquad/pquad confusion bug

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,7 +147,7 @@ target_sources( T8 PRIVATE
     t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
     t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_connectivity.c 
     t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
-    t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c
+    t8_schemes/t8_default/t8_default_quad/t8_default_quad_bits.cxx
     t8_schemes/t8_default/t8_default_tet/t8_default_tet.cxx
     t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.c
     t8_schemes/t8_default/t8_default_tet/t8_dtet_connectivity.c

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
@@ -24,6 +24,7 @@
 #include <t8_schemes/t8_default/t8_default_line/t8_dline_bits.h>
 #include <t8_schemes/t8_default/t8_default_common/t8_default_common.hxx>
 #include <t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx>
+#include <t8_schemes/t8_default/t8_default_quad/t8_default_quad_bits.hxx>
 #include <t8_schemes/t8_scheme.hxx>
 
 /* We want to export the whole implementation to be callable from "C" */
@@ -694,7 +695,7 @@ t8_default_scheme_quad::element_get_reference_coords (const t8_element_t *elem, 
                                                       const size_t num_coords, double *out_coords) const
 {
   T8_ASSERT (element_is_valid (elem));
-  t8_dquad_compute_reference_coords ((const t8_dquad_t *) elem, ref_coords, num_coords, out_coords);
+  t8_dquad_compute_reference_coords ((const p4est_quadrant_t *) elem, ref_coords, num_coords, out_coords);
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
@@ -33,8 +33,6 @@
 
 #include <p4est.h>
 #include <t8_element.h>
-#include <t8_schemes/t8_default/t8_default_quad/t8_dquad.h>
-#include <t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h>
 #include <t8_schemes/t8_default/t8_default_line/t8_default_line.hxx>
 #include <t8_schemes/t8_default/t8_default_common/t8_default_common.hxx>
 

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_bits.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_bits.cxx
@@ -20,22 +20,20 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-#include <t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h>
+#include <t8_schemes/t8_default/t8_default_quad/t8_default_quad_bits.hxx>
 #include <p4est_bits.h>
 
 void
-t8_dquad_compute_reference_coords (const t8_dquad_t *elem, const double *ref_coords, const size_t num_coords,
+t8_dquad_compute_reference_coords (const p4est_quadrant_t *elem, const double *ref_coords, const size_t num_coords,
                                    double *out_coords)
 {
-  const p4est_quadrant_t *q1 = (const p4est_quadrant_t *) elem;
-
-  const p4est_qcoord_t h = P4EST_QUADRANT_LEN (q1->level);
+  const p4est_qcoord_t h = P4EST_QUADRANT_LEN (elem->level);
 
   for (size_t icoord = 0; icoord < num_coords; ++icoord) {
     const size_t offset_2d = icoord * 2;
     const size_t offset_3d = icoord * 3;
-    out_coords[offset_2d + 0] = q1->x + ref_coords[offset_3d + 0] * h;
-    out_coords[offset_2d + 1] = q1->y + ref_coords[offset_3d + 1] * h;
+    out_coords[offset_2d + 0] = elem->x + ref_coords[offset_3d + 0] * h;
+    out_coords[offset_2d + 1] = elem->y + ref_coords[offset_3d + 1] * h;
 
     out_coords[offset_2d + 0] /= (double) P4EST_ROOT_LEN;
     out_coords[offset_2d + 1] /= (double) P4EST_ROOT_LEN;

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_bits.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_bits.hxx
@@ -20,7 +20,7 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-/** \file t8_dquad_bits.h
+/** \file t8_default_quad_bits.hxx
  * Definitions of quad-specific functions.
  */
 
@@ -28,7 +28,7 @@
 #define T8_DQUAD_BITS_H
 
 #include <t8_element.h>
-#include <t8_schemes/t8_default/t8_default_quad/t8_dquad.h>
+#include <t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx>
 
 T8_EXTERN_C_BEGIN ();
 
@@ -43,7 +43,7 @@ T8_EXTERN_C_BEGIN ();
  *                         of the points on the quad.
  */
 void
-t8_dquad_compute_reference_coords (const t8_dquad_t *elem, const double *ref_coords, const size_t num_coords,
+t8_dquad_compute_reference_coords (const t8_pquad_t *elem, const double *ref_coords, const size_t num_coords,
                                    double *out_coords);
 
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad.h
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad.h
@@ -47,13 +47,4 @@
 /** The length of a quad at a given level in integer coordinates. */
 #define T8_DQUAD_LEN(l) (1 << (T8_DQUAD_MAXLEVEL - (l)))
 
-typedef int32_t t8_dquad_coord_t;
-
-typedef struct t8_dquad
-{
-  int8_t level;
-  t8_dquad_coord_t x; /**< The x integer coordinate of the anchor node. */
-  t8_dquad_coord_t y; /**< The y integer coordinate of the anchor node. */
-} t8_dquad_t;
-
 #endif /* T8_DQUAD_H */


### PR DESCRIPTION
**_Describe your changes here:_**

The default quad scheme uses the `t8_pquad_t` data type (internally mapped to `p4est_quadrant_t`).
One header defined the data type `t8_dquad_t` ("d" instead of "p") completely differently and used it in the function `t8_dquad_compute_reference_coords` where it was wrongly casted into a `t8_pquad_t`.

This is a serious data conversion bug that may have caused issue in the past.

What we did to resolve it:

- Remove `t8_dquad_t` since it was not used elsewhere
- Use `t8_pquad_t` instead
- Rename the files `src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.cxx` to `src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_bits.cxx` to avoid name confusion in the future.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [x] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [x] The author added the patch/minor/major label in accordance to semantic versioning.
