### PR TITLE
Move element_find_owner to public interface

### DIFF
--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -860,6 +860,22 @@ void
 t8_forest_element_points_inside (t8_forest_t forest, t8_locidx_t ltreeid, const t8_element_t *element,
                                  const double *points, int num_points, int *is_inside, const double tolerance);
 
+/** Find the owner process of a given element.
+ * \param [in]    forest  The forest.
+ * \param [in]    gtreeid The global id of the tree in which the element lies.
+ * \param [in]    element The element to look for.
+ * \param [in]    eclass  The element class of the tree \a gtreeid.
+ * \return                The mpirank of the process that owns \a element.
+ * \note The element must not exist in the forest, but an ancestor of its first
+ *       descendant has to. If the element's owner is not unique, the owner of the element's
+ *       first descendant is returned.
+ * \note \a forest must be committed before calling this function.
+ * \see t8_forest_element_find_owner_ext
+ * \see t8_forest_element_owners_bounds
+ */
+int
+t8_forest_element_find_owner (t8_forest_t forest, t8_gloidx_t gtreeid, t8_element_t *element, t8_eclass_t eclass);
+
 /* TODO: if set level and partition/adapt/balance all give NULL, then
  * refine uniformly and partition/adapt/balance the uniform forest. */
 /** Build a uniformly refined forest on a coarse mesh.

--- a/src/t8_forest/t8_forest_private.h
+++ b/src/t8_forest/t8_forest_private.h
@@ -219,22 +219,6 @@ int
 t8_forest_element_find_owner_old (t8_forest_t forest, t8_gloidx_t gtreeid, t8_element_t *element, t8_eclass_t eclass,
                                   sc_array_t *all_owners_of_tree);
 
-/** Find the owner process of a given element.
- * \param [in]    forest  The forest.
- * \param [in]    gtreeid The global id of the tree in which the element lies.
- * \param [in]    element The element to look for.
- * \param [in]    eclass  The element class of the tree \a gtreeid.
- * \return                The mpirank of the process that owns \a element.
- * \note The element must not exist in the forest, but an ancestor of its first
- *       descendant has to. If the element's owner is not unique, the owner of the element's
- *       first descendant is returned.
- * \note \a forest must be committed before calling this function.
- * \see t8_forest_element_find_owner_ext
- * \see t8_forest_element_owners_bounds
- */
-int
-t8_forest_element_find_owner (t8_forest_t forest, t8_gloidx_t gtreeid, t8_element_t *element, t8_eclass_t eclass);
-
 /** Find the owner process of a given element, if bounds for the owner process are known.
  * \param [in]    forest  The forest.
  * \param [in]    gtreeid The global id of the tree in which the element lies.


### PR DESCRIPTION
**_Describe your changes here:_**



**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [ ] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [x] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
