### PR TITLE
Correct order of execution in docu and some typos

### DIFF
--- a/doc/author_ploetzke.txt
+++ b/doc/author_ploetzke.txt
@@ -1,0 +1,1 @@
+I place my contributions to t8code under the FreeBSD license. Lena Plötzke (lena.ploetzke@gmx.de)

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -249,7 +249,7 @@ t8_forest_set_copy (t8_forest_t forest, const t8_forest_t from);
  *                          and it is recursive otherwise.
  * \note This setting can be combined with \ref t8_forest_set_partition and \ref
  * t8_forest_set_balance. The order in which these operations are executed is always
- * 1) Adapt 2) Balance 3) Partition
+ * 1) Adapt 2) Partition 3) Balance.
  * \note This setting may not be combined with \ref t8_forest_set_copy and overwrites
  * this setting.
  */
@@ -312,7 +312,7 @@ t8_forest_get_user_function (const t8_forest_t forest);
  *                          operation.
  * \note This setting can be combined with \ref t8_forest_set_adapt and \ref
  * t8_forest_set_balance. The order in which these operations are executed is always
- * 1) Adapt 2) Balance 3) Partition
+ * 1) Adapt 2) Partition 3) Balance.
  * If \ref t8_forest_set_balance is called with the \a no_repartition parameter set as
  * false, it is not necessary to call \ref t8_forest_set_partition additionally.
  * \note This setting may not be combined with \ref t8_forest_set_copy and overwrites
@@ -339,8 +339,8 @@ t8_forest_set_partition (t8_forest_t forest, const t8_forest_t set_from, int set
  *                          If \a no_repartition is false, an additional call of \ref t8_forest_set_partition is not
  *                          necessary.
  * \note This setting can be combined with \ref t8_forest_set_adapt and \ref
- * t8_forest_set_balance. The order in which these operations are executed is always
- * 1) Adapt 2) Balance 3) Partition.
+ * t8_forest_set_partition. The order in which these operations are executed is always
+ * 1) Adapt 2) Partition 3) Balance.
  * \note This setting may not be combined with \ref t8_forest_set_copy and overwrites
  * this setting.
  */

--- a/tutorials/general/t8_step2_uniform_forest.cxx
+++ b/tutorials/general/t8_step2_uniform_forest.cxx
@@ -83,7 +83,7 @@ t8_step2_build_uniform_forest (sc_MPI_Comm comm, t8_cmesh_t cmesh, int level)
   t8_forest_t forest;
   const t8_scheme *scheme = t8_scheme_new_default ();
 
-  /* Creat the uniform forest. */
+  /* Create the uniform forest. */
   forest = t8_forest_new_uniform (cmesh, scheme, level, 0, comm);
 
   return forest;

--- a/tutorials/general/t8_step3_adapt_forest.cxx
+++ b/tutorials/general/t8_step3_adapt_forest.cxx
@@ -33,7 +33,7 @@
  * of any element will change by at most +-1.
  * 
  * How you can experiment here:
- *   - Look at the paraview output files of the unifomr and the adapted forest.
+ *   - Look at the paraview output files of the uniform and the adapted forest.
  *     For the adapted forest you can apply a slice filter to look into the cube.
  *   - Run the program with different process numbers. You should see that refining is
  *     independent of the number of processes, but coarsening is not.
@@ -45,7 +45,7 @@
  *   - Use t8_productionf to print the local number of elements on each process.
  *     Notice, that the uniform forest is evenly distributed, but that the adapted forest
  *     is not. This is due to the fact that we do not repartition our forest here.
- *   - Add a maximum refinement level to the adapt_data struct and use non-recursive refinement.
+ *   - Add a maximum refinement level to the adapt_data struct and use recursive refinement.
  *     Do not refine an element if it has reached the maximum level. (Hint: scheme->element_get_level)
  */
 
@@ -80,7 +80,7 @@ T8_EXTERN_C_BEGIN ();
  * \param [in] which_tree   The process local id of the current tree.
  * \param [in] tree_class   The eclass of \a which_tree.
  * \param [in] lelement_id  The tree local index of the current element (or the first of the family).
- * \param [in] scheme           The refinement scheme for this tree's element class.
+ * \param [in] scheme       The refinement scheme for this tree's element class.
  * \param [in] is_family    if 1, the first \a num_elements entries in \a elements form a family. If 0, they do not.
  * \param [in] num_elements The number of entries in \a elements elements that are defined.
  * \param [in] elements     The element or family of elements to consider for refinement/coarsening.

--- a/tutorials/general/t8_step4_partition_balance_ghost.cxx
+++ b/tutorials/general/t8_step4_partition_balance_ghost.cxx
@@ -25,7 +25,7 @@
  * This is step4 of the t8code tutorials.
  * After generating a coarse mesh (step1), building a uniform forest
  * on it (step2) and adapting this forest (step3) 
- * we will now lear how to control the forest creation in more detail,
+ * we will now learn how to control the forest creation in more detail,
  * how to partition and balance a forest and how to generate a layer of ghost elements.
  * 
  * Partition: Each forest is distributed among the MPI processes. Partitioning a forest means
@@ -269,6 +269,8 @@ t8_step4_main (int argc, char **argv)
   t8_step3_print_forest_information (forest);
   /* Write forest to vtu files. */
   t8_forest_write_vtk_ext (forest, prefix_partition_ghost, 1, 1, 1, 1, 1, 0, 1, 0, NULL);
+  t8_global_productionf (" [step4] Wrote repartitioned forest with ghost layer to vtu files: %s*\n",
+                         prefix_partition_ghost);
 
   /*
    * Balance

--- a/tutorials/general/t8_step5_element_data.cxx
+++ b/tutorials/general/t8_step5_element_data.cxx
@@ -214,8 +214,8 @@ t8_step5_output_data_to_vtu (t8_forest_t forest, struct t8_step5_data_per_elemen
     element_volumes[ielem] = data[ielem].volume;
   }
   {
-    /* To write user defined data, we need to extended output function t8_forest_vtk_write_file
-     * from t8_forest_vtk.h. Despite writin user data, it also offers more control over which 
+    /* To write user defined data, we need the extended output function t8_forest_vtk_write_file
+     * from t8_forest_vtk.h. Despite writing user data, it also offers more control over which 
      * properties of the forest to write. */
     int write_treeid = 1;
     int write_mpirank = 1;


### PR DESCRIPTION
**_Describe your changes here:_**

- In the documentation of the adapt, partition and balance functions, it was stated that the order of execution is always 1) Adapt 2) Balance 3) Partition, although it is 1) Adapt 2) Partition 3) Balance.
- Fixed some typos in the tutorials. 
- Added one productionf in step 4.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [x] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [x] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [x] The author added the patch/minor/major label in accordance to semantic versioning.
