### PR TITLE
Add element ancestor test

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.hxx
@@ -252,8 +252,9 @@ class t8_default_scheme_hex: public t8_default_scheme_common<t8_default_scheme_h
   /** Compute the ancestor id of an element, that is the child id
    * at a given level.
    * \param [in] elem     This must be a valid element.
-   * \param [in] level    A refinement level. Must satisfy \a level < elem.level
+   * \param [in] level    A refinement level. Must satisfy \a level <= elem.level
    * \return              The child_id of \a elem in regard to its \a level ancestor.
+   * \note The ancestor id at elem.level is the same as the child id.
    */
   int
   element_get_ancestor_id (const t8_element_t *elem, int level) const;

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.hxx
@@ -258,8 +258,9 @@ class t8_default_scheme_line: public t8_default_scheme_common<t8_default_scheme_
   /** Compute the ancestor id of an element, that is the child id
    * at a given level.
    * \param [in] elem     This must be a valid element.
-   * \param [in] level    A refinement level. Must satisfy \a level < elem.level
+   * \param [in] level    A refinement level. Must satisfy \a level <= elem.level
    * \return              The child_id of \a elem in regard to its \a level ancestor.
+   * \note The ancestor id at elem.level is the same as the child id.
    */
   int
   element_get_ancestor_id (const t8_element_t *elem, int level) const;

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.hxx
@@ -245,10 +245,12 @@ class t8_default_scheme_prism: public t8_default_scheme_common<t8_default_scheme
   int
   element_get_child_id (const t8_element_t *elem) const;
 
-  /** Compute the ancestor id of an element, that is the child id at a given level.
+  /** Compute the ancestor id of an element, that is the child id
+   * at a given level.
    * \param [in] elem     This must be a valid element.
-   * \param [in] level    A refinement level. Must satisfy \a level < elem.level
+   * \param [in] level    A refinement level. Must satisfy \a level <= elem.level
    * \return              The child_id of \a elem in regard to its \a level ancestor.
+   * \note The ancestor id at elem.level is the same as the child id.
    */
   int
   element_get_ancestor_id (const t8_element_t *elem, int level) const;

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.hxx
@@ -260,10 +260,12 @@ class t8_default_scheme_pyramid: public t8_default_scheme_common<t8_default_sche
   int
   element_get_child_id (const t8_element_t *elem) const;
 
-  /** Compute the ancestor id of an element, that is the child id at a given level.
+  /** Compute the ancestor id of an element, that is the child id
+   * at a given level.
    * \param [in] elem     This must be a valid element.
-   * \param [in] level    A refinement level. Must satisfy \a level < elem.level
+   * \param [in] level    A refinement level. Must satisfy \a level <= elem.level
    * \return              The child_id of \a elem in regard to its \a level ancestor.
+   * \note The ancestor id at elem.level is the same as the child id.
    */
   int
   element_get_ancestor_id (const t8_element_t *elem, const int level) const;

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
@@ -286,8 +286,9 @@ class t8_default_scheme_quad: public t8_default_scheme_common<t8_default_scheme_
   /** Compute the ancestor id of an element, that is the child id
    * at a given level.
    * \param [in] elem     This must be a valid element.
-   * \param [in] level    A refinement level. Must satisfy \a level < elem.level
+   * \param [in] level    A refinement level. Must satisfy \a level <= elem.level
    * \return              The child_id of \a elem in regard to its \a level ancestor.
+   * \note The ancestor id at elem.level is the same as the child id.
    */
   int
   element_get_ancestor_id (const t8_element_t *elem, int level) const;

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.hxx
@@ -230,10 +230,12 @@ class t8_default_scheme_tet: public t8_default_scheme_common<t8_default_scheme_t
   int
   element_get_child_id (const t8_element_t *elem) const;
 
-  /** Compute the ancestor id of an element, that is the child id at a given level.
+  /** Compute the ancestor id of an element, that is the child id
+   * at a given level.
    * \param [in] elem     This must be a valid element.
-   * \param [in] level    A refinement level. Must satisfy \a level < elem.level
+   * \param [in] level    A refinement level. Must satisfy \a level <= elem.level
    * \return              The child_id of \a elem in regard to its \a level ancestor.
+   * \note The ancestor id at elem.level is the same as the child id.
    */
   int
   element_get_ancestor_id (const t8_element_t *elem, int level) const;

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.hxx
@@ -230,10 +230,12 @@ class t8_default_scheme_tri: public t8_default_scheme_common<t8_default_scheme_t
   int
   element_get_child_id (const t8_element_t *elem) const;
 
-  /** Compute the ancestor id of an element, that is the child id at a given level.
+  /** Compute the ancestor id of an element, that is the child id
+   * at a given level.
    * \param [in] elem     This must be a valid element.
-   * \param [in] level    A refinement level. Must satisfy \a level < elem.level
+   * \param [in] level    A refinement level. Must satisfy \a level <= elem.level
    * \return              The child_id of \a elem in regard to its \a level ancestor.
+   * \note The ancestor id at elem.level is the same as the child id.
    */
   int
   element_get_ancestor_id (const t8_element_t *elem, int level) const;

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.hxx
@@ -251,8 +251,9 @@ class t8_default_scheme_vertex: public t8_default_scheme_common<t8_default_schem
   /** Compute the ancestor id of an element, that is the child id
    * at a given level.
    * \param [in] elem     This must be a valid element.
-   * \param [in] level    A refinement level. Must satisfy \a level < elem.level
+   * \param [in] level    A refinement level. Must satisfy \a level <= elem.level
    * \return              The child_id of \a elem in regard to its \a level ancestor.
+   * \note The ancestor id at elem.level is the same as the child id.
    */
   int
   element_get_ancestor_id (const t8_element_t *elem, int level) const;

