### PR TITLE
Update GitHub Runners

### DIFF
--- a/.github/workflows/build_cmake_tarball.yml
+++ b/.github/workflows/build_cmake_tarball.yml
@@ -41,7 +41,7 @@ jobs:
   build:
 
     if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: dlramr/t8code-ubuntu:t8-dependencies
     timeout-minutes: 90
     steps:
@@ -59,8 +59,6 @@ jobs:
       uses: nikeee/setup-pandoc@v1
     - name: Test pandoc
       run: pandoc --version
-    # On the github Ubuntu 20.04, sudo is not available by default
-    # we need it, however, to update/upgrade our packages.    
     - name: Update packages
       run: sudo apt-get update && sudo apt-get upgrade -y
     # This step is necessary to get the newest package data
@@ -99,14 +97,12 @@ jobs:
 
   test-tarball:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: dlramr/t8code-ubuntu:t8-dependencies
     timeout-minutes: 90
     steps:
     - name: install sudo
       run: apt update && apt install sudo
-    # On the github Ubuntu 20.04, sudo is not available by default
-    # we need it, however, to update/upgrade our packages.       
     - name: Update packages
       run: sudo apt-get update && sudo apt-get upgrade -y
     # This step is necessary to get the newest package data

--- a/.github/workflows/check_indentation.yml
+++ b/.github/workflows/check_indentation.yml
@@ -48,7 +48,7 @@ on:
 jobs:
   indent:
     if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
@@ -58,8 +58,6 @@ jobs:
     # Deactivated the install sudo because it failed.
     #- name: install sudo
     #  run: apt update && apt install sudo
-    # On the github Ubuntu 20.04, sudo is not available by default
-    # we need it, however, to update/upgrade our packages.
     - name: Update packages
       run: sudo apt-get update && sudo apt-get upgrade -y
     # This step is necessary to get the newest package data

--- a/.github/workflows/mattermost_issue.yml
+++ b/.github/workflows/mattermost_issue.yml
@@ -39,7 +39,7 @@ env:
 jobs:
   send_mm_message_issue:
     if: github.repository == 'DLR-AMR/t8code'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: debug_before_build
         run: echo ${{ env.message_build}}

--- a/.github/workflows/mattermost_pull_request.yml
+++ b/.github/workflows/mattermost_pull_request.yml
@@ -39,7 +39,7 @@ env:
 jobs:
   send_mm_message_pr:
     if: github.repository == 'DLR-AMR/t8code'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: debug_before_build
         run: echo ${{ env.message_build}}


### PR DESCRIPTION
**_Describe your changes here:_**
Update the GitHub runners because 20.04 is deprecated


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
