### PR TITLE
Improve CI to a more finegrained CI

### DIFF
--- a/.github/workflows/check_indentation.yml
+++ b/.github/workflows/check_indentation.yml
@@ -32,9 +32,6 @@ name: t8code indentation check
 
 on:
   merge_group:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch: # Be able to trigger this manually on github.com
   # Run every night at 1:05

--- a/.github/workflows/spell_check.yml
+++ b/.github/workflows/spell_check.yml
@@ -2,9 +2,6 @@ name: spell_check
 
 on:
   merge_group:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch: # Be able to trigger this manually on github.com
 

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -138,7 +138,7 @@ jobs:
       TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
 
   t8code_tarball:
-    if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
+    if: (github.event_name == 'schedule' || github.event_name == 'merge_group') && github.repository == 'DLR-AMR/t8code'
     uses: ./.github/workflows/build_cmake_tarball.yml
     needs: [preparation, sc_p4est_tests, t8code_tests, t8code_linkage_tests, t8code_api_tests, t8code_w_shipped_submodules_tests]
     with:

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -57,21 +57,19 @@ jobs:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
         fetch-depth: 0
-    - name: get the latest commit message
-      run: |
-        latest_commit_message=$(git log -1 --pretty=%B)
-        echo "Latest commit message: $latest_commit_message"
     - name: trigger the testsuite
       run: |
         if [[ "${{ github.event_name }}" == "schedule" && "${{ github.repository }}" == "DLR-AMR/t8code" ]]; then
           echo "Scheduled run for DLR-AMR/t8code, proceeding with CI."
           exit 0
         fi
+        latest_commit_message=$(git log -1 --pretty=%B)
+        echo "Latest commit message: $latest_commit_message"
         if [[ "${{ github.event_name }}" != "schedule" ]]; then
           if [[ "${{ github.event.pull_request.draft }}" == "false" ]]; then
             echo "Not a draft PR, proceeding with CI."
             exit 0
-          elif [[ "${{ github.event.pull_request.draft }}" == "true" && "$latest_commit_message" == *"[run CI]"* ]]; then
+            elif [[ "${{ github.event.pull_request.draft }}" == "true" && "$latest_commit_message" == *"[run CI]"* ]]; then
             echo "Draft PR with '[run CI]' in the latest commit message, proceeding with CI."
             exit 0
           fi

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -32,9 +32,6 @@ name: t8code CMake testsuite
 
 on:
   merge_group:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch: # Be able to trigger this manually on github.com
   # Run every night at 1:10

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -175,7 +175,6 @@ jobs:
       TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
 
   t8code_tarball:
-    if: github.event_name == 'merge_group' && github.repository == 'DLR-AMR/t8code'
     uses: ./.github/workflows/build_cmake_tarball.yml
     needs: [preparation, sc_p4est_tests, t8code_tests, t8code_linkage_tests, t8code_api_tests, t8code_w_shipped_submodules_tests]
     with:

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -67,6 +67,10 @@ jobs:
           echo "Scheduled run for DLR-AMR/t8code, proceeding with CI."
           echo "RUN_CI=true" >> $GITHUB_OUTPUT
           exit 0
+        elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+          echo "Merge group event, proceeding with CI."
+          echo "RUN_CI=true" >> $GITHUB_OUTPUT
+          exit 0
         fi
         latest_commit_message=$(git log -1 --pretty=%B)
         echo "Latest commit message: $latest_commit_message"

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -38,10 +38,53 @@ on:
   schedule:
       - cron:  '10 1 * * *'
 
+# The CI pipeline should:
+# - fully run in the merge queue with the full test suite
+# - not run on Draft PRs
+# - run on Draft PRs, IF the latest commit message contains '[run CI]'
+# - run on scheduled runs for the DLR-AMR/t8code repository
+# - run on all other pull request events
+# These conditions are checked in the fine_grained_trigger job. If it completes successfully, it triggers the preparation job, 
+# which triggers the actual tests. 
+# The job to build the tarball is only triggered on merge_group events for the DLR-AMR/t8code repository.
+
 jobs:
