### PR TITLE
Enable Ghost value output for ASCII VTK

### DIFF
--- a/src/t8_vtk/t8_vtk_write_ASCII.cxx
+++ b/src/t8_vtk/t8_vtk_write_ASCII.cxx
@@ -317,24 +317,39 @@ t8_forest_vtk_cells_elementid_kernel (t8_forest_t forest, const t8_locidx_t ltre
   return 1;
 }
 
+// TODO: Move to forest_general.h
+static t8_locidx_t
+t8_forest_compute_data_index (const t8_forest_t forest,
+                              const t8_locidx_t ltree_or_ghost_id, // 0<= ID < num_local_trees + num_ghosts
+                              const t8_locidx_t element_in_tree_index)
+{
+  const bool is_local = t8_forest_tree_is_local (forest, ltree_or_ghost_id);
+
+  if (is_local) {
+      const t8_locidx_t element_offset = t8_forest_get_tree_element_offset (forest, ltree_or_ghost_id);
+      return element_offset + element_in_tree_index;
+  }
+  else {
+      // Compute the tree id of the ghost tree
+      const t8_locidx_t ghost_tree_id = ltree_or_ghost_id - t8_forest_get_num_local_trees (forest);
+      // Compute the offset among ghost elements
+      const t8_locidx_t ghost_tree_offset = t8_forest_ghost_get_tree_element_offset (forest, ghost_tree_id);
+      // Add the local element count
+      const t8_locidx_t ghost_element_offset = ghost_tree_offset + t8_forest_get_local_num_elements (forest);
+      return ghost_element_offset + element_in_tree_index;
+  }
+}                              
+
 static int
 t8_forest_vtk_cells_scalar_kernel (t8_forest_t forest, const t8_locidx_t ltree_id, const t8_tree_t tree,
                                    const t8_locidx_t element_index, const t8_element_t *element,
                                    const t8_eclass_t tree_class, const int is_ghost, FILE *vtufile, int *columns,
                                    void **data, T8_VTK_KERNEL_MODUS modus)
 {
-  double element_value = 0;
-  t8_locidx_t scalar_index;
-
   if (modus == T8_VTK_KERNEL_EXECUTE) {
     /* For local elements access the data array, for ghosts, write 0 */
-    if (!is_ghost) {
-      scalar_index = t8_forest_get_tree_element_offset (forest, ltree_id) + element_index;
-      element_value = ((double *) *data)[scalar_index];
-    }
-    else {
-      element_value = 0;
-    }
+    const t8_locidx_t data_index = t8_forest_compute_data_index (forest, ltree_id, element_index);
+    const double element_value = ((double *) *data)[data_index];
     fprintf (vtufile, "%g ", element_value);
     *columns += 1;
   }
@@ -347,22 +362,14 @@ t8_forest_vtk_cells_vector_kernel (t8_forest_t forest, const t8_locidx_t ltree_i
                                    const t8_eclass_t tree_class, const int is_ghost, FILE *vtufile, int *columns,
                                    void **data, T8_VTK_KERNEL_MODUS modus)
 {
-  double *element_values, null_vec[3] = { 0, 0, 0 };
   int dim, idim;
-  t8_locidx_t tree_offset;
 
   if (modus == T8_VTK_KERNEL_EXECUTE) {
     dim = 3;
     T8_ASSERT (forest->dimension <= 3);
     /* For local elements access the data array, for ghosts, write 0 */
-    if (!is_ghost) {
-      tree_offset = t8_forest_get_tree_element_offset (forest, ltree_id);
-      /* Get a pointer to the start of the element's vector data */
-      element_values = ((double *) *data) + (tree_offset + element_index) * dim;
-    }
-    else {
-      element_values = null_vec;
-    }
+    const t8_locidx_t data_index = t8_forest_compute_data_index (forest, ltree_id, element_index);
+    const double *element_values = ((double *) *data) + data_index * dim;
     for (idim = 0; idim < dim; idim++) {
       fprintf (vtufile, "%g ", element_values[idim]);
     }


### PR DESCRIPTION
**_Describe your changes here:_**

The vtk routines currently write 0 as output value for data living on the ghost cells.
In this PR we extend the ASCII output routines to write the actual data on the ghost cells.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### Tag Label
- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).