### PR TITLE
add a function to pretty print scheme and eclass

### DIFF
--- a/test/t8_forest_incomplete/t8_gtest_recursive.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_recursive.cxx
@@ -155,4 +155,4 @@ TEST_P (recursive_tree, test_recursive)
   ASSERT_TRUE (t8_forest_is_equal (forest, forest_base));
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_recursive, recursive_tree, AllSchemes);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_recursive, recursive_tree, AllSchemes, print_all_schemes);

--- a/test/t8_gtest_schemes.hxx
+++ b/test/t8_gtest_schemes.hxx
@@ -41,6 +41,13 @@ create_from_scheme_id (const int scheme_id)
   }
 }
 
+static const char *t8_scheme_to_string[] = { "default", "standalone" };
+
+auto print_all_schemes = [] (const testing::TestParamInfo<std::tuple<int, t8_eclass_t>> &info) {
+  return std::string (t8_scheme_to_string[std::get<0> (info.param)]) + "_"
+         + t8_eclass_to_string[std::get<1> (info.param)];
+};
+
 #define AllSchemes ::testing::Combine (::testing::Range (0, 2), ::testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT))
 /* Only used for disabling face tests*/
 #define DefaultSchemes ::testing::Combine (::testing::Range (0, 1), ::testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT))

--- a/test/t8_schemes/t8_gtest_ancestor_id.cxx
+++ b/test/t8_schemes/t8_gtest_ancestor_id.cxx
@@ -83,4 +83,4 @@ TEST_P (class_ancestor_id, t8_recursive_dfs_ancestor_id)
   check_recursive_dfs_to_max_lvl (maxlvl);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_ancestor_id, class_ancestor_id, AllSchemes);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_ancestor_id, class_ancestor_id, AllSchemes, print_all_schemes);

--- a/test/t8_schemes/t8_gtest_descendant.cxx
+++ b/test/t8_schemes/t8_gtest_descendant.cxx
@@ -159,4 +159,4 @@ TEST_P (class_schemes_descendant, test_recursive_descendant)
   t8_large_step_descendant (elem, desc, test, scheme, eclass, maxlvl);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_descendant, class_schemes_descendant, AllSchemes);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_descendant, class_schemes_descendant, AllSchemes, print_all_schemes);

--- a/test/t8_schemes/t8_gtest_element_count_leaves.cxx
+++ b/test/t8_schemes/t8_gtest_element_count_leaves.cxx
@@ -128,4 +128,4 @@ TEST_P (class_element_leaves, test_element_count_leaves_one_level)
   scheme->element_destroy (eclass, 1, &element);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_element_count_leaves, class_element_leaves, AllSchemes);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_element_count_leaves, class_element_leaves, AllSchemes, print_all_schemes);

--- a/test/t8_schemes/t8_gtest_equal.cxx
+++ b/test/t8_schemes/t8_gtest_equal.cxx
@@ -84,4 +84,4 @@ TEST_P (class_test_equal, test_equal_dfs)
   check_recursive_dfs_to_max_lvl (maxlvl);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_test_all_imps, class_test_equal, AllSchemes);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_test_all_imps, class_test_equal, AllSchemes, print_all_schemes);

--- a/test/t8_schemes/t8_gtest_find_parent.cxx
+++ b/test/t8_schemes/t8_gtest_find_parent.cxx
@@ -74,4 +74,4 @@ TEST_P (class_find_parent, t8_compute_child_find_parent)
   check_recursive_dfs_to_max_lvl (maxlvl);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_find_parent, class_find_parent, AllSchemes);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_find_parent, class_find_parent, AllSchemes, print_all_schemes);

--- a/test/t8_schemes/t8_gtest_init_linear_id.cxx
+++ b/test/t8_schemes/t8_gtest_init_linear_id.cxx
@@ -148,4 +148,4 @@ TEST_P (linear_id, id_at_other_level)
   }
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_test_init_linear_id, linear_id, AllSchemes);
+INSTANTIATE_TEST_SUITE_P (t8_test_init_linear_id, linear_id, AllSchemes, print_all_schemes);

--- a/test/t8_schemes/t8_gtest_nca.cxx
+++ b/test/t8_schemes/t8_gtest_nca.cxx
@@ -315,4 +315,4 @@ TEST_P (nca, recursive_check_higher_level)
   scheme->element_destroy (tree_class, 1, &correct_nca_high_level);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_nca, nca, AllSchemes);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_nca, nca, AllSchemes, print_all_schemes);

--- a/test/t8_schemes/t8_gtest_pack_unpack.cxx
+++ b/test/t8_schemes/t8_gtest_pack_unpack.cxx
@@ -135,4 +135,4 @@ TEST_P (class_test_pack, test_equal_dfs)
   check_recursive_dfs_to_max_lvl (maxlvl);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_test_all_imps, class_test_pack, AllSchemes);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_test_all_imps, class_test_pack, AllSchemes, print_all_schemes);

--- a/test/t8_schemes/t8_gtest_root.cxx
+++ b/test/t8_schemes/t8_gtest_root.cxx
@@ -70,4 +70,4 @@ TEST_P (root, equals_linear_id_0_0)
   scheme->element_destroy (eclass, 1, &root_compare);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_root, root, AllSchemes);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_root, root, AllSchemes, print_all_schemes);

--- a/test/t8_schemes/t8_gtest_successor.cxx
+++ b/test/t8_schemes/t8_gtest_successor.cxx
@@ -154,4 +154,4 @@ TEST_P (class_successor, test_recursive_and_deep_successor)
   t8_deep_successor (element, successor, last, scheme, tree_class);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_successor, class_successor, AllSchemes);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_successor, class_successor, AllSchemes, print_all_schemes);


### PR DESCRIPTION
The AllSchemes had no function to print their input. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