--- a/src/t8_schemes/t8_scheme.hxx
+++ b/src/t8_schemes/t8_scheme.hxx
@@ -453,8 +453,9 @@ class t8_scheme {
    * at a given level.
    * \param [in] tree_class    The eclass of the current tree.
    * \param [in] elem     This must be a valid element.
-   * \param [in] level    A refinement level. Must satisfy \a level < elem.level
+   * \param [in] level    A refinement level. Must satisfy \a level <= elem.level
    * \return              The child_id of \a elem in regard to its \a level ancestor.
+   * \note The ancestor id at elem.level is the same as the child id.
    */
   inline int
   element_get_ancestor_id (const t8_eclass_t tree_class, const t8_element_t *elem, const int level) const

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -125,6 +125,7 @@ add_t8_test( NAME t8_gtest_pyra_connectivity_serial     SOURCES t8_gtest_main.cx
 add_t8_test( NAME t8_gtest_face_neigh_serial            SOURCES t8_gtest_main.cxx t8_schemes/t8_gtest_face_neigh.cxx )
 add_t8_test( NAME t8_gtest_init_linear_id_serial        SOURCES t8_gtest_main.cxx t8_schemes/t8_gtest_init_linear_id.cxx )
 add_t8_test( NAME t8_gtest_ancestor_serial              SOURCES t8_gtest_main.cxx t8_schemes/t8_gtest_ancestor.cxx )
+add_t8_test( NAME t8_gtest_ancestor_id_serial           SOURCES t8_gtest_main.cxx t8_schemes/t8_gtest_ancestor_id.cxx )
 add_t8_test( NAME t8_gtest_element_count_leaves_serial  SOURCES t8_gtest_main.cxx t8_schemes/t8_gtest_element_count_leaves.cxx )
 add_t8_test( NAME t8_gtest_element_ref_coords_serial    SOURCES t8_gtest_main.cxx t8_schemes/t8_gtest_element_ref_coords.cxx )
 add_t8_test( NAME t8_gtest_descendant_serial            SOURCES t8_gtest_main.cxx t8_schemes/t8_gtest_descendant.cxx )

--- a/test/t8_schemes/t8_gtest_ancestor.cxx
+++ b/test/t8_schemes/t8_gtest_ancestor.cxx
@@ -22,7 +22,7 @@
 
 /** \file t8_gtest_nca.cxx
 * Provide tests to check the functionality of the nearest-common-ancestor function
-* for every element.
+* for every element of a pyramid.
 */
 
 #include <gtest/gtest.h>

--- a/test/t8_schemes/t8_gtest_ancestor_id.cxx
+++ b/test/t8_schemes/t8_gtest_ancestor_id.cxx
@@ -1,0 +1,86 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2025 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_gtest_ancestor_id.cxx
+ * This test checks that the ancestor id of an element at level elem.level is the same
+ * as the child id of the element. This traverses up the tree and checks if the ancestor id
+ * at elem.level - 1, -2, ... is the same as the child id of the parent, grandparent and so on. 
+ */
+
+#include <gtest/gtest.h>
+#include <t8_eclass.h>
+#include <t8_schemes/t8_default/t8_default.hxx>
+#include <test/t8_gtest_custom_assertion.hxx>
+#include "t8_gtest_dfs_base.hxx"
+#include <test/t8_gtest_macros.hxx>
+
+class class_ancestor_id: public TestDFS {
+  void
+  check_element () override
+  {
+    t8_element_t *ancestor;
+    scheme->element_new (eclass, 1, &ancestor);
+    /* Get level of current element */
+    const int level = scheme->element_get_level (eclass, element);
+
+    /* Iterate over all levels above the current element and check
+    if ancestor id corresponds with the child id of elem, parent, grandparent, ... */
+    for (int levels_above_elem = 0; levels_above_elem < level; levels_above_elem++) {
+      const int ancestor_level = level - levels_above_elem;
+      const int ancestor_id = scheme->element_get_ancestor_id (eclass, element, ancestor_level);
+      /* Compute elem/parent/grandparent... */
+      scheme->element_copy (eclass, element, ancestor);
+      for (int level_diff = 0; level_diff < levels_above_elem; level_diff++) {
+        scheme->element_get_parent (eclass, ancestor, ancestor);
+      }
+      const int child_id = scheme->element_get_child_id (eclass, ancestor);
+      EXPECT_EQ (ancestor_id, child_id);
+    }
+    scheme->element_destroy (eclass, 1, &ancestor);
+  }
+
+ protected:
+  void
+  SetUp () override
+  {
+    /* Setup DFS test */
+    dfs_test_setup ();
+  }
+  void
+  TearDown () override
+  {
+    /* Destroy DFS test */
+    dfs_test_teardown ();
+  }
+};
+
+TEST_P (class_ancestor_id, t8_recursive_dfs_ancestor_id)
+{
+#ifdef T8_ENABLE_LESS_TESTS
+  const int maxlvl = 4;
+#else
+  const int maxlvl = 6;
+#endif
+  check_recursive_dfs_to_max_lvl (maxlvl);
+}
+
+INSTANTIATE_TEST_SUITE_P (t8_gtest_ancestor_id, class_ancestor_id, AllSchemes);


### PR DESCRIPTION
**_Describe your changes here:_**



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
