### PR TITLE
final? minor change in paper.bib

### DIFF
--- a/JOSS/paper.bib
+++ b/JOSS/paper.bib
@@ -274,7 +274,7 @@
   abstract     = {To achieve the exponential rates of convergence possible with the p-version finite element method requires properly constructed meshes. In the case of piecewise smooth domains, these meshes are characterized by having large curved elements over smooth portions of the domain and geometrically graded curved elements to isolate the edge and vertex singularities that are of interest. This paper presents a procedure under development for the automatic generation of such meshes for general three-dimensional domains defined in solid modeling systems. Two key steps in the procedure are the determination of the singular model edges and vertices, and the creation of geometrically graded elements around those entities. The other key step is the use of general curved element mesh modification procedures to correct any invalid elements created by the curving of mesh entities on the model boundary, which is required to ensure a properly geometric approximation of the domain. Example meshes are included to demonstrate the features of the procedure.}
 }
 @article{burstedde_coarse_2017,
-  title        = {Coarse {Mesh} {Partitioning} for {Tree}-{Based} {AMR}},
+  title        = {Coarse Mesh Partitioning for Tree-Based {AMR}},
   author       = {Burstedde, Carsten and Holke, Johannes},
   year         = 2017,
   journal      = {SIAM Journal on Scientific Computing},


### PR DESCRIPTION
**_Describe your changes here:_**



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
