### PR TITLE
C-interface for pack/unpack of data

### DIFF
--- a/src/t8_data/t8_data_handler.h
+++ b/src/t8_data/t8_data_handler.h
@@ -1,0 +1,57 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#ifndef T8_DATA_HANDLER_H
+#define T8_DATA_HANDLER_H
+
+#include <t8.h>
+
+T8_EXTERN_C_BEGIN ();
+
+typedef struct t8_c_data_handler *t8_data_handler;
+
+void
+t8_data_handler_init (t8_c_data_handler handler);
+
+int
+t8_data_handler_buffer_size (t8_c_data_handler handler, sc_MPI_Comm comm);
+
+void
+t8_data_handler_pack_prefix (t8_c_data_handler handler, void *buffer, const int num_bytes, int *pos, sc_MPI_Comm comm);
+
+void
+t8_data_handler_unpack_prefix (t8_c_data_handler handler, const void *buffer, const int num_bytes, int *pos,
+                               int *outcount, sc_MPI_Comm comm);
+
+int
+t8_data_handler_send (t8_c_data_handler handler, const int dest, const int tag, sc_MPI_Comm comm);
+
+int
+t8_data_handler_recv (t8_c_data_handler handler, const int source, const int tag, sc_MPI_Comm comm,
+                      sc_MPI_Status *status, int *outcount);
+
+void
+t8_data_handler_destroy (t8_data_handler *handler);
+
+T8_EXTERN_C_END ();
+
+#endif /* T8_DATA_HANDLER_H */

--- a/src/t8_data/t8_data_handler.hxx
+++ b/src/t8_data/t8_data_handler.hxx
@@ -251,6 +251,12 @@ class t8_data_handler: public t8_abstract_data_handler {
     return single_handler.type ();
   }
 
+  t8_data_handler (const std::vector<T> &data, t8_single_data_handler_c single_handler)
+  {
+    m_data = std::make_shared<std::vector<T>> (data);
+    this->single_handler = single_handler;
+  }
+
  private:
   /**
   * \brief A shared pointer to a vector of data. 


### PR DESCRIPTION
Implementation of a C-Interface that enables the User to use C to pack and unpack its data. Will wrap around the existing C++ functionality. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
