### PR TITLE
Fixed vtk read documentation

### DIFF
--- a/doc/author_nguyenxuan.txt
+++ b/doc/author_nguyenxuan.txt
@@ -1,0 +1,2 @@
+I place my contributions to t8code under the FreeBSD license.
+Tu Nguyen Xuan (tu.nguyenxuan@dlr.de)

--- a/example/IO/cmesh/vtk/t8_cmesh_read_from_vtk.cxx
+++ b/example/IO/cmesh/vtk/t8_cmesh_read_from_vtk.cxx
@@ -131,7 +131,7 @@ main (int argc, char **argv)
   snprintf (usage, BUFSIZ, "Usage:\t%s <OPTIONS> <ARGUMENTS>\n\t%s -h\t for a brief overview of all options.",
             basename (argv[0]), basename (argv[0]));
   sreturn = snprintf (help, BUFSIZ,
-                      "This program reads a .vtk-file and constructs a mesh representing the given Data."
+                      "This program reads a .vtk-file and constructs a mesh representing the given Data.\n"
                       "Arguments can be passed via:\n%s\n\n",
                       usage);
   if (sreturn >= BUFSIZ) {
@@ -151,7 +151,7 @@ main (int argc, char **argv)
   sc_options_add_string (opt, 'f', "vtk-file", &vtk_file, "", "The prefix of the .vtk file.");
   sc_options_add_string (opt, 'o', "output", &out_file, "output", "The prefix of the output-file.");
   sc_options_add_int (opt, 'c', "num_cell_values", &num_keys, 0, "Number of values per cell stored in the vtk-file.");
-  sc_options_add_bool (opt, 'p', "partition", &partition, 0, "If set, partition the cmesh uniformly.");
+  sc_options_add_switch (opt, 'p', "partition", &partition, "If set, partition the cmesh uniformly.");
   sc_options_add_int (opt, 't', "type_of_file", &vtk_file_type_int, -1,
                       "Set the type of the data in the file.\n"
                       "\t\t\t\t\t0 for vtkUnstructuredGrid,\n"


### PR DESCRIPTION
**_Describe your changes here:_**
Fixed the documentation in the `t8_cmesh_read_from_vtk` file


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
