### PR TITLE
Avoid dynamic allocation in element-functions

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -127,16 +127,14 @@ t8_dprism_child_id (const t8_dprism_t *p)
 int
 t8_dprism_is_familypv (t8_dprism_t **fam)
 {
-  t8_dtri_t **tri_fam = T8_ALLOC (t8_dtri_t *, T8_DTRI_CHILDREN);
-  t8_dline_t **line_fam = T8_ALLOC (t8_dline_t *, T8_DLINE_CHILDREN);
+  t8_dtri_t *tri_fam[T8_DPRISM_CHILDREN];
+  t8_dline_t *line_fam[T8_DLINE_CHILDREN];
 
   for (int i = 0; i < T8_DLINE_CHILDREN; i++) {
     for (int j = 0; j < T8_DTRI_CHILDREN; j++) {
       tri_fam[j] = &fam[j + i * T8_DTRI_CHILDREN]->tri;
     }
     if (!t8_dtri_is_familypv ((const t8_dtri_t **) tri_fam)) {
-      T8_FREE (tri_fam);
-      T8_FREE (line_fam);
       return 0;
     }
   }
@@ -151,21 +149,15 @@ t8_dprism_is_familypv (t8_dprism_t **fam)
           && (fam[i]->tri.type == fam[i + T8_DTRI_CHILDREN]->tri.type)
           && (fam[i]->tri.x == fam[i + T8_DTRI_CHILDREN]->tri.x)
           && (fam[i]->tri.y == fam[i + T8_DTRI_CHILDREN]->tri.y))) {
-      T8_FREE (tri_fam);
-      T8_FREE (line_fam);
       return 0;
     }
   }
 
   for (int i = 0; i < T8_DPRISM_CHILDREN; i++) {
     if (fam[i]->line.level != fam[i]->tri.level) {
-      T8_FREE (tri_fam);
-      T8_FREE (line_fam);
       return 0;
     }
   }
-  T8_FREE (tri_fam);
-  T8_FREE (line_fam);
   return 1;
 }
 

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -1327,17 +1327,15 @@ t8_dpyramid_children_at_face (const t8_dpyramid_t *p, const int face, t8_dpyrami
   T8_ASSERT (0 <= face && face < T8_DPYRAMID_FACES);
   if (t8_dpyramid_shape (p) == T8_ECLASS_TET) {
     /* Use tet-algo */
-    t8_dtet_t **tet_children = T8_ALLOC (t8_dtet_t *, T8_DTET_FACE_CHILDREN);
-    for (int i = 0; i < T8_DTET_FACE_CHILDREN; i++) {
-      tet_children[i] = T8_ALLOC (t8_dtet_t, 1);
-    }
+    t8_dtet_t face_children[T8_DTET_FACE_CHILDREN];
+    t8_dtet_t *tet_children[T8_DTET_FACE_CHILDREN]
+      = { &face_children[0], &face_children[1], &face_children[2], &face_children[3] };
+
     t8_dtet_children_at_face (&(p->pyramid), face, tet_children, num_children, child_indices);
     for (int i = 0; i < T8_DTET_FACE_CHILDREN; i++) {
       t8_dtet_copy (tet_children[i], &(children[i]->pyramid));
       children[i]->switch_shape_at_level = p->switch_shape_at_level;
-      T8_FREE (tet_children[i]);
     }
-    T8_FREE (tet_children);
   }
   else {
     int *children_at_face_id, children_at_face_id_local[T8_DPYRAMID_FACE_CHILDREN];

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -267,12 +267,11 @@ t8_dpyramid_is_family (t8_dpyramid_t **fam)
 {
   const int level = fam[0]->pyramid.level;
   if (t8_dpyramid_shape (fam[0]) == T8_ECLASS_TET) {
-    t8_dtet_t **tet_fam = T8_ALLOC (t8_dtet_t *, T8_DTET_CHILDREN);
+    t8_dtet_t *tet_fam[T8_DTET_CHILDREN];
     for (int i = 0; i < T8_DTET_CHILDREN; i++) {
       tet_fam[i] = &fam[i]->pyramid;
     }
     const int is_family = t8_dtet_is_familypv ((const t8_dtet_t **) tet_fam);
-    T8_FREE (tet_fam);
     return is_family;
   }
   else {


### PR DESCRIPTION
I found some dynamic allocations where the length of the array is already known at compile time and got rid of the dynamic allocation. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
