### PR TITLE
introduce more setters to the vtk writer

### DIFF
--- a/src/t8_vtk/t8_vtk_writer.hxx
+++ b/src/t8_vtk/t8_vtk_writer.hxx
@@ -135,7 +135,7 @@ class vtk_writer {
    * \return true 
    * \return false 
    */
-  inline bool
+  bool
   write_ASCII (const grid_t grid);
 
   /**

--- a/src/t8_vtk/t8_vtk_writer.hxx
+++ b/src/t8_vtk/t8_vtk_writer.hxx
@@ -135,7 +135,7 @@ class vtk_writer {
    * \return true 
    * \return false 
    */
-  bool
+  inline bool
   write_ASCII (const grid_t grid);
 
   /**
@@ -143,7 +143,7 @@ class vtk_writer {
    * 
    * \param[in] write_treeid true or false
    */
-  void
+  inline void
   set_write_treeid (const bool write_treeid)
   {
     this->write_treeid = write_treeid;
@@ -154,7 +154,7 @@ class vtk_writer {
    * 
    * \param[in] write_mpirank true or false
    */
-  void
+  inline void
   set_write_mpirank (const bool write_mpirank)
   {
     this->write_mpirank = write_mpirank;
@@ -165,7 +165,7 @@ class vtk_writer {
    * 
    * \param[in] write_level true or false
    */
-  void
+  inline void
   set_write_level (const bool write_level)
   {
     this->write_level = write_level;
@@ -176,7 +176,7 @@ class vtk_writer {
    * 
    * \param[in] write_element_id true or false
    */
-  void
+  inline void
   set_write_element_id (const bool write_element_id)
   {
     this->write_element_id = write_element_id;
@@ -187,7 +187,7 @@ class vtk_writer {
    * 
    * \param[in] write_ghosts true or false
    */
-  void
+  inline void
   set_write_ghosts (const bool write_ghosts)
   {
     this->write_ghosts = write_ghosts;
@@ -199,7 +199,7 @@ class vtk_writer {
    * 
    * \param[in] curved_flag true or false
    */
-  void
+  inline void
   set_curved_flag (const bool curved_flag)
   {
     this->curved_flag = curved_flag;
@@ -209,7 +209,7 @@ class vtk_writer {
    * Set the fileprefix for the output files.
    * \param[in] fileprefix 
    */
-  void
+  inline void
   set_fileprefix (std::string fileprefix)
   {
     this->fileprefix = fileprefix;

--- a/src/t8_vtk/t8_vtk_writer.hxx
+++ b/src/t8_vtk/t8_vtk_writer.hxx
@@ -138,6 +138,83 @@ class vtk_writer {
   bool
   write_ASCII (const grid_t grid);
 
+  /**
+   * Set the write treeid flag. Set to true, if you want to write the tree id of every element.
+   * 
+   * \param[in] write_treeid true or false
+   */
+  void
+  set_write_treeid (const bool write_treeid)
+  {
+    this->write_treeid = write_treeid;
+  }
+
+  /**
+   * Set the write mpirank flag. Set to true, if you want to write the mpirank of every element.
+   * 
+   * \param[in] write_mpirank true or false
+   */
+  void
+  set_write_mpirank (const bool write_mpirank)
+  {
+    this->write_mpirank = write_mpirank;
+  }
+
+  /**
+   * Set the write level flag. Set to true, if you want to write the level of every element.
+   * 
+   * \param[in] write_level true or false
+   */
+  void
+  set_write_level (const bool write_level)
+  {
+    this->write_level = write_level;
+  }
+
+  /**
+   * Set the write element id flag. Set to true, if you want to write the element id of every element.
+   * 
+   * \param[in] write_element_id true or false
+   */
+  void
+  set_write_element_id (const bool write_element_id)
+  {
+    this->write_element_id = write_element_id;
+  }
+
+  /**
+   * Set the write ghosts flag. Set to true, if you want to write the ghost elements, too.
+   * 
+   * \param[in] write_ghosts true or false
+   */
+  void
+  set_write_ghosts (const bool write_ghosts)
+  {
+    this->write_ghosts = write_ghosts;
+  }
+
+  /**
+   * Set the curved flag. Set to true, if you want to use quadratic vtk cells. 
+   * Uses the geometry of the grid to evaluate points between corners.
+   * 
+   * \param[in] curved_flag true or false
+   */
+  void
+  set_curved_flag (const bool curved_flag)
+  {
+    this->curved_flag = curved_flag;
+  }
+
+  /**
+   * Set the fileprefix for the output files.
+   * \param[in] fileprefix 
+   */
+  void
+  set_fileprefix (std::string fileprefix)
+  {
+    this->fileprefix = fileprefix;
+  }
+
  private:
 #if T8_WITH_VTK
   /**


### PR DESCRIPTION
Add more setters to the vtk-writer. That way a single vtk writer is sufficient to write in various configurations. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
