### PR TITLE
Remove doubled underscores in test names

### DIFF
--- a/test/t8_cmesh_generator/t8_cmesh_example_sets.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_example_sets.hxx
@@ -52,7 +52,7 @@ auto pretty_print_base_example = [] (const testing::TestParamInfo<cmesh_example_
 auto pretty_print_base_example_scheme = [] (const testing::TestParamInfo<std::tuple<int, cmesh_example_base *>> &info) {
   std::string name;
   std::get<1> (info.param)->param_to_string (name);
-  name += std::string ("scheme_") + std::to_string (std::get<0> (info.param));
+  name += std::string ("_scheme_") + std::to_string (std::get<0> (info.param));
   name += std::string ("_") + std::to_string (info.index);
   return name;
 };

--- a/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_bigmesh_param.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_bigmesh_param.hxx
@@ -51,7 +51,7 @@ example_set *cmesh_example
     std::make_pair (cmesh_params::eclasses.begin (), cmesh_params::eclasses.end ()),
     std::make_pair (cmesh_params::large_mesh.begin (), cmesh_params::large_mesh.end ()),
     std::make_pair (cmesh_params::my_comms.begin (), cmesh_params::my_comms.end ()), bigmesh, make_param_string_wrapper,
-    "t8_cmesh_new_bigmesh_");
+    "t8_cmesh_new_bigmesh");
 }  // namespace new_bigmesh
 
 #endif /* T8_CMESH_NEW_BIGMESH_PARAM_HXX */

--- a/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_comm.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_comm.hxx
@@ -52,18 +52,18 @@ std::vector<std::function<t8_cmesh_t (sc_MPI_Comm)>> cmesh_functions = { t8_cmes
                                                                          t8_cmesh_new_hybrid_gate_deformed,
                                                                          t8_cmesh_new_full_hybrid };
 
-std::vector<std::string> names = { "t8_cmesh_new_periodic_tri_",
-                                   "t8_cmesh_new_periodic_hybrid_",
-                                   "t8_cmesh_new_periodic_line_more_trees_",
-                                   "t8_cmesh_new_line_zigzag_",
-                                   "t8_cmesh_new_prism_deformed_",
-                                   "t8_cmesh_new_pyramid_deformed_",
-                                   "t8_cmesh_new_prism_cake_funny_oriented_",
-                                   "t8_cmesh_new_prism_geometry_",
-                                   "t8_cmesh_new_tet_orientation_test_",
-                                   "t8_cmesh_new_hybrid_gate_",
-                                   "t8_cmesh_new_hybrid_gate_deformed_",
-                                   "t8_cmesh_new_full_hybrid_" };
+std::vector<std::string> names = { "t8_cmesh_new_periodic_tri",
+                                   "t8_cmesh_new_periodic_hybrid",
+                                   "t8_cmesh_new_periodic_line_more_trees",
+                                   "t8_cmesh_new_line_zigzag",
+                                   "t8_cmesh_new_prism_deformed",
+                                   "t8_cmesh_new_pyramid_deformed",
+                                   "t8_cmesh_new_prism_cake_funny_oriented",
+                                   "t8_cmesh_new_prism_geometry",
+                                   "t8_cmesh_new_tet_orientation_test",
+                                   "t8_cmesh_new_hybrid_gate",
+                                   "t8_cmesh_new_hybrid_gate_deformed",
+                                   "t8_cmesh_new_full_hybrid" };
 
 example_set *cmesh_example
   = (example_set *) new cmesh_cartesian_product_params<decltype (cmesh_params::my_comms.begin ())> (

--- a/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_disjoint_bricks_param.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_disjoint_bricks_param.hxx
@@ -60,7 +60,7 @@ example_set *cmesh_example = (example_set *) new cmesh_cartesian_product_params<
   std::make_pair (cmesh_params::periodic.begin (), cmesh_params::periodic.end ()),
   std::make_pair (cmesh_params::periodic.begin (), cmesh_params::periodic.end ()),
   std::make_pair (cmesh_params::my_comms.begin (), cmesh_params::my_comms.end ()), disjoint_bricks,
-  make_param_string_wrapper, "t8_cmesh_new_disjoint_brick_");
+  make_param_string_wrapper, "t8_cmesh_new_disjoint_brick");
 }  // namespace new_disjoint_bricks
 
 #endif /* T8_CMESH_NEW_DISJOINT_BRICKS_PARAM_HXX */

