### PR TITLE
Printable strong types

### DIFF
--- a/src/t8_types/t8_operators.hxx
+++ b/src/t8_types/t8_operators.hxx
@@ -175,10 +175,11 @@ struct PrefixDecrementable: t8_crtp_operator<TUnderlying, PrefixDecrementable>
 template <typename TUnderlying>
 struct Printable: t8_crtp_operator<TUnderlying, Printable>
 {
-  void
-  print (std::ostream& os) const
+  friend std::ostream&
+  operator<< (std::ostream& os, const TUnderlying& obj)
   {
-    os << this->underlying ().get ();
+    os << obj.get ();
+    return os;
   }
 };
 
@@ -211,19 +212,6 @@ struct EqualityComparable: t8_crtp_operator<TUnderlying, EqualityComparable>
     return this->underlying ().get () == other.get ();
   }
 };
-
-/**
- * \brief A template for << types. Provides the << operator.
- * 
- * \tparam T 
- */
-template <typename TUnderlying, typename Parameter>
-std::ostream&
-operator<< (std::ostream& os, T8Type<TUnderlying, Parameter> const& p)
-{
-  p.print (os);
-  return os;
-}
 
 /**
  * \brief A template for hashable types. Used to make a type hashable.

--- a/src/t8_types/t8_operators.hxx
+++ b/src/t8_types/t8_operators.hxx
@@ -146,7 +146,7 @@ struct AddAssignable: t8_crtp_operator<TUnderlying, AddAssignable>
 template <typename TUnderlying>
 struct PrefixIncrementable: t8_crtp_operator<TUnderlying, PrefixIncrementable>
 {
-  constexpr TUnderlying&
+  TUnderlying&
   operator++ () noexcept
   {
     ++this->underlying ().get ();
@@ -164,7 +164,7 @@ struct PrefixIncrementable: t8_crtp_operator<TUnderlying, PrefixIncrementable>
 template <typename TUnderlying>
 struct PrefixDecrementable: t8_crtp_operator<TUnderlying, PrefixDecrementable>
 {
-  constexpr TUnderlying&
+  TUnderlying&
   operator-- () noexcept
   {
     --this->underlying ().get ();

--- a/test/t8_types/t8_gtest_type.cxx
+++ b/test/t8_types/t8_gtest_type.cxx
@@ -177,6 +177,7 @@ TEST (t8_gtest_type, use_constexpr)
   static_assert (my_result_int4.get () == 0, "constexpr operator/ failed");
   constexpr DummyInt my_int_eq (5);
   static_assert (my_int_eq == my_int, "constexpr operator== failed");
+  static_assert (my_int_eq != my_other_int, "constexpr operator!= failed");
 }
 
 /**

--- a/test/t8_types/t8_gtest_type.cxx
+++ b/test/t8_types/t8_gtest_type.cxx
@@ -26,6 +26,7 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 #include <t8_types/t8_operators.hxx>
 #include <typeinfo>
 #include <numeric>
+#include <iostream>
 
 /* Tags to differencce between strong types */
 struct dummy_int
@@ -66,7 +67,7 @@ struct int_and_double_tag
 
 /* Strong types for testing */
 using DummyInt = T8Type<int, dummy_int, Addable, Subtractable, AddAssignable, Multipliable, Dividable,
-                        PrefixDecrementable, PrefixIncrementable, EqualityComparable>;
+                        PrefixDecrementable, PrefixIncrementable, EqualityComparable, Printable>;
 using DummyInt2 = T8Type<int, dummy_int_2>;
 using DummyDouble = T8Type<double, dummy_double>;
 using DummyRefInt = T8Type<int &, dummy_ref_int>;
@@ -114,6 +115,7 @@ TEST (t8_gtest_type, strong_type_size)
 TEST (t8_gtest_type, strong_type_get)
 {
   DummyInt dummy_int (5);
+  std::cout << "dummy_int: " << dummy_int << "\n";
   DummyInt2 dummy_int_2 (10);
   DummyDouble dummy_double (3.14);
   DummyRefInt dummy_ref_int (dummy_int.get ());


### PR DESCRIPTION
Being printable is now a proper toggable competence of a T8Type


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
