### PR TITLE
Avoid dynamic allocations with hard-coded numbers

### DIFF
--- a/src/t8_cmesh/t8_cmesh_commit.cxx
+++ b/src/t8_cmesh/t8_cmesh_commit.cxx
@@ -90,9 +90,9 @@ t8_cmesh_add_attributes (const t8_cmesh_t cmesh, sc_hash_t *ghost_ids)
   const t8_stash_t stash = cmesh->stash;
   t8_locidx_t ltree;
   size_t si, sj;
-  t8_ghost_facejoin_t *temp_facejoin, **facejoin_pp; /* used to lookup global ghost ids in the hash */
+  t8_ghost_facejoin_t **facejoin_pp; /* used to lookup global ghost ids in the hash */
 
-  temp_facejoin = T8_ALLOC_ZERO (t8_ghost_facejoin_t, 1);
+  t8_ghost_facejoin_t temp_facejoin = { 0, 0, 0 };
 
   t8_locidx_t ghosts_inserted = 0;
   ltree = -1;
@@ -111,8 +111,8 @@ t8_cmesh_add_attributes (const t8_cmesh_t cmesh, sc_hash_t *ghost_ids)
     }
     else {
       T8_ASSERT (ghost_ids != NULL);
-      temp_facejoin->ghost_id = attribute->id;
-      if (sc_hash_lookup (ghost_ids, temp_facejoin, (void ***) &facejoin_pp)) {
+      temp_facejoin.ghost_id = attribute->id;
+      if (sc_hash_lookup (ghost_ids, &temp_facejoin, (void ***) &facejoin_pp)) {
         T8_ASSERT ((t8_locidx_t) sj == (t8_locidx_t) (*facejoin_pp)->attr_id);
         if (sj == 0) {
           ghosts_inserted++;
@@ -124,7 +124,6 @@ t8_cmesh_add_attributes (const t8_cmesh_t cmesh, sc_hash_t *ghost_ids)
       }
     }
   }
-  T8_FREE (temp_facejoin);
 }
 
 static void

--- a/src/t8_forest/t8_forest_netcdf.cxx
+++ b/src/t8_forest/t8_forest_netcdf.cxx
@@ -748,7 +748,7 @@ t8_forest_write_netcdf_coordinate_data (t8_forest_t forest, t8_forest_netcdf_con
       i = 0;
       for (; i < number_nodes; i++) {
         t8_forest_element_coordinate (forest, ltree_id, element,
-                                      t8_element_shape_vtk_corner_number ((int) element_shape, i), &vertex_coords);
+                                      t8_element_shape_vtk_corner_number ((int) element_shape, i), vertex_coords);
         /* Stores the x-, y- and z- coordinate of the nodes */
         Mesh_node_x[num_it] = vertex_coords[0];
         Mesh_node_y[num_it] = vertex_coords[1];

--- a/src/t8_forest/t8_forest_netcdf.cxx
+++ b/src/t8_forest/t8_forest_netcdf.cxx
@@ -665,7 +665,7 @@ static void
 t8_forest_write_netcdf_coordinate_data (t8_forest_t forest, t8_forest_netcdf_context_t *context, sc_MPI_Comm comm)
 {
 #if T8_WITH_NETCDF
-  double *vertex_coords = T8_ALLOC (double, 3);
+  double vertex_coords[3];
   t8_eclass_t tree_class;
   t8_locidx_t num_local_trees;
   t8_locidx_t ltree_id = 0;
@@ -748,7 +748,7 @@ t8_forest_write_netcdf_coordinate_data (t8_forest_t forest, t8_forest_netcdf_con
       i = 0;
       for (; i < number_nodes; i++) {
         t8_forest_element_coordinate (forest, ltree_id, element,
-                                      t8_element_shape_vtk_corner_number ((int) element_shape, i), vertex_coords);
+                                      t8_element_shape_vtk_corner_number ((int) element_shape, i), &vertex_coords);
         /* Stores the x-, y- and z- coordinate of the nodes */
         Mesh_node_x[num_it] = vertex_coords[0];
         Mesh_node_y[num_it] = vertex_coords[1];
@@ -765,8 +765,6 @@ t8_forest_write_netcdf_coordinate_data (t8_forest_t forest, t8_forest_netcdf_con
       }
     }
   }
-  /* Free allocated memory */
-  T8_FREE (vertex_coords);
 
   /* *Write the data into the NetCDF coordinate variables.* */
 


### PR DESCRIPTION
Following #1347 I did a quick search over our base looking for T8_ALLOCs with Makros or hard coded numbers in it. This is what I found. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