+  fine_grained_trigger:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+        fetch-depth: 0
+    - name: get the latest commit message
+      run: |
+        latest_commit_message=$(git log -1 --pretty=%B)
+        echo "Latest commit message: $latest_commit_message"
+    - name: trigger the testsuite
+      run: |
+        if [[ "${{ github.event.pull_request.draft }}" == "false" ]]; then
+          echo "Not a draft PR, proceeding with CI."
+          exit 0
+        elif [[ "${{ github.event.pull_request.draft }}" == "true" && "$latest_commit_message" == *"[run CI]"* ]]; then
+          echo "Draft PR with '[run CI]' in the latest commit message, proceeding with CI."
+          exit 0
+        elif [[ "${{ github.event_name }}" == "schedule" && "${{ github.repository }}" == "DLR-AMR/t8code" ]]; then
+          echo "Scheduled run for DLR-AMR/t8code, proceeding with CI."
+          exit 0
+        elif [[ "${{ github.event_name }}" != "schedule" ]]; then
+          echo "Event is not schedule, proceeding with CI."
+          exit 0
+        else
+          echo "Conditions not met, skipping CI."
+          exit 1
+        fi
+
+
+
   # Preparation step for tests. Repo is cloned and sc + p4est are compiled with and without MPI.
   preparation:
-    if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
+    needs: [fine_grained_trigger]
     uses: ./.github/workflows/tests_cmake_preparation.yml
     strategy:
       fail-fast: false
@@ -57,7 +100,6 @@ jobs:
   
   # Run parallel tests for sc and p4est with and without MPI
   sc_p4est_tests:
