### PR TITLE
Bugfix: Invalid read size

### DIFF
--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_lagrange.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_lagrange.cxx
@@ -292,12 +292,15 @@ t8_lagrange_element::t8_lagrange_element (t8_eclass_t eclass, uint32_t degree, s
   // TODO: Check if the number of nodes corresponds to the element type and degree.
   // if (nodes.size () != parametric_nodes.size ())
   //   SC_ABORTF ("Provide the 3 coordinates of the nodes.\n");
+
+  // Assert that the vector of nodes contains nodes with 3 coordinates each.
+  T8_ASSERT (0 == nodes.size () % 3);
   /* Create a cmesh with a single element */
   t8_cmesh_init (&cmesh);
   t8_cmesh_set_attribute (cmesh, 0, t8_get_package_id (), T8_CMESH_LAGRANGE_POLY_DEGREE_KEY, &degree, sizeof (int), 1);
   t8_cmesh_register_geometry<t8_geometry_lagrange> (cmesh);
   t8_cmesh_set_tree_class (cmesh, 0, eclass);
-  t8_cmesh_set_tree_vertices (cmesh, 0, nodes.data (), nodes.size ());
+  t8_cmesh_set_tree_vertices (cmesh, 0, nodes.data (), (int) (nodes.size () / 3.0));
   t8_cmesh_commit (cmesh, sc_MPI_COMM_WORLD);
 }
 


### PR DESCRIPTION
**_Describe your changes here:_**
The valgrind check for all test files developed in #1453 detected an invalid read size in the test t8_geometry/t8_geometry_implementations/t8_gtest_geometry_lagrange_serial. The changes here fix the problem.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.


#### General
- [x] The reviewer executed the new code features at least once and checked the results manually

- [x] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline)
- [x] New source/header files are properly added to the Makefiles
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)

#### Tests
- [x] The code is covered in an existing or new test case using Google Test

#### Github action

- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)
- [x] All tests pass (in various configurations, this should be executed automatically in a github action)

  If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

#### Scripts and Wiki

- [ ] If a new directory with source-files is added, it must be covered by the `script/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example/tutorial and a Wiki article.

#### License

- [x] The author added a BSD statement to `doc/` (or already has one)

#### Tag Label

- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
