### PR TITLE
Bugfix: vtk writer num_cells_to_write [1/3]

### DIFF
--- a/src/t8_vtk/t8_vtk_writer_helper.cxx
+++ b/src/t8_vtk/t8_vtk_writer_helper.cxx
@@ -147,7 +147,7 @@ template <>
 t8_locidx_t
 num_cells_to_write<t8_forest_t> (const t8_forest_t grid, const int write_ghosts)
 {
-  return grid_local_num_elements (grid) + (write_ghosts ? t8_forest_get_num_ghost_trees (grid) : 0);
+  return grid_local_num_elements (grid) + (write_ghosts ? t8_forest_get_num_ghosts (grid) : 0);
 }
 
 template <>


### PR DESCRIPTION
**_Describe your changes here:_**

The vtk writer function `num_cells_to_write` computed the wrong value for forests.
For forests it computed "#local_elements + #ghost_trees" instead of "#local_elements + #ghost_elements".

This can be tested with `test/t8_IO/t8_gtest_vtk_writer_parallel` if ghost writing is enabled in the test (see also upcoming PRs and #1489 #1488).

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [x] The reviewer executed the new code features at least once and checked the results manually.
- [x] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [x] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### Tag Label
- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).