### PR TITLE
 Revert loop to prevent overwriting of the input element

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -329,24 +329,24 @@ t8_dprism_children_at_face (const t8_dprism_t *p, int face, t8_dprism_t **childr
   T8_ASSERT (num_children == t8_dprism_num_face_children (p, face));
   T8_ASSERT (0 <= face && face < T8_DPRISM_FACES);
   if (face < 3) {
-    for (int ichild = 0; ichild < 4; ichild++) {
+    for (int ichild = 3; ichild >= 0; ichild--) {
       t8_dprism_child (p, children_at_face[p->tri.type][face * 4 + ichild], children[ichild]);
     }
   }
   else {
-    for (int ichild = 0; ichild < 4; ichild++) {
+    for (int ichild = 3; ichild >= 0; ichild--) {
       t8_dprism_child (p, (face % 3) * 4 + ichild, children[ichild]);
     }
   }
   /* Fill child-indices array */
   if (child_indices != NULL) {
     if (face < 3) {
-      for (int ichild = 0; ichild < 4; ichild++) {
+      for (int ichild = 3; ichild >= 0; ichild--) {
         child_indices[ichild] = children_at_face[p->tri.type][face * 4 + ichild];
       }
     }
     else {
-      for (int ichild = 0; ichild < 4; ichild++) {
+      for (int ichild = 3; ichild >= 0; ichild--) {
         child_indices[ichild] = (face % 3) * 4 + ichild;
       }
     }


### PR DESCRIPTION
**_Describe your changes here:_**

In the `children_at_face` function the documentation specifies, that "It is valid to call this function with elem = children[0]." 
This wasn't true for this function as proven with a new test, which will be introduced with the standalone scheme face functions. 

With the reversion of the loop, the input element at children[0] is overwritten in the last step, which is intended. 

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
