### PR TITLE
Feature: Add a scalar and vector data field to VTK write test

### DIFF
--- a/test/t8_IO/t8_gtest_vtk_writer.cxx
+++ b/test/t8_IO/t8_gtest_vtk_writer.cxx
@@ -113,6 +113,24 @@ use_c_interface<t8_cmesh_t> (const t8_cmesh_t grid, const char *fileprefix, cons
 #endif
 }
 
+void
+vtk_writer_test_fill_data (const t8_locidx_t cells_to_write_count, std::vector<double> &scalar_data,
+                           std::vector<double> &vector_data)
+{
+  // Fill scalar data vector with entries 0,1/10,...,(N-1)/10
+  //    vector[n] = (n/10.)
+  // Fill vector data vector with entries (0, 0, 42), (0.1,-0.1,42), ...
+  //    vector[n] = (n/10.,-n/10., 42)
+  for (t8_locidx_t icell = 0; icell < cells_to_write_count; ++icell) {
+    const double scalar_value = icell / 10.;
+    const double vector_values[3] = { scalar_value, -scalar_value, 42. };
+    scalar_data.push_back (icell);
+    vector_data.push_back (vector_values[0]);
+    vector_data.push_back (vector_values[1]);
+    vector_data.push_back (vector_values[2]);
+  }
+}
+
 /**
  * Templated class to test the vtk writer for forests and cmeshes. 
  * 
@@ -125,14 +143,27 @@ class vtk_writer_test: public testing::Test {
   SetUp () override
   {
     grid = make_grid<grid_t> ();
-    writer = new vtk_writer<grid_t> (true, true, true, true, true, true, std::string ("test_vtk"), 0, NULL,
-                                     sc_MPI_COMM_WORLD);
+    const t8_locidx_t cells_to_write_count = num_cells_to_write (grid, 1);
+
+    // Fill the test data vectors with dummy data.
+    vtk_writer_test_fill_data (cells_to_write_count, scalar_data, vector_data);
+
+    // Fill the vtk_data descriptors
+    vtk_data[0].type = T8_VTK_SCALAR;
+    strncpy (vtk_data[0].description, "Testdata scalar i/10.", BUFSIZ);
+    vtk_data[0].data = scalar_data.data ();
+    vtk_data[1].type = T8_VTK_VECTOR;
+    strncpy (vtk_data[1].description, "Testdata vector (i/10.,-i/10.,42)", BUFSIZ);
+    vtk_data[1].data = vector_data.data ();
+
+    writer = new vtk_writer<grid_t> (true, true, true, true, true, true, std::string ("test_vtk"), num_vtk_data,
+                                     vtk_data, sc_MPI_COMM_WORLD);
   }
 
   int
   grid_c_interface ()
   {
-    return use_c_interface (grid, "test_vtk_c_interface", 1, 1, 1, 1, 1, 1, 0, NULL, sc_MPI_COMM_WORLD);
+    return use_c_interface (grid, "test_vtk_c_interface", 1, 1, 1, 1, 1, 1, num_vtk_data, vtk_data, sc_MPI_COMM_WORLD);
   }
 
   void
@@ -143,6 +174,10 @@ class vtk_writer_test: public testing::Test {
 
   grid_t grid;
   vtk_writer<grid_t> *writer;
+  std::vector<double> scalar_data;             // Scalar data used for data output
+  std::vector<double> vector_data;             // Vector data used for data output
+  static constexpr int num_vtk_data = 2;       // Number of data items
+  t8_vtk_data_field_t vtk_data[num_vtk_data];  // The metadata descriptor for data output
 };
 
 TYPED_TEST_SUITE_P (vtk_writer_test);


### PR DESCRIPTION
**_Describe your changes here:_**

The first step towards #1487.
The vtk_writer example did not write any user data.
Extended the example with 2 data fields, one scalar, one vector and dummy data.
The data fields do already contain values for the ghost elements.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### Tag Label
- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).