### PR TITLE
Improvement: Dinstinguish internal header files from public ones

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -203,14 +203,22 @@ install( FILES
     t8_types/t8_vec.hxx
     t8_version.h
     t8_vtk.h
-    t8_windows.h DESTINATION include
+    DESTINATION include
 )
 
-install( DIRECTORY t8_cmesh DESTINATION include FILES_MATCHING PATTERN "*.h" )
+install( DIRECTORY t8_cmesh DESTINATION include FILES_MATCHING PATTERN "*.h" 
+  PATTERN "t8_cmesh/t8_cmesh_copy.h"      EXCLUDE
+  PATTERN "t8_cmesh/t8_cmesh_offset.h"    EXCLUDE 
+  PATTERN "t8_cmesh/t8_cmesh_partition.h" EXCLUDE
+  PATTERN "t8_cmesh/t8_cmesh_trees.h"     EXCLUDE 
+  )
 install( DIRECTORY t8_data DESTINATION include FILES_MATCHING PATTERN "*.h" )
-install( DIRECTORY t8_forest DESTINATION include FILES_MATCHING
-  PATTERN "*.h"
-  PATTERN "*private.h" EXCLUDE )
+install( DIRECTORY t8_forest DESTINATION include FILES_MATCHING PATTERN "*.h"
+  PATTERN "t8_forest/t8_forest_balance.h" EXCLUDE
+  PATTERN "t8_forest/t8_forest_ghost.h "  EXCLUDE
+  PATTERN "t8_forest/t8_forest_private.h" EXCLUDE
+  PATTERN "t8_forest/t8_forest_types.h"   EXCLUDE
+  )
 install( DIRECTORY t8_geometry DESTINATION include FILES_MATCHING PATTERN "*.h" )
 install( DIRECTORY t8_schemes DESTINATION include FILES_MATCHING PATTERN "*.h" )
 install( DIRECTORY t8_vtk DESTINATION include FILES_MATCHING PATTERN "*.h" )
@@ -220,7 +228,13 @@ install( DIRECTORY t8_data DESTINATION include FILES_MATCHING PATTERN "*.hxx" )
 install( DIRECTORY t8_forest DESTINATION include FILES_MATCHING PATTERN "*.hxx" )
 install( DIRECTORY t8_geometry DESTINATION include FILES_MATCHING PATTERN "*.hxx" )
 install( DIRECTORY t8_schemes DESTINATION include FILES_MATCHING PATTERN "*.hxx" )
-install( DIRECTORY t8_vtk DESTINATION include FILES_MATCHING PATTERN "*.hxx" )
+install( DIRECTORY t8_vtk DESTINATION include FILES_MATCHING PATTERN "*.hxx" 
+  PATTERN "t8_vtk/t8_vtk_parallel.hxx"      EXCLUDE
+  PATTERN "t8_vtk/t8_vtk_polydata.hxx"      EXCLUDE
+  PATTERN "t8_vtk/t8_vtk_unstructured.hxx"  EXCLUDE
+  PATTERN "t8_vtk/t8_vtk_writer_helper.hxx" EXCLUDE
+  PATTERN "t8_vtk/t8_vtk_write_ASCII.hxx"   EXCLUDE
+  )
 install( DIRECTORY t8_types DESTINATION include FILES_MATCHING PATTERN "*.hxx" )
 
 install( TARGETS T8 DESTINATION lib )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -232,8 +232,8 @@ install( DIRECTORY t8_vtk DESTINATION include FILES_MATCHING PATTERN "*.hxx"
   PATTERN "t8_vtk/t8_vtk_parallel.hxx"      EXCLUDE
   PATTERN "t8_vtk/t8_vtk_polydata.hxx"      EXCLUDE
   PATTERN "t8_vtk/t8_vtk_unstructured.hxx"  EXCLUDE
-  PATTERN "t8_vtk/t8_vtk_writer_helper.hxx" EXCLUDE
   PATTERN "t8_vtk/t8_vtk_write_ASCII.hxx"   EXCLUDE
+  PATTERN "t8_vtk/t8_vtk_writer_helper.hxx" EXCLUDE
   )
 install( DIRECTORY t8_types DESTINATION include FILES_MATCHING PATTERN "*.hxx" )
 


### PR DESCRIPTION
**_Describe your changes here:_**

Solves #1461. So far, when installing t8code using CMake, all headers were added to `<my_install_dir>/include/`. This PR keeps those header files supposed to be for internal use only from getting copied to the install directory. This list of excluded headers is taken from the `Makefile.am` of the autoconf build.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [x] The reviewer executed the new code features at least once and checked the results manually.
- [x] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [x] New source/header files are properly added to the CMake files.
- [x] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [x] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### Tag Label
- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).