### PR TITLE
constexpr for strong types

### DIFF
--- a/src/t8_types/t8_operators.hxx
+++ b/src/t8_types/t8_operators.hxx
@@ -40,16 +40,16 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 template <typename TUnderlying, template <typename> class crtpType>
 struct t8_crtp_operator
 {
-  inline TUnderlying&
-  underlying ()
+  constexpr TUnderlying&
+  underlying () noexcept
   {
     return static_cast<TUnderlying&> (*this);
   }
 
-  inline TUnderlying const&
-  underlying () const
+  constexpr const TUnderlying&
+  underlying () const noexcept
   {
-    return static_cast<TUnderlying const&> (*this);
+    return static_cast<const TUnderlying&> (*this);
   }
 };
 
@@ -68,8 +68,8 @@ template <typename TUnderlying>
 struct Addable: t8_crtp_operator<TUnderlying, Addable>
 {
 
-  TUnderlying
-  operator+ (TUnderlying const& other)
+  constexpr TUnderlying
+  operator+ (const TUnderlying& other) const noexcept
   {
     return TUnderlying (this->underlying ().get () + other.get ());
   }
@@ -83,8 +83,8 @@ struct Addable: t8_crtp_operator<TUnderlying, Addable>
 template <typename TUnderlying>
 struct Subtractable: t8_crtp_operator<TUnderlying, Subtractable>
 {
-  TUnderlying
-  operator- (TUnderlying const& other)
+  constexpr TUnderlying
+  operator- (const TUnderlying& other) const noexcept
   {
     return TUnderlying (this->underlying ().get () - other.get ());
   }
@@ -98,8 +98,8 @@ struct Subtractable: t8_crtp_operator<TUnderlying, Subtractable>
 template <typename TUnderlying>
 struct Multipliable: t8_crtp_operator<TUnderlying, Multipliable>
 {
-  TUnderlying
-  operator* (TUnderlying const& other)
+  constexpr TUnderlying
+  operator* (const TUnderlying& other) const noexcept
   {
     return TUnderlying (this->underlying ().get () * other.get ());
   }
@@ -113,8 +113,8 @@ struct Multipliable: t8_crtp_operator<TUnderlying, Multipliable>
 template <typename TUnderlying>
 struct Dividable: t8_crtp_operator<TUnderlying, Dividable>
 {
-  TUnderlying
-  operator/ (TUnderlying const& other)
+  constexpr TUnderlying
+  operator/ (const TUnderlying& other) const noexcept
   {
     return TUnderlying (this->underlying ().get () / other.get ());
   }
@@ -128,8 +128,8 @@ struct Dividable: t8_crtp_operator<TUnderlying, Dividable>
 template <typename TUnderlying>
 struct AddAssignable: t8_crtp_operator<TUnderlying, AddAssignable>
 {
-  TUnderlying&
-  operator+= (TUnderlying const& other)
+  constexpr TUnderlying&
+  operator+= (const TUnderlying& other) noexcept
   {
     this->underlying ().get () += other.get ();
     return this->underlying ();
@@ -146,10 +146,10 @@ struct AddAssignable: t8_crtp_operator<TUnderlying, AddAssignable>
 template <typename TUnderlying>
 struct PrefixIncrementable: t8_crtp_operator<TUnderlying, PrefixIncrementable>
 {
-  TUnderlying&
-  operator++ ()
+  constexpr TUnderlying&
+  operator++ () noexcept
   {
-    this->underlying ().get ()++;
+    ++this->underlying ().get ();
     return this->underlying ();
   }
 };
@@ -164,10 +164,10 @@ struct PrefixIncrementable: t8_crtp_operator<TUnderlying, PrefixIncrementable>
 template <typename TUnderlying>
 struct PrefixDecrementable: t8_crtp_operator<TUnderlying, PrefixDecrementable>
 {
-  TUnderlying&
-  operator-- ()
+  constexpr TUnderlying&
+  operator-- () noexcept
   {
-    this->underlying ().get ()--;
+    --this->underlying ().get ();
     return this->underlying ();
   }
 };
@@ -190,10 +190,10 @@ struct Printable: t8_crtp_operator<TUnderlying, Printable>
 template <typename TUnderlying>
 struct Swapable: t8_crtp_operator<TUnderlying, Swapable>
 {
-  void
-  swap (TUnderlying& other)
+  constexpr void
+  swap (TUnderlying& lhs, TUnderlying& other) noexcept
   {
-    std::swap (this->underlying ().get (), other.get ());
+    std::swap (lhs.get (), other.get ());
   }
 };
 
@@ -205,8 +205,8 @@ struct Swapable: t8_crtp_operator<TUnderlying, Swapable>
 template <typename TUnderlying>
 struct EqualityComparable: t8_crtp_operator<TUnderlying, EqualityComparable>
 {
-  bool
-  operator== (TUnderlying const& other) const
+  constexpr bool
+  operator== (TUnderlying const& other) const noexcept
   {
     return this->underlying ().get () == other.get ();
   }

--- a/src/t8_types/t8_type.hxx
+++ b/src/t8_types/t8_type.hxx
@@ -45,9 +45,11 @@
 template <typename T, typename Parameter, template <typename> class... competence>
 class T8Type: public competence<T8Type<T, Parameter, competence...>>... {
  public:
-  explicit T8Type () = default;
+  using value_type = T;
 
-  explicit T8Type (T const& value): value_ (value)
+  explicit constexpr T8Type () = default;
+
+  explicit constexpr T8Type (const T& value): value_ (value)
   {
   }
 
@@ -60,21 +62,29 @@ class T8Type: public competence<T8Type<T, Parameter, competence...>>... {
    * \note This constructor is only enabled if T is not a reference.
    */
   template <typename T_ref = T>
-  explicit T8Type (T&& value, typename std::enable_if<!std::is_reference<T_ref> {}, std::nullptr_t>::type = nullptr)
+  explicit constexpr T8Type (T&& value,
+                             typename std::enable_if<!std::is_reference<T_ref> {}, std::nullptr_t>::type = nullptr)
     : value_ (std::move (value))
   {
   }
 
-  T&
-  get ()
+  constexpr T8Type&
+  operator= (const T& value)
+  {
+    value_ = value;
+    return *this;
+  }
+
+  constexpr T&
+  get () noexcept
   {
     return value_;
   }
 
-  T const&
-  get () const
+  constexpr T const&
+  get () const noexcept
   {
-    return value_;
+    return std::move (value_);
   }
 
  private:

--- a/test/t8_types/t8_gtest_type.cxx
+++ b/test/t8_types/t8_gtest_type.cxx
@@ -66,7 +66,7 @@ struct int_and_double_tag
 
 /* Strong types for testing */
 using DummyInt = T8Type<int, dummy_int, Addable, Subtractable, AddAssignable, Multipliable, Dividable,
-                        PrefixDecrementable, PrefixIncrementable>;
+                        PrefixDecrementable, PrefixIncrementable, EqualityComparable>;
 using DummyInt2 = T8Type<int, dummy_int_2>;
 using DummyDouble = T8Type<double, dummy_double>;
 using DummyRefInt = T8Type<int &, dummy_ref_int>;
@@ -158,9 +158,25 @@ TEST (t8_gtest_type, operators)
   EXPECT_EQ (vec1, vec2);
   Dummy3DVec vec3 ({ 2.0, 2.0, 3.0 });
   EXPECT_NE (vec1, vec3);
-  vec2.swap (vec3);
-  EXPECT_EQ (vec1, vec3);
-  EXPECT_NE (vec1, vec2);
+  swap (vec1, vec3);
+  EXPECT_NE (vec1, vec3);
+  EXPECT_EQ (vec3, vec2);
+}
+
+TEST (t8_gtest_type, use_constexpr)
+{
+  constexpr DummyInt my_int (5);
+  constexpr DummyInt my_other_int (10);
+  constexpr DummyInt my_result_int = my_int + my_other_int;
+  static_assert (my_result_int.get () == 15, "constexpr operator+ failed");
+  constexpr DummyInt my_result_int2 = my_int - my_other_int;
+  static_assert (my_result_int2.get () == -5, "constexpr operator- failed");
+  constexpr DummyInt my_result_int3 = my_int * my_other_int;
+  static_assert (my_result_int3.get () == 50, "constexpr operator* failed");
+  constexpr DummyInt my_result_int4 = my_int / my_other_int;
+  static_assert (my_result_int4.get () == 0, "constexpr operator/ failed");
+  constexpr DummyInt my_int_eq (5);
+  static_assert (my_int_eq == my_int, "constexpr operator== failed");
 }
 
 /**


### PR DESCRIPTION
Made everything in the strong type constexpr and every competence that is constexpr, too. 



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