--- a/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_empty.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_empty.hxx
@@ -52,7 +52,7 @@ example_set *cmesh_example
     std::make_pair (cmesh_params::my_comms.begin (), cmesh_params::my_comms.end ()),
     std::make_pair (cmesh_params::partition.begin (), cmesh_params::partition.end ()),
     std::make_pair (cmesh_params::do_bcast.begin (), cmesh_params::do_bcast.end ()), new_from_class_wrapper,
-    print_function, "t8_cmesh_new_empty_");
+    print_function, "t8_cmesh_new_empty");
 } /* namespace new_empty */
 
 #endif /* T8_CMESH_NEW_EMPTY_HXX */

--- a/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_from_class_param.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_from_class_param.hxx
@@ -49,7 +49,7 @@ example_set *cmesh_example
                                                        decltype (cmesh_params::my_comms.begin ())> (
     std::make_pair (cmesh_params::eclasses.begin (), cmesh_params::eclasses.end ()),
     std::make_pair (cmesh_params::my_comms.begin (), cmesh_params::my_comms.end ()), new_from_class_wrapper,
-    print_function, "t8_cmesh_new_from_class_");
+    print_function, "t8_cmesh_new_from_class");
 
 }  // namespace new_from_class
 

--- a/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_hypercube_param.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_hypercube_param.hxx
@@ -63,7 +63,7 @@ example_set *cmesh_example = (example_set *) new cmesh_cartesian_product_params<
   std::make_pair (cmesh_params::do_bcast.begin (), cmesh_params::do_bcast.end ()),
   std::make_pair (cmesh_params::partition.begin (), cmesh_params::partition.end ()),
   std::make_pair (cmesh_params::periodic.begin (), cmesh_params::periodic.end ()), cmesh_wrapper, param_to_string,
-  "t8_cmesh_new_hypercube_");
+  "t8_cmesh_new_hypercube");
 
 example_set *cmesh_example_pyra = (example_set *) new cmesh_cartesian_product_params<
   decltype (periodic_eclasses.begin ()), decltype (cmesh_params::my_comms.begin ()),
@@ -74,7 +74,7 @@ example_set *cmesh_example_pyra = (example_set *) new cmesh_cartesian_product_pa
   std::make_pair (cmesh_params::do_bcast.begin (), cmesh_params::do_bcast.end ()),
   std::make_pair (cmesh_params::partition.begin (), cmesh_params::partition.end ()),
   std::make_pair (cmesh_params::no_periodic.begin (), cmesh_params::no_periodic.end ()), cmesh_wrapper, param_to_string,
-  "t8_cmesh_new_hypercube_");
+  "t8_cmesh_new_hypercube");
 }  // namespace new_hypercube_cmesh
 
 #endif /* T8_CMESH_NEW_HYPERCUBE_PARAM_HXX */

--- a/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_periodic.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_periodic.hxx
@@ -47,7 +47,7 @@ example_set *cmesh_example
                                                        decltype (cmesh_params::dims.begin ())> (
     std::make_pair (cmesh_params::my_comms.begin (), cmesh_params::my_comms.end ()),
     std::make_pair (cmesh_params::dims.begin (), cmesh_params::dims.end ()), new_from_periodic_wrapper, print_function,
-    "t8_cmesh_new_periodic_");
+    "t8_cmesh_new_periodic");
 }  // namespace new_periodic
 
 #endif /* T8_CMESH_NEW_PERIODIC_HXX */

--- a/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_prism_cake_param.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_prism_cake_param.hxx
@@ -46,7 +46,7 @@ example_set *cmesh_example
                                                        decltype (cmesh_params::num_prisms.begin ())> (
     std::make_pair (cmesh_params::my_comms.begin (), cmesh_params::my_comms.end ()),
     std::make_pair (cmesh_params::num_prisms.begin (), cmesh_params::num_prisms.end ()), prism_cake,
-    make_param_string_wrapper, "t8_cmesh_new_prism_cake_");
+    make_param_string_wrapper, "t8_cmesh_new_prism_cake");
 }  // namespace new_prism_cake
 
 #endif /* T8_CMESH_NEW_PRISM_CAKE_PARAM_HXX */


### PR DESCRIPTION
**_Describe your changes here:_**
- Problem was that scheme was appended without _ (-> added_)
- and we had two underscores for all other test (as names ended with _ and the functions make_param_string startet with a delimiter. I chose to remove the _ from the names.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
