### PR TITLE
Valgrind check in CI

### DIFF
--- a/.github/workflows/build_cmake_tarball.yml
+++ b/.github/workflows/build_cmake_tarball.yml
@@ -149,5 +149,4 @@ jobs:
       with:
         name: build_tar.log
         path: build_tar/test-suite.log
-
-
+      

--- a/.github/workflows/check_indentation.yml
+++ b/.github/workflows/check_indentation.yml
@@ -35,7 +35,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch: # Be able to trigger this manually on github.com
   # Run every night at 1:05
   schedule:

--- a/.github/workflows/check_indentation.yml
+++ b/.github/workflows/check_indentation.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Indentation check
       run: cd scripts/ && ./check_if_all_files_indented.scp &> >(tee -a indent_script_output.txt)
     - name: Archive script output
-    # Do this regardess of the result of the previous step.
+    # Do this regardless of the result of the previous step.
     # We especially want to upload the result when the check fails.
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/spell_check.yml
+++ b/.github/workflows/spell_check.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch: # Be able to trigger this manually on github.com
 
 jobs:

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -59,65 +59,99 @@ jobs:
       MPI: ${{ matrix.MPI }}
   
   # Run parallel tests for sc and p4est with and without MPI
-  sc_p4est_tests:
-    if: ((github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule'))
-    needs: preparation
-    uses: ./.github/workflows/tests_cmake_sc_p4est.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        MPI: [OFF, ON]
-        include: 
-          - MAKEFLAGS: -j4
-    with:
-      MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
-      MPI: ${{ matrix.MPI }}
+  # sc_p4est_tests:
+  #   if: ((github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule'))
+  #   needs: preparation
+  #   uses: ./.github/workflows/tests_cmake_sc_p4est.yml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       MPI: [OFF, ON]
+  #       include: 
+  #         - MAKEFLAGS: -j4
+  #   with:
+  #     MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
+  #     MPI: ${{ matrix.MPI }}
 
   # Run t8code tests with and without MPI and in serial and debug mode
-  t8code_tests:
-    if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
-    uses: ./.github/workflows/tests_cmake_t8code.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        MPI: [OFF, ON]
-        BUILD_TYPE: [Debug, Release]
-        include: 
-          - MAKEFLAGS: -j4
-    needs: preparation
-    with:
-      MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
-      MPI: ${{ matrix.MPI }}
-      BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
-      TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
+  # t8code_tests:
+  #   if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
+  #   uses: ./.github/workflows/tests_cmake_t8code.yml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       MPI: [OFF, ON]
+  #       BUILD_TYPE: [Debug, Release]
+  #       include: 
+  #         - MAKEFLAGS: -j4
+  #   needs: preparation
+  #   with:
+  #     MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
+  #     MPI: ${{ matrix.MPI }}
+  #     BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
+  #     TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
       
   # Run t8code linkage tests with and without MPI and in serial and debug mode
-  t8code_linkage_tests:
-    if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
-    uses: ./.github/workflows/tests_cmake_t8code_linkage.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        MPI: [OFF, ON]
-        BUILD_TYPE: [Debug, Release]
-        include: 
-          - MAKEFLAGS: -j4
-    needs: preparation
-    with:
-      MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
-      MPI: ${{ matrix.MPI }}
-      BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
-      TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
+  # t8code_linkage_tests:
+  #   if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
+  #   uses: ./.github/workflows/tests_cmake_t8code_linkage.yml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       MPI: [OFF, ON]
+  #       BUILD_TYPE: [Debug, Release]
+  #       include: 
+  #         - MAKEFLAGS: -j4
+  #   needs: preparation
+  #   with:
+  #     MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
+  #     MPI: ${{ matrix.MPI }}
+  #     BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
+  #     TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
 
   # Run t8code linkage tests with and without MPI and in serial and debug mode
-  t8code_api_tests:
+  # t8code_api_tests:
+  #   if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
+  #   uses: ./.github/workflows/tests_cmake_t8code_api.yml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       MPI: [ON] # For now the fortran API only supports building with MPI
+  #       BUILD_TYPE: [Debug, Release]
+  #       include: 
+  #         - MAKEFLAGS: -j4
+  #   needs: preparation
+  #   with:
+  #     MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
+  #     MPI: ${{ matrix.MPI }}
+  #     BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
+  #     TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
+  
+  # Run t8code tests with shipped submodules. This test is only for the build system, so only one config is tested.
+  # t8code_w_shipped_submodules_tests:
+  #   if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
+  #   uses: ./.github/workflows/tests_cmake_t8code_w_shipped_submodules.yml
+  #   with:
+  #     MAKEFLAGS: -j4
+  #     MPI: ON
+  #     BUILD_TYPE: Debug
+  #     TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
+
+  # t8code_tarball:
+  #   if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
+  #   uses: ./.github/workflows/build_cmake_tarball.yml
+  #   needs: [preparation, sc_p4est_tests, t8code_tests, t8code_linkage_tests, t8code_api_tests, t8code_w_shipped_submodules_tests]
+  #   with:
+  #     TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
+
+  t8code_valgrind:
     if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
-    uses: ./.github/workflows/tests_cmake_t8code_api.yml
+    uses: ./.github/workflows/tests_cmake_valgrind.yml
     strategy:
       fail-fast: false
       matrix:
-        MPI: [ON] # For now the fortran API only supports building with MPI
-        BUILD_TYPE: [Debug, Release]
+        MPI: ON
+        BUILD_TYPE: Debug
         include: 
           - MAKEFLAGS: -j4
     needs: preparation
@@ -125,21 +159,4 @@ jobs:
       MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
       MPI: ${{ matrix.MPI }}
       BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
-      TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
-  
-  # Run t8code tests with shipped submodules. This test is only for the build system, so only one config is tested.
-  t8code_w_shipped_submodules_tests:
-    if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
-    uses: ./.github/workflows/tests_cmake_t8code_w_shipped_submodules.yml
-    with:
-      MAKEFLAGS: -j4
-      MPI: ON
-      BUILD_TYPE: Debug
-      TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
-
-  t8code_tarball:
-    if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
-    uses: ./.github/workflows/build_cmake_tarball.yml
-    needs: [preparation, sc_p4est_tests, t8code_tests, t8code_linkage_tests, t8code_api_tests, t8code_w_shipped_submodules_tests]
-    with:
-      TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
+      TEST_LEVEL: 2 # Set test level to two as valgrind can be very slow.

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -147,16 +147,9 @@ jobs:
   t8code_valgrind:
     if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
     uses: ./.github/workflows/tests_cmake_valgrind.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        MPI: ON
-        BUILD_TYPE: Debug
-        include: 
-          - MAKEFLAGS: -j4
     needs: preparation
     with:
-      MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
-      MPI: ${{ matrix.MPI }}
-      BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
-      TEST_LEVEL: 2 # Set test level to two as valgrind can be very slow.
+      MAKEFLAGS: -j4
+      MPI: ON
+      BUILD_TYPE: Debug
+      TEST_LEVEL: 2

--- a/.github/workflows/tests_cmake_valgrind.yml
+++ b/.github/workflows/tests_cmake_valgrind.yml
@@ -102,4 +102,4 @@ jobs:
     - name: Valgrind Checker
       uses: Ximaz/valgrind-action@1.2.1
       with:
-        binary_path: build/test/t8_gtest_cmesh_bcast_parallel
+        binary_path: build/test/t8_cmesh/t8_gtest_cmesh_bcast_parallel

--- a/.github/workflows/tests_cmake_valgrind.yml
+++ b/.github/workflows/tests_cmake_valgrind.yml
@@ -5,7 +5,7 @@ name: Valgrind check
 #  t8code is a C library to manage a collection (a forest) of multiple
 #  connected adaptive space-trees of general element types in parallel.
 #
-#  Copyright (C) 2024 the developers
+#  Copyright (C) 2025 the developers
 #
 #  t8code is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -114,7 +114,7 @@ jobs:
       with:
         name: test-suite_${{ inputs.BUILD_TYPE }}_MPI_${{ inputs.MPI }}.log
         path: build/Testing/Temporary/LastTest.log
-    - name: Run Valgrind
+    - name: Valgrind Checker
       uses: Ximaz/valgrind-action@1.2.1
       with:
         binary_path: build/test/t8_gtest_cmesh_bcast_parallel

--- a/.github/workflows/tests_cmake_valgrind.yml
+++ b/.github/workflows/tests_cmake_valgrind.yml
@@ -118,3 +118,4 @@ jobs:
       uses: Ximaz/valgrind-action@1.2.1
       with:
         binary_path: build/test/t8_gtest_cmesh_bcast_parallel
+

--- a/.github/workflows/tests_cmake_valgrind.yml
+++ b/.github/workflows/tests_cmake_valgrind.yml
@@ -45,7 +45,7 @@ on:
         description: 'Test level used for configuring (0 for full tests, 1 for less thorough tests, 2 for minimal tests)'
 
 jobs:  
-  t8code_valgrind:
+  valgrind_build:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     container: dlramr/t8code-ubuntu:t8-dependencies
@@ -99,7 +99,33 @@ jobs:
       run: cd build && ninja $MAKEFLAGS
     - name: ninja install
       run: cd build && ninja install $MAKEFLAGS
+    - name: create build dir archive
+      shell: bash
+      run: tar -czf build.tar.gz build
+    - name: Upload directory
+      uses: actions/upload-artifact@v4
+      with:
+        name: valgrind-build-${{ inputs.MAKEFLAGS }}-${{ inputs.MPI }}-${{ inputs.BUILD_TYPE }}-${{ inputs.TEST_LEVEL }}
+        path: build.tar.gz
+        retention-days: 1
+
+  jobs_valgrind:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    container: dlramr/t8code-ubuntu:t8-dependencies
+    needs: valgrind_build
+    strategy:
+      matrix:
+        BIN_PATHS: [build/test/t8_cmesh/t8_gtest_cmesh_bcast_parallel, build/test/t8_gtest_cmesh_copy_serial]
+    steps:
+    - name: Download directory
+      uses: actions/download-artifact@v4
+      with:
+        name: valgrind-build-${{ inputs.MAKEFLAGS }}-${{ inputs.MPI }}-${{ inputs.BUILD_TYPE }}-${{ inputs.TEST_LEVEL }}
+    - name: extract build archive
+      shell: bash
+      run: tar -xzf build.tar.gz
     - name: Valgrind Checker
       uses: Ximaz/valgrind-action@1.2.1
       with:
-        binary_path: build/test/t8_cmesh/t8_gtest_cmesh_bcast_parallel
+        binary_path: ${{ matrix.BIN_PATHS }}

--- a/.github/workflows/tests_cmake_valgrind.yml
+++ b/.github/workflows/tests_cmake_valgrind.yml
@@ -103,4 +103,3 @@ jobs:
       uses: Ximaz/valgrind-action@1.2.1
       with:
         binary_path: build/test/t8_gtest_cmesh_bcast_parallel
-

--- a/.github/workflows/tests_cmake_valgrind.yml
+++ b/.github/workflows/tests_cmake_valgrind.yml
@@ -1,0 +1,120 @@
+name: Valgrind check
+
+
+#  This file is part of t8code.
+#  t8code is a C library to manage a collection (a forest) of multiple
+#  connected adaptive space-trees of general element types in parallel.
+#
+#  Copyright (C) 2024 the developers
+#
+#  t8code is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  t8code is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with t8code; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+env:
+  DEBUG_CONFIG: "-O1"
+
+on:
+  workflow_call:
+    inputs:
+      MAKEFLAGS:
+        required: true
+        type: string
+        description: 'Make flags to use for compilation (like -j4)'
+      MPI:
+        required: true
+        type: string
+        description: 'Use MPI for compilation (ON/OFF)'
+      BUILD_TYPE:
+        required: true
+        type: string
+        description: 'Build type (Release/Debug)'
+      TEST_LEVEL:
+        required: true
+        type: number
+        description: 'Test level used for configuring (0 for full tests, 1 for less thorough tests, 2 for minimal tests)'
+
+jobs:  
+  t8code_valgrind:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    container: dlramr/t8code-ubuntu:t8-dependencies
+    steps:
+#
+# Setup
+#
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: SC_P4EST_MPI_${{ inputs.MPI }}
+    - name: untar artifact
+      run: tar -xf artifact.tar && rm artifact.tar
+    - name: Update packages
+      run: apt-get update && apt-get upgrade -y
+      # This seems to be necessary because of the docker container
+    - name: disable ownership checks
+      run: git config --global --add safe.directory '*'
+    - name: Get input vars
+      run: export MAKEFLAGS="${{ inputs.MAKEFLAGS }}"
+        && export MPI="${{ inputs.MPI }}"
+        && export BUILD_TYPE="${{ inputs.BUILD_TYPE }}"
+        && export SC_PATH=$PWD/sc/build/$BUILD_TYPE
+        && export P4EST_PATH=$PWD/p4est/build/$BUILD_TYPE
+        && echo MAKEFLAGS="$MAKEFLAGS" >> $GITHUB_ENV
+        && echo MPI="$MPI" >> $GITHUB_ENV
+        && echo BUILD_TYPE="$BUILD_TYPE" >> $GITHUB_ENV
+        && echo SC_PATH="$SC_PATH" >> $GITHUB_ENV
+        && echo P4EST_PATH="$P4EST_PATH" >> $GITHUB_ENV
+#
+#  T8CODE
+#
+    # build config vars
+    - name: Set test level
+      if: ${{ inputs.TEST_LEVEL != 0 }}
+      run: export TEST_LEVEL_FLAG="-DT8CODE_TEST_LEVEL=${{ inputs.TEST_LEVEL }}"
+           && echo TEST_LEVEL_FLAG="$TEST_LEVEL_FLAG" >> $GITHUB_ENV
+    - name: build config variables
+      run: export CONFIG_OPTIONS="${TEST_LEVEL_FLAG} -GNinja -DCMAKE_C_FLAGS_DEBUG=${DEBUG_CONFIG} -DCMAKE_CXX_FLAGS_DEBUG=${DEBUG_CONFIG} -DT8CODE_USE_SYSTEM_SC=ON -DT8CODE_USE_SYSTEM_P4EST=ON -DT8CODE_BUILD_PEDANTIC=ON -DT8CODE_BUILD_WALL=ON -DT8CODE_BUILD_WERROR=ON -DT8CODE_ENABLE_MPI=$MPI -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSC_DIR=$SC_PATH/install/cmake -DP4EST_DIR=$P4EST_PATH/install/cmake"
+        && echo CONFIG_OPTIONS="$CONFIG_OPTIONS" >> $GITHUB_ENV
+    # cmake and test
+    - name: cmake
+      run: mkdir build && cd build && cmake ../ $CONFIG_OPTIONS
+    - name: OnFailUploadLog
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: cmake_${{ inputs.BUILD_TYPE }}_MPI_${{ inputs.MPI }}.log
+        path: build/CMakeFiles/CMakeOutput.log
+    - name: ninja
+      run: cd build && ninja $MAKEFLAGS
+    - name: ninja install
+      run: cd build && ninja install $MAKEFLAGS
+    - name: serial tests (if MPI is enabled)
+      run: cd build && ctest $MAKEFLAGS -R _serial
+      if: ${{ inputs.MPI == 'ON' }}
+    - name: parallel tests (if MPI is enabled)
+      run: cd build && ctest -R _parallel
+      if: ${{ inputs.MPI == 'ON' }}
+    - name: tests (if MPI is disabled)
+      run: cd build && ctest $MAKEFLAGS
+      if: ${{ inputs.MPI == 'OFF' }}
+    - name: OnFailUploadLog
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-suite_${{ inputs.BUILD_TYPE }}_MPI_${{ inputs.MPI }}.log
+        path: build/Testing/Temporary/LastTest.log
+    - name: Run Valgrind
+      uses: Ximaz/valgrind-action@1.2.1
+      with:
+        binary_path: build/test/t8_gtest_cmesh_bcast_parallel

--- a/.github/workflows/tests_cmake_valgrind.yml
+++ b/.github/workflows/tests_cmake_valgrind.yml
@@ -118,7 +118,29 @@ jobs:
       matrix:
         BIN_PATHS: [build/test/t8_cmesh/t8_gtest_cmesh_bcast_parallel, build/test/t8_gtest_cmesh_copy_serial]
     steps:
-    - name: Download directory
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: SC_P4EST_MPI_${{ inputs.MPI }}
+    - name: untar artifact
+      run: tar -xf artifact.tar && rm artifact.tar
+    - name: Update packages
+      run: apt-get update && apt-get upgrade -y
+      # This seems to be necessary because of the docker container
+    - name: disable ownership checks
+      run: git config --global --add safe.directory '*'
+    - name: Get input vars
+      run: export MAKEFLAGS="${{ inputs.MAKEFLAGS }}"
+        && export MPI="${{ inputs.MPI }}"
+        && export BUILD_TYPE="${{ inputs.BUILD_TYPE }}"
+        && export SC_PATH=$PWD/sc/build/$BUILD_TYPE
+        && export P4EST_PATH=$PWD/p4est/build/$BUILD_TYPE
+        && echo MAKEFLAGS="$MAKEFLAGS" >> $GITHUB_ENV
+        && echo MPI="$MPI" >> $GITHUB_ENV
+        && echo BUILD_TYPE="$BUILD_TYPE" >> $GITHUB_ENV
+        && echo SC_PATH="$SC_PATH" >> $GITHUB_ENV
+        && echo P4EST_PATH="$P4EST_PATH" >> $GITHUB_ENV
+    - name: Download build directory
       uses: actions/download-artifact@v4
       with:
         name: valgrind-build-${{ inputs.MAKEFLAGS }}-${{ inputs.MPI }}-${{ inputs.BUILD_TYPE }}-${{ inputs.TEST_LEVEL }}

--- a/.github/workflows/tests_cmake_valgrind.yml
+++ b/.github/workflows/tests_cmake_valgrind.yml
@@ -99,21 +99,6 @@ jobs:
       run: cd build && ninja $MAKEFLAGS
     - name: ninja install
       run: cd build && ninja install $MAKEFLAGS
-    - name: serial tests (if MPI is enabled)
-      run: cd build && ctest $MAKEFLAGS -R _serial
-      if: ${{ inputs.MPI == 'ON' }}
-    - name: parallel tests (if MPI is enabled)
-      run: cd build && ctest -R _parallel
-      if: ${{ inputs.MPI == 'ON' }}
-    - name: tests (if MPI is disabled)
-      run: cd build && ctest $MAKEFLAGS
-      if: ${{ inputs.MPI == 'OFF' }}
-    - name: OnFailUploadLog
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-suite_${{ inputs.BUILD_TYPE }}_MPI_${{ inputs.MPI }}.log
-        path: build/Testing/Temporary/LastTest.log
     - name: Valgrind Checker
       uses: Ximaz/valgrind-action@1.2.1
       with:


### PR DESCRIPTION
**_Describe your changes here:_**



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