-    if: ((github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule'))
     needs: preparation
     uses: ./.github/workflows/tests_cmake_sc_p4est.yml
     strategy:
@@ -72,7 +114,7 @@ jobs:
 
   # Run t8code tests with and without MPI and in serial and debug mode
   t8code_tests:
-    if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
+    needs: preparation
     uses: ./.github/workflows/tests_cmake_t8code.yml
     strategy:
       fail-fast: false
@@ -81,7 +123,6 @@ jobs:
         BUILD_TYPE: [Debug, Release]
         include: 
           - MAKEFLAGS: -j4
-    needs: preparation
     with:
       MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
       MPI: ${{ matrix.MPI }}
@@ -90,7 +131,7 @@ jobs:
       
   # Run t8code linkage tests with and without MPI and in serial and debug mode
   t8code_linkage_tests:
-    if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
+    needs: preparation
     uses: ./.github/workflows/tests_cmake_t8code_linkage.yml
     strategy:
       fail-fast: false
@@ -99,7 +140,6 @@ jobs:
         BUILD_TYPE: [Debug, Release]
         include: 
           - MAKEFLAGS: -j4
-    needs: preparation
     with:
       MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
       MPI: ${{ matrix.MPI }}
@@ -108,7 +148,7 @@ jobs:
 
   # Run t8code linkage tests with and without MPI and in serial and debug mode
   t8code_api_tests:
-    if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
+    needs: preparation
     uses: ./.github/workflows/tests_cmake_t8code_api.yml
     strategy:
       fail-fast: false
@@ -117,7 +157,6 @@ jobs:
         BUILD_TYPE: [Debug, Release]
         include: 
           - MAKEFLAGS: -j4
-    needs: preparation
     with:
       MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
       MPI: ${{ matrix.MPI }}
@@ -126,7 +165,7 @@ jobs:
   
   # Run t8code tests with shipped submodules. This test is only for the build system, so only one config is tested.
   t8code_w_shipped_submodules_tests:
-    if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') || (github.event_name != 'schedule')
+    needs: fine_grained_trigger
     uses: ./.github/workflows/tests_cmake_t8code_w_shipped_submodules.yml
     with:
       MAKEFLAGS: -j4
@@ -135,7 +174,7 @@ jobs:
       TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
 
   t8code_tarball:
-    if: (github.event_name == 'schedule' || github.event_name == 'merge_group') && github.repository == 'DLR-AMR/t8code'
+    if: github.event_name == 'merge_group' && github.repository == 'DLR-AMR/t8code'
     uses: ./.github/workflows/build_cmake_tarball.yml
     needs: [preparation, sc_p4est_tests, t8code_tests, t8code_linkage_tests, t8code_api_tests, t8code_w_shipped_submodules_tests]
     with:

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         if [[ "${{ github.event_name }}" == "schedule" && "${{ github.repository }}" == "DLR-AMR/t8code" ]]; then
           echo "Scheduled run for DLR-AMR/t8code, proceeding with CI."
-          echo "RUN_CI=true" >> $GITHUB_ENV
+          echo "RUN_CI=true" >> $GITHUB_OUTPUT
           exit 0
         fi
         latest_commit_message=$(git log -1 --pretty=%B)
@@ -73,20 +73,20 @@ jobs:
         if [[ "${{ github.event_name }}" != "schedule" ]]; then
           if [[ "${{ github.event.pull_request.draft }}" == "false" ]]; then
             echo "Not a draft PR, proceeding with CI."
-            echo "RUN_CI=true" >> $GITHUB_ENV
+            echo "RUN_CI=true" >> $GITHUB_OUTPUT
             exit 0
           elif [[ "${{ github.event.pull_request.draft }}" == "true" && "$latest_commit_message" == *"[run CI]"* ]]; then
             echo "Draft PR with '[run CI]' in the latest commit message, proceeding with CI."
-            echo "RUN_CI=true" >> $GITHUB_ENV
+            echo "RUN_CI=true" >> $GITHUB_OUTPUT
             exit 0
           else
             echo "Draft PR without '[run CI]' in the latest commit message, skipping CI."
-            echo "RUN_CI=false" >> $GITHUB_ENV
+            echo "RUN_CI=false" >> $GITHUB_OUTPUT
             exit 0
           fi
         else
           echo "Conditions not met, skipping CI."
-          echo "RUN_CI=false" >> $GITHUB_ENV
+          echo "RUN_CI=false" >> $GITHUB_OUTPUT
           exit 0
         fi
 

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -41,7 +41,7 @@ on:
 # The CI pipeline should:
 # - fully run in the merge queue with the full test suite
 # - not run on draft PRs
-# - run on draft PRs, if the latest commit message contains '[run CI]'
+# - run on draft PRs, if the latest commit message contains '[run ci]'
 # - run on scheduled runs for the DLR-AMR/t8code repository
 # - run on all other pull request events
 # These conditions are checked in the fine_grained_trigger job. If it completes successfully, it triggers the preparation job, 
@@ -75,12 +75,12 @@ jobs:
             echo "Not a draft PR, proceeding with CI."
             echo "RUN_CI=true" >> $GITHUB_OUTPUT
             exit 0
-          elif [[ "${{ github.event.pull_request.draft }}" == "true" && "$latest_commit_message" == *"[run CI]"* ]]; then
-            echo "Draft PR with '[run CI]' in the latest commit message, proceeding with CI."
+          elif [[ "${{ github.event.pull_request.draft }}" == "true" && "$latest_commit_message" == *"[run ci]"* ]]; then
+            echo "Draft PR with '[run ci]' in the latest commit message, proceeding with CI."
             echo "RUN_CI=true" >> $GITHUB_OUTPUT
             exit 0
           else
-            echo "Draft PR without '[run CI]' in the latest commit message, skipping CI."
+            echo "Draft PR without '[run ci]' in the latest commit message, skipping CI."
             echo "RUN_CI=false" >> $GITHUB_OUTPUT
             exit 0
           fi

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -67,7 +67,7 @@ jobs:
           echo "Scheduled run for DLR-AMR/t8code, proceeding with CI."
           exit 0
         fi
-        if [["${{ github.event_name }}" != "schedule" ]]; then
+        if [[ "${{ github.event_name }}" != "schedule" ]]; then
           if [[ "${{ github.event.pull_request.draft }}" == "false" ]]; then
             echo "Not a draft PR, proceeding with CI."
             exit 0

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -177,6 +177,8 @@ jobs:
   # Run t8code tests with shipped submodules. This test is only for the build system, so only one config is tested.
   t8code_w_shipped_submodules_tests:
     needs: fine_grained_trigger
+    secrets: inherit
+    if: ${{ needs.fine_grained_trigger.outputs.run_ci == 'true' }}
     uses: ./.github/workflows/tests_cmake_t8code_w_shipped_submodules.yml
     with:
       MAKEFLAGS: -j4

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -69,9 +69,12 @@ jobs:
           if [[ "${{ github.event.pull_request.draft }}" == "false" ]]; then
             echo "Not a draft PR, proceeding with CI."
             exit 0
-            elif [[ "${{ github.event.pull_request.draft }}" == "true" && "$latest_commit_message" == *"[run CI]"* ]]; then
+          elif [[ "${{ github.event.pull_request.draft }}" == "true" && "$latest_commit_message" == *"[run CI]"* ]]; then
             echo "Draft PR with '[run CI]' in the latest commit message, proceeding with CI."
             exit 0
+          else
+            echo "Draft PR without '[run CI]' in the latest commit message, skipping CI."
+            exit 1
           fi
         else
           echo "Conditions not met, skipping CI."

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -40,8 +40,8 @@ on:
 
 # The CI pipeline should:
 # - fully run in the merge queue with the full test suite
-# - not run on Draft PRs
-# - run on Draft PRs, IF the latest commit message contains '[run CI]'
+# - not run on draft PRs
+# - run on draft PRs, if the latest commit message contains '[run CI]'
 # - run on scheduled runs for the DLR-AMR/t8code repository
 # - run on all other pull request events
 # These conditions are checked in the fine_grained_trigger job. If it completes successfully, it triggers the preparation job, 

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -49,6 +49,7 @@ on:
 # The job to build the tarball is only triggered on merge_group events for the DLR-AMR/t8code repository.
 
 jobs:
+
   fine_grained_trigger:
     runs-on: ubuntu-latest
     outputs:
@@ -59,7 +60,7 @@ jobs:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
         fetch-depth: 0
-    - name: set the run_ci variable for the testsuite
+    - name: set the run_ci variable for the testsute
       id: set_run_ci
       run: |
         if [[ "${{ github.event_name }}" == "schedule" && "${{ github.repository }}" == "DLR-AMR/t8code" ]]; then
@@ -89,13 +90,11 @@ jobs:
           exit 0
         fi
 
-
-
   # Preparation step for tests. Repo is cloned and sc + p4est are compiled with and without MPI.
   preparation:
     needs: [fine_grained_trigger]
     secrets: inherit
-    if: ${{ needs.fine_grained_trigger.outputs.run_ci == 'true' }}
+    if: needs.fine_grained_trigger.outputs.run_ci == 'true'
     uses: ./.github/workflows/tests_cmake_preparation.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -63,18 +63,18 @@ jobs:
         echo "Latest commit message: $latest_commit_message"
     - name: trigger the testsuite
       run: |
-        if [[ "${{ github.event.pull_request.draft }}" == "false" ]]; then
-          echo "Not a draft PR, proceeding with CI."
-          exit 0
-        elif [[ "${{ github.event.pull_request.draft }}" == "true" && "$latest_commit_message" == *"[run CI]"* ]]; then
-          echo "Draft PR with '[run CI]' in the latest commit message, proceeding with CI."
-          exit 0
-        elif [[ "${{ github.event_name }}" == "schedule" && "${{ github.repository }}" == "DLR-AMR/t8code" ]]; then
+        if [[ "${{ github.event_name }}" == "schedule" && "${{ github.repository }}" == "DLR-AMR/t8code" ]]; then
           echo "Scheduled run for DLR-AMR/t8code, proceeding with CI."
           exit 0
-        elif [[ "${{ github.event_name }}" != "schedule" ]]; then
-          echo "Event is not schedule, proceeding with CI."
-          exit 0
+        fi
+        if [["${{ github.event_name }}" != "schedule" ]]; then
+          if [[ "${{ github.event.pull_request.draft }}" == "false" ]]; then
+            echo "Not a draft PR, proceeding with CI."
+            exit 0
+          elif [[ "${{ github.event.pull_request.draft }}" == "true" && "$latest_commit_message" == *"[run CI]"* ]]; then
+            echo "Draft PR with '[run CI]' in the latest commit message, proceeding with CI."
+            exit 0
+          fi
         else
           echo "Conditions not met, skipping CI."
           exit 1

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -51,16 +51,20 @@ on:
 jobs:
   fine_grained_trigger:
     runs-on: ubuntu-latest
+    outputs:
+      run_ci: ${{ steps.set_run_ci.outputs.RUN_CI }}
     steps:
     - uses: actions/checkout@v4
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
         fetch-depth: 0
-    - name: trigger the testsuite
+    - name: set the run_ci variable for the testsuite
+      id: set_run_ci
       run: |
         if [[ "${{ github.event_name }}" == "schedule" && "${{ github.repository }}" == "DLR-AMR/t8code" ]]; then
           echo "Scheduled run for DLR-AMR/t8code, proceeding with CI."
+          echo "RUN_CI=true" >> $GITHUB_ENV
           exit 0
         fi
         latest_commit_message=$(git log -1 --pretty=%B)
@@ -68,17 +72,21 @@ jobs:
         if [[ "${{ github.event_name }}" != "schedule" ]]; then
           if [[ "${{ github.event.pull_request.draft }}" == "false" ]]; then
             echo "Not a draft PR, proceeding with CI."
+            echo "RUN_CI=true" >> $GITHUB_ENV
             exit 0
           elif [[ "${{ github.event.pull_request.draft }}" == "true" && "$latest_commit_message" == *"[run CI]"* ]]; then
             echo "Draft PR with '[run CI]' in the latest commit message, proceeding with CI."
+            echo "RUN_CI=true" >> $GITHUB_ENV
             exit 0
           else
             echo "Draft PR without '[run CI]' in the latest commit message, skipping CI."
-            exit 1
+            echo "RUN_CI=false" >> $GITHUB_ENV
+            exit 0
           fi
         else
           echo "Conditions not met, skipping CI."
-          exit 1
+          echo "RUN_CI=false" >> $GITHUB_ENV
+          exit 0
         fi
 
 
@@ -86,6 +94,8 @@ jobs:
   # Preparation step for tests. Repo is cloned and sc + p4est are compiled with and without MPI.
   preparation:
     needs: [fine_grained_trigger]
+    secrets: inherit
+    if: ${{ needs.fine_grained_trigger.outputs.run_ci == 'true' }}
     uses: ./.github/workflows/tests_cmake_preparation.yml
     strategy:
       fail-fast: false
@@ -175,6 +185,7 @@ jobs:
       TEST_LEVEL: ${{ github.event_name == 'pull_request' && 1 || 0 }} # Set TEST_LEVEL to 1 if the event is a PR, otherwise 0.
 
   t8code_tarball:
+    if: github.event.pull_request == false
     uses: ./.github/workflows/build_cmake_tarball.yml
     needs: [preparation, sc_p4est_tests, t8code_tests, t8code_linkage_tests, t8code_api_tests, t8code_w_shipped_submodules_tests]
     with:


### PR DESCRIPTION
Closes #1425 

For a detailed description, please have a look at the Issue. We decided to optimize our CI, this branch implements the decision that we made. 

TODOS:
- [x] We discussed that the CMake CI should be skipped in draft PRs unless the commit message indicates otherwise (like including a [run ci]). This can easily be achieved via @lenaploetzke's proposed solution and the addition of the parsing of the commit message for s specific substring.
- [x] The spell and indentation check should run as usual.
- [ ] The tarball test should only be run in the nightly and the merge queue.
- [x] The tests in the merge queue should run the full test suite (without less tests)
- [x] Then all tests (including spell and indent) after a merge into main can be deactivated because they ran already in the merge



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually

- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [ ] The code is covered in an existing or new test case using Google Test

#### Github action

- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [ ] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
