### PR TITLE
Enhancement: Element is refinable check

### DIFF
--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -538,8 +538,9 @@ t8_forest_adapt (t8_forest_t forest)
                                        is_family, num_elements_to_adapt_callback, elements_from);
 
         T8_ASSERT (is_family || refine != -1);
-        if (refine > 0 && scheme->element_get_level (tree->eclass, elements_from[0]) >= forest->maxlevel) {
-          /* Only refine an element if it does not exceed the maximum level */
+        if (refine > 0 && scheme->element_get_level (tree->eclass, elements_from[0]) >= forest->maxlevel
+            && scheme->element_is_refinable (tree->eclass, elements_from[0])) {
+          /* Only refine an element if it does not exceed the maximum level and if it is refinable */
           refine = 0;
         }
         if (refine == 1) {

--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common.hxx
@@ -242,6 +242,20 @@ class t8_default_scheme_common: public t8_crtp_operator<TUnderlyingEclassScheme,
     return count_leaves_from_level (element_level, level, dim);
   }
 
+  /**
+   * Indicates if an element is refinable. Possible reasons for being not refinable could be
+   * that the element has reached its max level or that it is a subelement.
+   * \param [in] elem   The element to check.
+   * \return            True if the element is refinable.
+   */
+  inline bool
+  element_is_refinable (const t8_element_t *elem) const
+  {
+    T8_ASSERT (this->underlying ().element_is_valid (elem));
+
+    return this->underlying ().element_get_level (elem) != this->underlying ().get_maxlevel ();
+  }
+
   /** Compute the number of siblings of an element. That is the number of 
    * Children of its parent.
    * \param [in] elem The element.

--- a/src/t8_schemes/t8_scheme.cxx
+++ b/src/t8_schemes/t8_scheme.cxx
@@ -88,6 +88,12 @@ t8_element_is_equal (const t8_scheme_c *scheme, const t8_eclass_t tree_class, co
   return scheme->element_is_equal (tree_class, elem1, elem2);
 }
 
+int
+element_is_refinable (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *elem)
+{
+  return scheme->element_is_refinable (tree_class, elem);
+};
+
 void
 t8_element_get_parent (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *elem,
                        t8_element_t *parent)

--- a/src/t8_schemes/t8_scheme.h
+++ b/src/t8_schemes/t8_scheme.h
@@ -125,10 +125,22 @@ int
 t8_element_is_equal (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *elem1,
                      const t8_element_t *elem2);
 
-/** Compute the parent of a given element \b elem and store it in \b parent.
- *  \b parent needs to be an existing element. No memory is allocated by this function.
- *  \b elem and \b parent can point to the same element, then the entries of
- *  \b elem are overwritten by the ones of its parent.
+/**
+ * Indicates if an element is refinable. Possible reasons for being not refinable could be
+ * that the element has reached its max level or that it is a subelement.
+ * \param [in] scheme      The scheme of the forest.
+ * \param [in] tree_class  The eclass of tree the elements are part of.
+ * \param [in] elem        The element to check.
+ * \return                 1 if the element is refinable, 0 otherwise.
+ */
+int
+element_is_refinable (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *elem);
+
+/**
+ * Compute the parent of a given element \b elem and store it in \b parent.
+ * \b parent needs to be an existing element. No memory is allocated by this function.
+ * \b elem and \b parent can point to the same element, then the entries of
+ * \b elem are overwritten by the ones of its parent.
  * \param [in] scheme        The scheme of the forest.
  * \param [in] tree_class    The eclass of tree the elements are part of.
  * \param [in] elem   The element whose parent will be computed.

--- a/src/t8_schemes/t8_scheme.hxx
+++ b/src/t8_schemes/t8_scheme.hxx
@@ -254,6 +254,18 @@ class t8_scheme {
                        eclass_schemes[tree_class]);
   };
 
+  /**
+   * Indicates if an element is refinable. Possible reasons for being not refinable could be
+   * that the element has reached its max level or that it is a subelement.
+   * \param [in] elem   The element to check.
+   * \return            True if the element is refinable.
+   */
+  inline bool
+  element_is_refinable (const t8_eclass_t tree_class, const t8_element_t *elem) const
+  {
+    return std::visit ([&] (auto &&scheme) { return scheme.element_is_refinable (elem); }, eclass_schemes[tree_class]);
+  };
+
   /** Compute the parent of a given element \a elem and store it in \a parent.
    *  \a parent needs to be an existing element. No memory is allocated by this function.
    *  \a elem and \a parent can point to the same element, then the entries of

--- a/src/t8_schemes/t8_standalone/t8_standalone_implementation.hxx
+++ b/src/t8_schemes/t8_standalone/t8_standalone_implementation.hxx
@@ -460,6 +460,20 @@ struct t8_standalone_scheme
     return T8_ELEMENT_NUM_CHILDREN[TEclass];
   }
 
+  /**
+   * Indicates if an element is refinable. Possible reasons for being not refinable could be
+   * that the element has reached its max level or that it is a subelement.
+   * \param [in] elem   The element to check.
+   * \return            True if the element is refinable.
+   */
+  static constexpr bool
+  element_is_refinable (const t8_element_t *elem) noexcept
+  {
+    T8_ASSERT (element_is_valid (elem));
+
+    return element_get_level (elem) != get_maxlevel ();
+  }
+
   /** Construct all children of a given element.
    * \param [in] elem     This must be a valid element, bigger than maxlevel.
    * \param [in] length   The length of the output array \a c must match


### PR DESCRIPTION
**_Describe your changes here:_**
Adds an `element_is_refinable` function to the schemes. This function is used during `t8_forest_adapt` as another criterion if an element is refined. Reasons for an element being not refinable are that the element has reached its max level, the element is a subelement or in the multilevel scheme elements which are children of themselves cannot be refined anymore.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### Tag Label
- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).