### PR TITLE
Feature: Added workflow files to automize project board usage.

### DIFF
--- a/.github/workflows/issue_event_moves_card.yml
+++ b/.github/workflows/issue_event_moves_card.yml
@@ -68,7 +68,6 @@ jobs:
           for combined_id in $combined_ids; do
             issue_id=$(echo $combined_id | cut -d, -f1)
             PVII_id=$(echo $combined_id | cut -d, -f2)
-            echo "PVII_id is $PVII_id"
             if [ "$issue_id" == "$ISSUE_NODE_ID" ]; then
               echo "Found issue $issue_id in project $project_id"
               # Extract the status field id

--- a/.github/workflows/issue_event_moves_card.yml
+++ b/.github/workflows/issue_event_moves_card.yml
@@ -73,12 +73,12 @@ jobs:
               # Extract the status field id
               status_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
               # Get the current status of the issue
-              current_status=$(echo $project_fields_and_issues | jq -r --arg PVII_id "$PVII_id" '.data.node.items.nodes[] | select(.id == $PVII_id) | .fieldValues.nodes[] | select(.field.name == "Status") | .text')
+              current_status=$(echo $project_fields_and_issues | jq -r --arg PVII_id "$PVII_id" '.data.node.items.nodes[] | select(.id == $PVII_id) | .fieldValues.nodes[] | select(.field.name == "Status") | .name')
               echo "current_status is $current_status"
               priority_message=""
               workload_message=""
               status_message=""
-              if [ "$current_status" != "$COLUMN_NAME" ]; then
+              if [ "$current_status" == "$CURRENT_COLUMN_NAME" ]; then
                 # Move the issue to the specified column
                 Option_id=$(echo $project_fields_and_issues | jq -r --arg COLUMN_NAME "$COLUMN_NAME" '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == $COLUMN_NAME) | .id')
                 echo "Option_id is $Option_id"

--- a/.github/workflows/issue_event_moves_card.yml
+++ b/.github/workflows/issue_event_moves_card.yml
@@ -21,7 +21,127 @@ on:
         description: 'The workload of the issue'
     secrets:
         PAT:
+          required: truename: Move an Issue Card to a different Column triggered by an Issue event
+
+on:
+  workflow_call:
+    inputs:
+      ISSUE_NODE_ID:
+        required: true
+        type: string
+        description: 'The node id of the issue that triggered the workflow'
+      COLUMN_NAME:
+        type: string
+        default: 'In-Box'
+        description: 'The name of the column to move the issue card to'
+      CURRENT_COLUMN_NAME:
+        type: string
+        default: 'In-Box'
+        description: 'The name of the column the issue card was in before'
+      PRIORITY:
+        type: string
+        default: 'NONE'
+        description: 'The priority of the issue'
+      WORKLOAD:
+        type: string
+        default: 'NONE'
+        description: 'The workload of the issue'
+    secrets:
+        PAT:
           required: true
+
+jobs:
+  Move_card:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Move card in projects"
+      id: move_cards
+      run: |
+        ISSUE_NODE_ID="${{ inputs.ISSUE_NODE_ID }}"
+        PRIORITY="${{ inputs.PRIORITY }}"
+        WORKLOAD="${{ inputs.WORKLOAD }}"
+        COLUMN_NAME="${{ inputs.COLUMN_NAME }}"
+        CURRENT_COLUMN_NAME="${{ inputs.CURRENT_COLUMN_NAME }}"
+        echo "ISSUE_NODE_ID=$ISSUE_NODE_ID"
+        echo "PRIORITY=$PRIORITY"
+        echo "WORKLOAD=$WORKLOAD"
+        echo "COLUMN_NAME=$COLUMN_NAME"
+        # Get the projects associated with the organization
+        projects=$(curl --request POST \
+            --url https://api.github.com/graphql \
+            --header "Authorization: Bearer ${{ secrets.PAT }}" \
+            --data '{"query":"{organization(login: \"DLR-AMR\") {projectsV2(first: 20) {nodes {id title}}}}"}')
+        echo "projects=$projects"
+        # Get the project IDs
+        project_ids=$(echo $projects | jq -r '.data.organization.projectsV2.nodes[].id')
+        for project_id in $project_ids; do
+          echo "project_id is $project_id"
+          # Get the issues within the project
+          project_fields_and_issues=$(curl --request POST \
+            --url https://api.github.com/graphql \
+            --header "Authorization: Bearer ${{ secrets.PAT }}" \
+            --data "{\"query\":\"{ node(id: \\\"$project_id\\\") { ... on ProjectV2 { items(first: 100) { nodes { id fieldValues(first: 8) { nodes { ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldDateValue { date field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } } } } content { ... on Issue { id } } } } fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }\"}")
+          echo "issues=$project_fields_and_issues"
+          # Extract the issue ids and PVII ids. The issue_id is the global_id, the PVII id is the project specific id
+          issue_ids=$(echo $project_fields_and_issues | jq -r '.data.node.items.nodes[].content.id')
+          PVII_ids=$(echo $project_fields_and_issues | jq -r '.data.node.items.nodes[].id')
+          # In the following loop we need both values, so we combine them into a single string
+          combined_ids=$(paste -d, <(echo "$issue_ids") <(echo "$PVII_ids"))
+          for combined_id in $combined_ids; do
+            issue_id=$(echo $combined_id | cut -d, -f1)
+            echo "issue_id is $issue_id"
+            PVII_id=$(echo $combined_id | cut -d, -f2)
+            echo "PVII_id is $PVII_id"
+            if [ "$issue_id" == "$ISSUE_NODE_ID" ]; then
+              # Extract the status field id
+              status_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
+              # Get the current status of the issue
+              current_status=$(echo $project_fields_and_issues | jq -r --arg PVII_id "$PVII_id" '.data.node.items.nodes[] | select(.id == $PVII_id) | .fieldValues.nodes[] | select(.field.name == "Status") | .text')
+              echo "current_status is $current_status"
+              priority_message=""
+              workload_message=""
+              status_message=""
+              if [ "$current_status" != "$COLUMN_NAME" ]; then
+                # Move the issue to the specified column
+                Option_id=$(echo $project_fields_and_issues | jq -r --arg COLUMN_NAME "$COLUMN_NAME" '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == $COLUMN_NAME) | .id')
+                echo "Option_id is $Option_id"
+                echo "change field $status_field_id of issue $issue_id in project $project_id to $COLUMN_NAME"
+                status_message="updateProjectV2ItemFieldValue: updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$status_field_id'\", value: { singleSelectOptionId: \"'$Option_id'\"}}) {projectV2Item {id}}"
+                echo "status_message is $status_message"
+              fi
+              if [ "$PRIORITY" != 'NONE' ]; then
+                priority_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Priority") | .id')
+                priority_option_id=$(echo $project_fields_and_issues | jq -r --arg PRIORITY "$PRIORITY" '.data.node.fields.nodes[] | select(.name == "Priority") | .options[] | select(.name == $PRIORITY) | .id')
+                priority_message="updateProjectV2ItemFieldValue1: updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$priority_field_id'\", value: { singleSelectOptionId: \"'$priority_option_id'\"}}) {projectV2Item {id}}"
+                echo "priority_message is $priority_message"
+              fi
+              if [ "$WORKLOAD" != 'NONE' ]; then
+                workload_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Workload") | .id')
+                workload_option_id=$(echo $project_fields_and_issues | jq -r --arg WORKLOAD "$WORKLOAD" '.data.node.fields.nodes[] | select(.name == "Workload") | .options[] | select(.name == $WORKLOAD) | .id')
+                workload_message="updateProjectV2ItemFieldValue2: updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$workload_field_id'\", value: { singleSelectOptionId: \"'$workload_option_id'\"}}) {projectV2Item {id}}"
+                echo "workload_message is $workload_message"
+              fi
+
+              # Construct the query to move the issue to the specified column.
+              # The query is a mutation that updates the status, priority, and workload fields of the issue.
+              # If priority or workload are not set, the corresponding message is empty.
+              # The query is constructed using jq and sed to remove null values and extra whitespace.
+              query=$(jq -n --arg sm "$status_message" \
+                      --arg pm "$priority_message" \
+                      --arg wm "$workload_message" \
+                      '{"query": "mutation { \($sm) \($pm) \($wm) }"}' | \
+                    jq '.query |= gsub("null"; "") | .query |= gsub("\\s+"; " ") | .query |= sub("\\{\\s*\\}"; "{}")' | \
+                    sed 's/\\\\"/"/g' | \
+                    sed "s/'//g")
+              echo "query=$query"
+              response=$(curl --request POST \
+                --url https://api.github.com/graphql \
+                --header "Authorization: Bearer ${{ secrets.PAT }}" \
+                --data "$query")
+              echo "response=$response"
+            fi
+          done
+        done
 
 jobs:
   Move_card:

--- a/.github/workflows/issue_event_moves_card.yml
+++ b/.github/workflows/issue_event_moves_card.yml
@@ -11,29 +11,6 @@ on:
         type: string
         default: 'In-Box'
         description: 'The name of the column to move the issue card to'
-      PRIORITY:
-        type: string
-        default: 'NONE'
-        description: 'The priority of the issue'
-      WORKLOAD:
-        type: string
-        default: 'NONE'
-        description: 'The workload of the issue'
-    secrets:
-        PAT:
-          required: truename: Move an Issue Card to a different Column triggered by an Issue event
-
-on:
-  workflow_call:
-    inputs:
-      ISSUE_NODE_ID:
-        required: true
-        type: string
-        description: 'The node id of the issue that triggered the workflow'
-      COLUMN_NAME:
-        type: string
-        default: 'In-Box'
-        description: 'The name of the column to move the issue card to'
       CURRENT_COLUMN_NAME:
         type: string
         default: 'In-Box'
@@ -122,91 +99,6 @@ jobs:
                 echo "workload_message is $workload_message"
               fi
 
-              # Construct the query to move the issue to the specified column.
-              # The query is a mutation that updates the status, priority, and workload fields of the issue.
-              # If priority or workload are not set, the corresponding message is empty.
-              # The query is constructed using jq and sed to remove null values and extra whitespace.
-              query=$(jq -n --arg sm "$status_message" \
-                      --arg pm "$priority_message" \
-                      --arg wm "$workload_message" \
-                      '{"query": "mutation { \($sm) \($pm) \($wm) }"}' | \
-                    jq '.query |= gsub("null"; "") | .query |= gsub("\\s+"; " ") | .query |= sub("\\{\\s*\\}"; "{}")' | \
-                    sed 's/\\\\"/"/g' | \
-                    sed "s/'//g")
-              echo "query=$query"
-              response=$(curl --request POST \
-                --url https://api.github.com/graphql \
-                --header "Authorization: Bearer ${{ secrets.PAT }}" \
-                --data "$query")
-              echo "response=$response"
-            fi
-          done
-        done
-
-jobs:
-  Move_card:
-    runs-on: ubuntu-latest
-    steps:
-    - name: "Move card in projects"
-      id: move_cards
-      run: |
-        ISSUE_NODE_ID="${{ inputs.ISSUE_NODE_ID }}"
-        PRIORITY="${{ inputs.PRIORITY }}"
-        WORKLOAD="${{ inputs.WORKLOAD }}"
-        COLUMN_NAME="${{ inputs.COLUMN_NAME }}"
-        echo "ISSUE_NODE_ID=$ISSUE_NODE_ID"
-        echo "PRIORITY=$PRIORITY"
-        echo "WORKLOAD=$WORKLOAD"
-        echo "COLUMN_NAME=$COLUMN_NAME"
-        # Get the projects associated with the organization
-        projects=$(curl --request POST \
-            --url https://api.github.com/graphql \
-            --header "Authorization: Bearer ${{ secrets.PAT }}" \
-            --data '{"query":"{organization(login: \"DLR-AMR\") {projectsV2(first: 20) {nodes {id title}}}}"}')
-        echo "projects=$projects"
-        # Get the project IDs
-        project_ids=$(echo $projects | jq -r '.data.organization.projectsV2.nodes[].id')
-        for project_id in $project_ids; do
-          echo "project_id is $project_id"
-          # Get the issues within the project
-          project_fields_and_issues=$(curl --request POST \
-            --url https://api.github.com/graphql \
-            --header "Authorization: Bearer ${{ secrets.PAT }}" \
-            --data "{\"query\":\"{ node(id: \\\"$project_id\\\") { ... on ProjectV2 { items(first: 100) { nodes { id fieldValues(first: 8) { nodes { ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldDateValue { date field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } } } } content { ... on Issue { id } } } } fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }\"}")
-          echo "issues=$project_fields_and_issues"
-          # Extract the issue ids and PVII ids. The issue_id is the global_id, the PVII id is the project specific id
-          issue_ids=$(echo $project_fields_and_issues | jq -r '.data.node.items.nodes[].content.id')
-          PVII_ids=$(echo $project_fields_and_issues | jq -r '.data.node.items.nodes[].id')
-          # In the following loop we need both values, so we combine them into a single string
-          combined_ids=$(paste -d, <(echo "$issue_ids") <(echo "$PVII_ids"))
-          for combined_id in $combined_ids; do
-            issue_id=$(echo $combined_id | cut -d, -f1)
-            echo "issue_id is $issue_id"
-            PVII_id=$(echo $combined_id | cut -d, -f2)
-            echo "PVII_id is $PVII_id"
-            if [ "$issue_id" == "$ISSUE_NODE_ID" ]; then
-              # Extract the status field id
-              status_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
-              Option_id=$(echo $project_fields_and_issues | jq -r --arg COLUMN_NAME "$COLUMN_NAME" '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == $COLUMN_NAME) | .id')
-              echo "Option_id is $Option_id"
-              echo "change field $status_field_id of issue $issue_id in project $project_id to $COLUMN_NAME"
-              # Move the issue to the specified column
-              priority_message=""
-              workload_message=""
-              if [ "$PRIORITY" != 'NONE' ]; then
-                priority_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Priority") | .id')
-                priority_option_id=$(echo $project_fields_and_issues | jq -r --arg PRIORITY "$PRIORITY" '.data.node.fields.nodes[] | select(.name == "Priority") | .options[] | select(.name == $PRIORITY) | .id')
-                priority_message="updateProjectV2ItemFieldValue1: updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$priority_field_id'\", value: { singleSelectOptionId: \"'$priority_option_id'\"}}) {projectV2Item {id}}"
-                echo "priority_message is $priority_message"
-              fi
-              if [ "$WORKLOAD" != 'NONE' ]; then
-                workload_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Workload") | .id')
-                workload_option_id=$(echo $project_fields_and_issues | jq -r --arg WORKLOAD "$WORKLOAD" '.data.node.fields.nodes[] | select(.name == "Workload") | .options[] | select(.name == $WORKLOAD) | .id')
-                workload_message="updateProjectV2ItemFieldValue2: updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$workload_field_id'\", value: { singleSelectOptionId: \"'$workload_option_id'\"}}) {projectV2Item {id}}"
-                
-                echo "workload_message is $workload_message"
-              fi
-              status_message="updateProjectV2ItemFieldValue: updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$status_field_id'\", value: { singleSelectOptionId: \"'$Option_id'\"}}) {projectV2Item {id}}"
               # Construct the query to move the issue to the specified column.
               # The query is a mutation that updates the status, priority, and workload fields of the issue.
               # If priority or workload are not set, the corresponding message is empty.

--- a/.github/workflows/issue_event_moves_card.yml
+++ b/.github/workflows/issue_event_moves_card.yml
@@ -86,6 +86,8 @@ jobs:
                 echo "change field $status_field_id of issue $issue_id in project $project_id to $COLUMN_NAME"
                 status_message="updateProjectV2ItemFieldValue: updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$status_field_id'\", value: { singleSelectOptionId: \"'$Option_id'\"}}) {projectV2Item {id}}"
                 echo "status_message is $status_message"
+              else
+                    echo "The issue is not in the correct column"
               fi
               if [ "$PRIORITY" != 'NONE' ]; then
                 priority_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Priority") | .id')

--- a/.github/workflows/issue_event_moves_card.yml
+++ b/.github/workflows/issue_event_moves_card.yml
@@ -92,6 +92,7 @@ jobs:
                 priority_option_id=$(echo $project_fields_and_issues | jq -r --arg PRIORITY "$PRIORITY" '.data.node.fields.nodes[] | select(.name == "Priority") | .options[] | select(.name == $PRIORITY) | .id')
                 priority_message="updateProjectV2ItemFieldValue1: updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$priority_field_id'\", value: { singleSelectOptionId: \"'$priority_option_id'\"}}) {projectV2Item {id}}"
                 echo "priority_message is $priority_message"
+                echo "change priority field $priority_field_id of issue $issue_id in project $project_id to $PRIORITY"
               fi
               if [ "$WORKLOAD" != 'NONE' ]; then
                 workload_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Workload") | .id')

--- a/.github/workflows/issue_event_moves_card.yml
+++ b/.github/workflows/issue_event_moves_card.yml
@@ -43,6 +43,7 @@ jobs:
         echo "PRIORITY=$PRIORITY"
         echo "WORKLOAD=$WORKLOAD"
         echo "COLUMN_NAME=$COLUMN_NAME"
+        echo "CURRENT_COLUMN_NAME=$CURRENT_COLUMN_NAME"
         # Get the projects associated with the organization
         projects=$(curl --request POST \
             --url https://api.github.com/graphql \
@@ -66,10 +67,10 @@ jobs:
           combined_ids=$(paste -d, <(echo "$issue_ids") <(echo "$PVII_ids"))
           for combined_id in $combined_ids; do
             issue_id=$(echo $combined_id | cut -d, -f1)
-            echo "issue_id is $issue_id"
             PVII_id=$(echo $combined_id | cut -d, -f2)
             echo "PVII_id is $PVII_id"
             if [ "$issue_id" == "$ISSUE_NODE_ID" ]; then
+              echo "Found issue $issue_id in project $project_id"
               # Extract the status field id
               status_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
               # Get the current status of the issue
@@ -97,6 +98,7 @@ jobs:
                 workload_option_id=$(echo $project_fields_and_issues | jq -r --arg WORKLOAD "$WORKLOAD" '.data.node.fields.nodes[] | select(.name == "Workload") | .options[] | select(.name == $WORKLOAD) | .id')
                 workload_message="updateProjectV2ItemFieldValue2: updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$workload_field_id'\", value: { singleSelectOptionId: \"'$workload_option_id'\"}}) {projectV2Item {id}}"
                 echo "workload_message is $workload_message"
+                echo "change workload field $workload_field_id of issue $issue_id in project $project_id to $WORKLOAD"
               fi
 
               # Construct the query to move the issue to the specified column.

--- a/.github/workflows/issue_event_moves_card.yml
+++ b/.github/workflows/issue_event_moves_card.yml
@@ -1,0 +1,109 @@
+name: Move an Issue Card to a different Column triggered by an Issue event
+
+on:
+  workflow_call:
+    inputs:
+      ISSUE_NODE_ID:
+        required: true
+        type: string
+        description: 'The node id of the issue that triggered the workflow'
+      COLUMN_NAME:
+        type: string
+        default: 'In-Box'
+        description: 'The name of the column to move the issue card to'
+      PRIORITY:
+        type: string
+        default: 'NONE'
+        description: 'The priority of the issue'
+      WORKLOAD:
+        type: string
+        default: 'NONE'
+        description: 'The workload of the issue'
+    secrets:
+        PAT:
+          required: true
+
+jobs:
+  Move_card:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Move card in projects"
+      id: move_cards
+      run: |
+        ISSUE_NODE_ID="${{ inputs.ISSUE_NODE_ID }}"
+        PRIORITY="${{ inputs.PRIORITY }}"
+        WORKLOAD="${{ inputs.WORKLOAD }}"
+        COLUMN_NAME="${{ inputs.COLUMN_NAME }}"
+        echo "ISSUE_NODE_ID=$ISSUE_NODE_ID"
+        echo "PRIORITY=$PRIORITY"
+        echo "WORKLOAD=$WORKLOAD"
+        echo "COLUMN_NAME=$COLUMN_NAME"
+        # Get the projects associated with the organization
+        projects=$(curl --request POST \
+            --url https://api.github.com/graphql \
+            --header "Authorization: Bearer ${{ secrets.PAT }}" \
+            --data '{"query":"{organization(login: \"DLR-AMR\") {projectsV2(first: 20) {nodes {id title}}}}"}')
+        echo "projects=$projects"
+        # Get the project IDs
+        project_ids=$(echo $projects | jq -r '.data.organization.projectsV2.nodes[].id')
+        for project_id in $project_ids; do
+          echo "project_id is $project_id"
+          # Get the issues within the project
+          project_fields_and_issues=$(curl --request POST \
+            --url https://api.github.com/graphql \
+            --header "Authorization: Bearer ${{ secrets.PAT }}" \
+            --data "{\"query\":\"{ node(id: \\\"$project_id\\\") { ... on ProjectV2 { items(first: 100) { nodes { id fieldValues(first: 8) { nodes { ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldDateValue { date field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } } } } content { ... on Issue { id } } } } fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }\"}")
+          echo "issues=$project_fields_and_issues"
+          # Extract the issue ids and PVII ids. The issue_id is the global_id, the PVII id is the project specific id
+          issue_ids=$(echo $project_fields_and_issues | jq -r '.data.node.items.nodes[].content.id')
+          PVII_ids=$(echo $project_fields_and_issues | jq -r '.data.node.items.nodes[].id')
+          # In the following loop we need both values, so we combine them into a single string
+          combined_ids=$(paste -d, <(echo "$issue_ids") <(echo "$PVII_ids"))
+          for combined_id in $combined_ids; do
+            issue_id=$(echo $combined_id | cut -d, -f1)
+            echo "issue_id is $issue_id"
+            PVII_id=$(echo $combined_id | cut -d, -f2)
+            echo "PVII_id is $PVII_id"
+            if [ "$issue_id" == "$ISSUE_NODE_ID" ]; then
+              # Extract the status field id
+              status_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
+              Option_id=$(echo $project_fields_and_issues | jq -r --arg COLUMN_NAME "$COLUMN_NAME" '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == $COLUMN_NAME) | .id')
+              echo "Option_id is $Option_id"
+              echo "change field $status_field_id of issue $issue_id in project $project_id to $COLUMN_NAME"
+              # Move the issue to the specified column
+              priority_message=""
+              workload_message=""
+              if [ "$PRIORITY" != 'NONE' ]; then
+                priority_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Priority") | .id')
+                priority_option_id=$(echo $project_fields_and_issues | jq -r --arg PRIORITY "$PRIORITY" '.data.node.fields.nodes[] | select(.name == "Priority") | .options[] | select(.name == $PRIORITY) | .id')
+                priority_message="updateProjectV2ItemFieldValue1: updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$priority_field_id'\", value: { singleSelectOptionId: \"'$priority_option_id'\"}}) {projectV2Item {id}}"
+                echo "priority_message is $priority_message"
+              fi
+              if [ "$WORKLOAD" != 'NONE' ]; then
+                workload_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Workload") | .id')
+                workload_option_id=$(echo $project_fields_and_issues | jq -r --arg WORKLOAD "$WORKLOAD" '.data.node.fields.nodes[] | select(.name == "Workload") | .options[] | select(.name == $WORKLOAD) | .id')
+                workload_message="updateProjectV2ItemFieldValue2: updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$workload_field_id'\", value: { singleSelectOptionId: \"'$workload_option_id'\"}}) {projectV2Item {id}}"
+                
+                echo "workload_message is $workload_message"
+              fi
+              status_message="updateProjectV2ItemFieldValue: updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$status_field_id'\", value: { singleSelectOptionId: \"'$Option_id'\"}}) {projectV2Item {id}}"
+              # Construct the query to move the issue to the specified column.
+              # The query is a mutation that updates the status, priority, and workload fields of the issue.
+              # If priority or workload are not set, the corresponding message is empty.
+              # The query is constructed using jq and sed to remove null values and extra whitespace.
+              query=$(jq -n --arg sm "$status_message" \
+                      --arg pm "$priority_message" \
+                      --arg wm "$workload_message" \
+                      '{"query": "mutation { \($sm) \($pm) \($wm) }"}' | \
+                    jq '.query |= gsub("null"; "") | .query |= gsub("\\s+"; " ") | .query |= sub("\\{\\s*\\}"; "{}")' | \
+                    sed 's/\\\\"/"/g' | \
+                    sed "s/'//g")
+              echo "query=$query"
+              response=$(curl --request POST \
+                --url https://api.github.com/graphql \
+                --header "Authorization: Bearer ${{ secrets.PAT }}" \
+                --data "$query")
+              echo "response=$response"
+            fi
+          done
+        done

--- a/.github/workflows/move_card.yml
+++ b/.github/workflows/move_card.yml
@@ -1,0 +1,232 @@
+name: "Move the Issue after workload and urgency is evaluated"
+
+on:
+  issues:
+    types: [labeled, assigned, unassigned, unlabeled]
+  pull_request:
+    types: [opened, reopened, ready_for_review, review_requested, review_request_removed, closed]
+
+jobs:
+  evaluate_issues:
+    if: ${{ github.event_name == 'issues' }}
+    runs-on: ubuntu-latest
+    outputs:
+      WORKLOAD_SET: ${{ steps.check_workload.outputs.WORKLOAD_SET || 'false' }}
+      PRIORITY_SET: ${{ steps.check_urgency.outputs.PRIORITY_SET || 'false' }}
+      WORKLOAD: ${{ steps.check_workload.outputs.WORKLOAD || 'false' }}
+      PRIORITY: ${{ steps.check_urgency.outputs.PRIORITY || 'false' }}
+    steps:
+      - name: "Check if workload is set"
+        id: check_workload
+        # Check if the issue has a workload label
+        if: |
+          contains(join(github.event.issue.labels.*.name, ','), 'workload:high') ||
+          contains(join(github.event.issue.labels.*.name, ','), 'workload:medium') ||
+          contains(join(github.event.issue.labels.*.name, ','), 'workload:low')
+        run: |
+            # Set WORKLOAD_SET to true
+            WORKLOAD_SET=true
+            echo "WORKLOAD_SET=$WORKLOAD_SET" >> $GITHUB_OUTPUT
+            # extract the workload value
+            labels=$(echo '${{ toJSON(github.event.issue.labels) }}' | jq -r '.[].name')
+            workload=$(echo "$labels" | grep -oE 'workload:(high|medium|low)' | cut -d: -f2)
+            echo "WORKLOAD=$workload"
+            WORKLOAD=$workload
+            echo "WORKLOAD=$WORKLOAD" >> $GITHUB_OUTPUT
+            echo "WORKLOAD=$WORKLOAD"
+            echo "WORKLOAD_SET=$WORKLOAD_SET"
+            echo "${{ github.event.action }}"
+      - name: "Check if workload has not been set"
+        id: check_workload_not_set
+        if: |
+          !contains(join(github.event.issue.labels.*.name, ','), 'workload:high') &&
+          !contains(join(github.event.issue.labels.*.name, ','), 'workload:medium') &&
+          !contains(join(github.event.issue.labels.*.name, ','), 'workload:low')
+        run: |
+            # Set WORKLOAD_SET to false
+            WORKLOAD_SET=false
+            echo "WORKLOAD_SET=$WORKLOAD_SET" >> $GITHUB_OUTPUT
+            echo "WORKLOAD_SET=$WORKLOAD_SET"
+      - name: "Check if priority is set"
+        id: check_urgency
+        # Check if the issue has a priority label
+        if: |
+          contains(join(github.event.issue.labels.*.name, ','), 'priority:high') ||
+          contains(join(github.event.issue.labels.*.name, ','), 'priority:medium') ||
+          contains(join(github.event.issue.labels.*.name, ','), 'priority:low')
+        run: |
+            # Set PRIORITY_SET to true
+            PRIORITY_SET=true
+            echo "PRIORITY_SET=$PRIORITY_SET" >> $GITHUB_OUTPUT
+            # extract the priority value
+            labels=$(echo '${{ toJSON(github.event.issue.labels) }}' | jq -r '.[].name')
+            priority=$(echo "$labels" | grep -oE 'priority:(high|medium|low)' | cut -d: -f2)
+            echo "PRIORITY=$priority"
+            PRIORITY=$priority
+            echo "PRIORITY=$PRIORITY" >> $GITHUB_OUTPUT
+            echo "PRIORITY=$PRIORITY"
+            echo "PRIORITY_SET=$PRIORITY_SET"
+            echo "${{ github.event.action }}"
+      - name: "Check if priority has not been set"
+        id: check_urgency_not_set
+        if: |
+          !contains(join(github.event.issue.labels.*.name, ','), 'priority:high') &&
+          !contains(join(github.event.issue.labels.*.name, ','), 'priority:medium') &&
+          !contains(join(github.event.issue.labels.*.name, ','), 'priority:low')
+        run: |
+            # Set PRIORITY_SET to false
+            PRIORITY_SET=false
+            echo "PRIORITY_SET=$PRIORITY_SET" >> $GITHUB_OUTPUT
+            echo "PRIORITY_SET=$PRIORITY_SET"
+  
+  evaluate_pr:
+    runs-on: ubuntu-latest
+    outputs:
+      NUMBER_IS_SET: ${{ steps.get_pr_issue_link.outputs.NUMBER_IS_SET }}
+      CLEAN_ISSUE_NUMBER: ${{ steps.get_pr_issue_link.outputs.CLEAN_ISSUE_NUMBER }}
+      REPO_NODE_ID: ${{ steps.get_pr_issue_link.outputs.REPO_NODE_ID }}
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: "Get link between PR and Issue"
+        id: get_pr_issue_link
+        run: |
+            # Extract the repository node ID from the pull request event
+            REPO_NODE_ID=$(jq -r '.repository.node_id' < $GITHUB_EVENT_PATH)
+            echo "REPO_NODE_ID=$REPO_NODE_ID"
+            echo "REPO_NODE_ID=$REPO_NODE_ID" >> $GITHUB_OUTPUT
+            # Extract the issue number from the pull request body
+            ISSUE_NUMBER=$(jq -r '.pull_request.body // ""' < $GITHUB_EVENT_PATH | grep -oE '#[0-9]+' || true)
+            # Set the issue number to an empty string if no issue number is found
+            ISSUE_NUMBER=${ISSUE_NUMBER:-""}
+            echo "ISSUE_NUMBER=$ISSUE_NUMBER"
+            # If no issue number is found, set NUMBER_IS_SET to false
+            if [ -z "$ISSUE_NUMBER" ]; then
+                echo "No issue number found in the pull request body."
+                NUMBER_IS_SET=false
+                echo "NUMBER_IS_SET=$NUMBER_IS_SET" >> $GITHUB_OUTPUT
+                echo "NUMBER_IS_SET=$NUMBER_IS_SET"
+                exit 0
+            fi
+            # Remove the '#' from the issue number
+            CLEAN_ISSUE_NUMBER=$(echo $ISSUE_NUMBER | tr -d '#')
+            # Set the cleaned issue number and NUMBER_IS_SET to true
+            echo "CLEAN_ISSUE_NUMBER=$CLEAN_ISSUE_NUMBER" >> $GITHUB_OUTPUT
+            NUMBER_IS_SET=true
+            echo "NUMBER_IS_SET=true" >> $GITHUB_OUTPUT
+            # Debug output!
+            echo "NUMBER_IS_SET=$NUMBER_IS_SET"
+            echo "CLEAN_ISSUE_NUMBER=$CLEAN_ISSUE_NUMBER"
+            echo "${{ github.event.action }}"
+
+  # Move the issue card to ToDo if the workload and priority are set
+  move_card_to_ToDo:
+    needs: [evaluate_issues]
+    if: ${{ github.event.action == 'labeled' && needs.evaluate_issues.outputs.WORKLOAD_SET == 'true' && needs.evaluate_issues.outputs.PRIORITY_SET == 'true' }}
+    uses: ./.github/workflows/issue_event_moves_card.yml
+    with:
+        ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+        COLUMN_NAME: 'ToDo'
+        PRIORITY: ${{ needs.evaluate_issues.outputs.PRIORITY }}
+        WORKLOAD: ${{ needs.evaluate_issues.outputs.WORKLOAD }}
+    secrets:
+        PAT: ${{ secrets.T8DDY_TOKEN }}
+  
+  # Move the Issue card to In Progress if the workload and priority are set and the issue is assigned
+  move_card_to_InProgress:
+    needs: [evaluate_issues]
+    if: ${{ needs.evaluate_issues.outputs.WORKLOAD_SET == 'true' && needs.evaluate_issues.outputs.PRIORITY_SET == 'true' && github.event.action == 'assigned' }}
+    uses: ./.github/workflows/issue_event_moves_card.yml
+    with:
+        ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+        COLUMN_NAME: 'In Progress'
+    secrets:
+        PAT: ${{ secrets.T8DDY_TOKEN }}
+
+  # Move the Issue card back to ToDo if the workload and priority are set and the issue is unassigned
+  move_card_back_to_ToDo:
+    needs: [evaluate_issues]
+    if: ${{ needs.evaluate_issues.outputs.WORKLOAD_SET == 'true' && needs.evaluate_issues.outputs.PRIORITY_SET == 'true' && github.event.action == 'unassigned' }}
+    uses: ./.github/workflows/issue_event_moves_card.yml
+    with:
+        ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+        COLUMN_NAME: 'ToDo'
+    secrets:
+        PAT: ${{ secrets.T8DDY_TOKEN }}
+  
+  # Move the Issue card back to In-Box if the workload and priority are unset
+  move_card_back_to_In-Box:
+    needs: [evaluate_issues]
+    if: ${{ github.event.action == 'unlabeled' && (needs.evaluate_issues.outputs.WORKLOAD_SET == 'false' || needs.evaluate_issues.outputs.PRIORITY_SET == 'false') }}
+    uses: ./.github/workflows/issue_event_moves_card.yml
+    with:
+        ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+        COLUMN_NAME: 'In-Box'
+    secrets:
+        PAT: ${{ secrets.T8DDY_TOKEN }}
+
+  # For a PR event, move the card to Needs Review if the PR is opened, ready for review, or reopened
+  move_card_to_Needs_Review:
+    needs: [evaluate_pr]
+    if: ${{ needs.evaluate_pr.outputs.NUMBER_IS_SET == 'true'  && (github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.action == 'reopened') }}
+    uses: ./.github/workflows/pr_event_moves_card.yml
+    with:
+        ISSUE_NUMBER: ${{ needs.evaluate_pr.outputs.CLEAN_ISSUE_NUMBER }}
+        COLUMN_NAME: 'Needs Review'
+        REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
+    secrets:
+        PAT: ${{ secrets.T8DDY_TOKEN }}
+
+  # For a PR event move the card to In Review if a review is requested
+  move_card_to_In_Review:
+    needs: [evaluate_pr]
+    if: ${{ needs.evaluate_pr.outputs.NUMBER_IS_SET == 'true'  && github.event.action == 'review_requested' }}
+    uses: ./.github/workflows/pr_event_moves_card.yml
+    with:
+        ISSUE_NUMBER: ${{ needs.evaluate_pr.outputs.CLEAN_ISSUE_NUMBER }}
+        COLUMN_NAME: 'In Review'
+        REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
+    secrets:
+        PAT: ${{ secrets.T8DDY_TOKEN }}
+
+  # For a PR event move the card back to Needs Review if a review is removed
+  move_card_back_to_Needs_Review:
+    needs: [evaluate_pr]
+    if: ${{ needs.evaluate_pr.outputs.NUMBER_IS_SET == 'true'  && github.event.action == 'review_request_removed' }}
+    uses: ./.github/workflows/pr_event_moves_card.yml
+    with:
+        ISSUE_NUMBER: ${{ needs.evaluate_pr.outputs.CLEAN_ISSUE_NUMBER }}
+        COLUMN_NAME: 'Needs Review'
+        REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
+    secrets:
+        PAT: ${{ secrets.T8DDY_TOKEN }}
+
+  # For a PR event move the card back to In Progress if the PR is closed and not merged
+  move_card_back_to_In_Progress:
+    needs: [evaluate_pr]
+    if: ${{ needs.evaluate_pr.outputs.NUMBER_IS_SET == 'true'  && github.event.action == 'closed' && github.event.pull_request.merged == false }}
+    uses: ./.github/workflows/pr_event_moves_card.yml
+    with:
+        ISSUE_NUMBER: ${{ needs.evaluate_pr.outputs.CLEAN_ISSUE_NUMBER }}
+        COLUMN_NAME: 'In Progress'
+        REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
+    secrets:
+        PAT: ${{ secrets.T8DDY_TOKEN }}
+
+  # For a PR event where no issue is linked, open a new issue and add "Closes #ISSUE_NUMBER" to the PR body
+  open_issue_for_quick_pr:
+    needs: [evaluate_pr]
+    if: ${{ github.event_name == 'pull_request' && needs.evaluate_pr.outputs.NUMBER_IS_SET == 'false' }}
+    uses: ./.github/workflows/quick_pr.yml
+    secrets:
+        PAT: ${{ secrets.T8DDY_TOKEN }}
+
+  # After the issue has been created by open_issue_for_quick_pr, move the card to Needs Review
+  move_quick_pr_issue_to_Needs_Review:
+    needs: [open_issue_for_quick_pr, evaluate_pr]
+    uses: ./.github/workflows/pr_event_moves_card.yml
+    with:
+        ISSUE_NUMBER: ${{ needs.open_issue_for_quick_pr.outputs.ISSUE_NUMBER }}
+        COLUMN_NAME: 'Needs Review'
+        REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
+    secrets:
+        PAT: ${{ secrets.T8DDY_TOKEN }}

--- a/.github/workflows/move_card.yml
+++ b/.github/workflows/move_card.yml
@@ -95,27 +95,23 @@ jobs:
             echo "REPO_NODE_ID=$REPO_NODE_ID"
             echo "REPO_NODE_ID=$REPO_NODE_ID" >> $GITHUB_OUTPUT
             # Extract the issue number from the pull request body
-            ISSUE_NUMBER=$(jq -r '.pull_request.body // ""' < $GITHUB_EVENT_PATH | grep -oE '#[0-9]+' || true)
+            CLEAN_ISSUE_NUMBER=$(jq -r '.pull_request.body // ""' < $GITHUB_EVENT_PATH | grep -oE 'Closes #[0-9]+' | grep -oE '[0-9]+' | paste -sd ',' -)
             # Set the issue number to an empty string if no issue number is found
-            ISSUE_NUMBER=${ISSUE_NUMBER:-""}
-            echo "ISSUE_NUMBER=$ISSUE_NUMBER"
+            CLEAN_ISSUE_NUMBER=${CLEAN_ISSUE_NUMBER:-""}
+            echo "CLEAN_ISSUE_NUMBER=$CLEAN_ISSUE_NUMBER"
             # If no issue number is found, set NUMBER_IS_SET to false
-            if [ -z "$ISSUE_NUMBER" ]; then
+            if [ -z "$CLEAN_ISSUE_NUMBER" ]; then
                 echo "No issue number found in the pull request body."
                 NUMBER_IS_SET=false
                 echo "NUMBER_IS_SET=$NUMBER_IS_SET" >> $GITHUB_OUTPUT
                 echo "NUMBER_IS_SET=$NUMBER_IS_SET"
                 exit 0
             fi
-            # Remove the '#' from the issue number
-            CLEAN_ISSUE_NUMBER=$(echo $ISSUE_NUMBER | tr -d '#')
-            # Set the cleaned issue number and NUMBER_IS_SET to true
             echo "CLEAN_ISSUE_NUMBER=$CLEAN_ISSUE_NUMBER" >> $GITHUB_OUTPUT
             NUMBER_IS_SET=true
             echo "NUMBER_IS_SET=true" >> $GITHUB_OUTPUT
             # Debug output!
             echo "NUMBER_IS_SET=$NUMBER_IS_SET"
-            echo "CLEAN_ISSUE_NUMBER=$CLEAN_ISSUE_NUMBER"
             echo "${{ github.event.action }}"
 
   # Move the issue card to ToDo if the workload and priority are set
@@ -125,6 +121,7 @@ jobs:
     uses: ./.github/workflows/issue_event_moves_card.yml
     with:
         ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+        CURRENT_COLUMN_NAME: 'In-Box'
         COLUMN_NAME: 'ToDo'
         PRIORITY: ${{ needs.evaluate_issues.outputs.PRIORITY }}
         WORKLOAD: ${{ needs.evaluate_issues.outputs.WORKLOAD }}
@@ -138,6 +135,7 @@ jobs:
     uses: ./.github/workflows/issue_event_moves_card.yml
     with:
         ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+        CURRENT_COLUMN_NAME: 'ToDo'
         COLUMN_NAME: 'In Progress'
     secrets:
         PAT: ${{ secrets.T8DDY_PROJECTS }}
@@ -149,6 +147,7 @@ jobs:
     uses: ./.github/workflows/issue_event_moves_card.yml
     with:
         ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+        CURRENT_COLUMN_NAME: 'In Progress'
         COLUMN_NAME: 'ToDo'
     secrets:
         PAT: ${{ secrets.T8DDY_PROJECTS }}
@@ -160,6 +159,7 @@ jobs:
     uses: ./.github/workflows/issue_event_moves_card.yml
     with:
         ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+        CURRENT_COLUMN_NAME: 'ToDo'
         COLUMN_NAME: 'In-Box'
     secrets:
         PAT: ${{ secrets.T8DDY_PROJECTS }}
@@ -171,6 +171,7 @@ jobs:
     uses: ./.github/workflows/pr_event_moves_card.yml
     with:
         ISSUE_NUMBER: ${{ needs.evaluate_pr.outputs.CLEAN_ISSUE_NUMBER }}
+        CURRENT_COLUMN_NAME: 'In Progress'
         COLUMN_NAME: 'Needs Review'
         REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
     secrets:
@@ -183,6 +184,7 @@ jobs:
     uses: ./.github/workflows/pr_event_moves_card.yml
     with:
         ISSUE_NUMBER: ${{ needs.evaluate_pr.outputs.CLEAN_ISSUE_NUMBER }}
+        CURRENT_COLUMN_NAME: 'Needs Review'
         COLUMN_NAME: 'In Review'
         REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
     secrets:
@@ -195,6 +197,7 @@ jobs:
     uses: ./.github/workflows/pr_event_moves_card.yml
     with:
         ISSUE_NUMBER: ${{ needs.evaluate_pr.outputs.CLEAN_ISSUE_NUMBER }}
+        CURRENT_COLUMN_NAME: 'In Review'
         COLUMN_NAME: 'Needs Review'
         REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
     secrets:
@@ -207,6 +210,7 @@ jobs:
     uses: ./.github/workflows/pr_event_moves_card.yml
     with:
         ISSUE_NUMBER: ${{ needs.evaluate_pr.outputs.CLEAN_ISSUE_NUMBER }}
+        CURRENT_COLUMN_NAME: 'Needs Review'
         COLUMN_NAME: 'In Progress'
         REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
     secrets:
@@ -226,6 +230,7 @@ jobs:
     uses: ./.github/workflows/pr_event_moves_card.yml
     with:
         ISSUE_NUMBER: ${{ needs.open_issue_for_quick_pr.outputs.ISSUE_NUMBER }}
+        CURRENT_COLUMN_NAME: 'IGNORE'
         COLUMN_NAME: 'Needs Review'
         REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
     secrets:

--- a/.github/workflows/move_card.yml
+++ b/.github/workflows/move_card.yml
@@ -129,7 +129,7 @@ jobs:
         PRIORITY: ${{ needs.evaluate_issues.outputs.PRIORITY }}
         WORKLOAD: ${{ needs.evaluate_issues.outputs.WORKLOAD }}
     secrets:
-        PAT: ${{ secrets.T8DDY_TOKEN }}
+        PAT: ${{ secrets.T8DDY_PROJECTS }}
   
   # Move the Issue card to In Progress if the workload and priority are set and the issue is assigned
   move_card_to_InProgress:
@@ -140,7 +140,7 @@ jobs:
         ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
         COLUMN_NAME: 'In Progress'
     secrets:
-        PAT: ${{ secrets.T8DDY_TOKEN }}
+        PAT: ${{ secrets.T8DDY_PROJECTS }}
 
   # Move the Issue card back to ToDo if the workload and priority are set and the issue is unassigned
   move_card_back_to_ToDo:
@@ -151,7 +151,7 @@ jobs:
         ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
         COLUMN_NAME: 'ToDo'
     secrets:
-        PAT: ${{ secrets.T8DDY_TOKEN }}
+        PAT: ${{ secrets.T8DDY_PROJECTS }}
   
   # Move the Issue card back to In-Box if the workload and priority are unset
   move_card_back_to_In-Box:
@@ -162,7 +162,7 @@ jobs:
         ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
         COLUMN_NAME: 'In-Box'
     secrets:
-        PAT: ${{ secrets.T8DDY_TOKEN }}
+        PAT: ${{ secrets.T8DDY_PROJECTS }}
 
   # For a PR event, move the card to Needs Review if the PR is opened, ready for review, or reopened
   move_card_to_Needs_Review:
@@ -174,7 +174,7 @@ jobs:
         COLUMN_NAME: 'Needs Review'
         REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
     secrets:
-        PAT: ${{ secrets.T8DDY_TOKEN }}
+        PAT: ${{ secrets.T8DDY_PROJECTS }}
 
   # For a PR event move the card to In Review if a review is requested
   move_card_to_In_Review:
@@ -186,7 +186,7 @@ jobs:
         COLUMN_NAME: 'In Review'
         REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
     secrets:
-        PAT: ${{ secrets.T8DDY_TOKEN }}
+        PAT: ${{ secrets.T8DDY_PROJECTS }}
 
   # For a PR event move the card back to Needs Review if a review is removed
   move_card_back_to_Needs_Review:
@@ -198,7 +198,7 @@ jobs:
         COLUMN_NAME: 'Needs Review'
         REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
     secrets:
-        PAT: ${{ secrets.T8DDY_TOKEN }}
+        PAT: ${{ secrets.T8DDY_PROJECTS }}
 
   # For a PR event move the card back to In Progress if the PR is closed and not merged
   move_card_back_to_In_Progress:
@@ -210,7 +210,7 @@ jobs:
         COLUMN_NAME: 'In Progress'
         REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
     secrets:
-        PAT: ${{ secrets.T8DDY_TOKEN }}
+        PAT: ${{ secrets.T8DDY_PROJECTS }}
 
   # For a PR event where no issue is linked, open a new issue and add "Closes #ISSUE_NUMBER" to the PR body
   open_issue_for_quick_pr:
@@ -218,7 +218,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && needs.evaluate_pr.outputs.NUMBER_IS_SET == 'false' }}
     uses: ./.github/workflows/quick_pr.yml
     secrets:
-        PAT: ${{ secrets.T8DDY_TOKEN }}
+        PAT: ${{ secrets.T8DDY_PROJECTS }}
 
   # After the issue has been created by open_issue_for_quick_pr, move the card to Needs Review
   move_quick_pr_issue_to_Needs_Review:
@@ -229,4 +229,4 @@ jobs:
         COLUMN_NAME: 'Needs Review'
         REPO_NODE_ID: ${{ needs.evaluate_pr.outputs.REPO_NODE_ID }}
     secrets:
-        PAT: ${{ secrets.T8DDY_TOKEN }}
+        PAT: ${{ secrets.T8DDY_PROJECTS }}

--- a/.github/workflows/pr_event_moves_card.yml
+++ b/.github/workflows/pr_event_moves_card.yml
@@ -66,10 +66,11 @@ jobs:
               # Extract the issue ids, PVII ids, and issue numbers. The issue_id is the global_id, the PVII id is the project specific id, and the issue number is the issue number (eg. #123)
               # The issue number is not unique over all projects. So we check if the repository of the issue and the PR are the same.
               issue_numbers=$(echo $project_fields_and_issues | jq -r '.data.node.items.nodes[].content.number')
-              issue_ids=$(echo $issues | jq -r '.data.node.items.nodes[].content.id')
-              PVII_ids=$(echo $issues | jq -r '.data.node.items.nodes[].id')
+              
+              issue_ids=$(echo $project_fields_and_issues | jq -r '.data.node.items.nodes[].content.id')
+              PVII_ids=$(echo $project_fields_and_issues | jq -r '.data.node.items.nodes[].id')
               # extract the repository id from the issue
-              repository_ids=$(echo $issues | jq -r '.data.node.items.nodes[].content.repository.id')
+              repository_ids=$(echo $project_fields_and_issues | jq -r '.data.node.items.nodes[].content.repository.id')
               # In the following loop we need all three values, so we combine them into a single string
               combined_ids=$(paste -d, <(echo "$issue_ids") <(echo "$PVII_ids") <(echo "$issue_numbers") <(echo "$repository_ids"))
               for combined_id in $combined_ids; do
@@ -99,7 +100,7 @@ jobs:
                   echo "status_field_id is $status_field_id"
                   # Extract the current status of the issue
                   #current_status=$(echo "$detailed_project" | jq -r --arg PVII_id "$PVII_id" '.data.node.items.nodes[] | select(.id == $PVII_id) | .fieldValues.nodes[] | select(.field.name == "Status") | .name')
-                  current_status=$(echo $project_fields_and_issues | jq -r --arg PVII_id "$PVII_id" '.data.node.items.nodes[] | select(.id == $PVII_id) | .fieldValues.nodes[] | select(.field.name == "Status") | .text')
+                  current_status=$(echo $project_fields_and_issues | jq -r --arg PVII_id "$PVII_id" '.data.node.items.nodes[] | select(.id == $PVII_id) | .fieldValues.nodes[] | select(.field.name == "Status") | .name')
 
                   echo "current_status is $current_status"
                   if [[ "$current_status" == "$CURRENT_COLUMN_NAME" || "$CURRENT_COLUMN_NAME" == "IGNORE" ]]; then

--- a/.github/workflows/pr_event_moves_card.yml
+++ b/.github/workflows/pr_event_moves_card.yml
@@ -52,12 +52,6 @@ jobs:
           # Iterate over the project Ids and find the issue within the project
           for project_id in $project_ids; do
               echo "project_id is $project_id"
-              # Get the issues within the project
-              #issues=$(curl --request POST \
-              #        --url https://api.github.com/graphql \
-              #        --header "Authorization: Bearer ${{ secrets.PAT }}" \
-              #        --data "{\"query\":\"{ node(id: \\\"$project_id\\\") { ... on ProjectV2 { items(first: 100) { nodes { id fieldValues(first: 8) { nodes { ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldDateValue { date field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } } } } content { ... on Issue { id number repository { id } } } } } } } }\"}")
-              #echo "issues=$issues"
               project_fields_and_issues=$(curl --request POST \
                 --url https://api.github.com/graphql \
                 --header "Authorization: Bearer ${{ secrets.PAT }}" \
@@ -88,13 +82,6 @@ jobs:
                   # Remove the issue_number from issue_numbers_array
                   issue_numbers_array=("${issue_numbers_array[@]/$issue_number}")
                   
-                  #detailed_project=$(curl --request POST \
-                  #      --url https://api.github.com/graphql \
-                  #      --header "Authorization: Bearer ${{ secrets.PAT }}" \
-                  #      --data "{\"query\":\"{ node(id: \\\"$project_id\\\") { ... on ProjectV2 { fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } items(first: 100) { nodes { content { ... on Issue { id number } } fieldValues(first: 8) { nodes { ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } } } } } } } } }\"}")
-                  #echo "detailed_project=$detailed_project"
-                  # Extract the status field id
-                  #status_field_id=$(echo $detailed_project | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
                   status_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
 
                   echo "status_field_id is $status_field_id"

--- a/.github/workflows/pr_event_moves_card.yml
+++ b/.github/workflows/pr_event_moves_card.yml
@@ -78,10 +78,7 @@ jobs:
                 echo "repository_id is $repository_id"
                 # Check if the issue number matches the cleaned issue number from the pull request
                 # An Issue number is not unique per project. We need to check if the issue is in the correct project
-                if [[ " ${issue_numbers_array[@]} " =~ " $issue_number " ]] && [ "$repository_id" = "${{ inputs.REPO_NODE_ID }}" ]; then
-                  # Remove the issue_number from issue_numbers_array
-                  issue_numbers_array=("${issue_numbers_array[@]/$issue_number}")
-                  
+                if [[ " ${issue_numbers_array[@]} " =~ " $issue_number " ]] && [ "$repository_id" = "${{ inputs.REPO_NODE_ID }}" ]; then                 
                   status_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
 
                   echo "status_field_id is $status_field_id"

--- a/.github/workflows/pr_event_moves_card.yml
+++ b/.github/workflows/pr_event_moves_card.yml
@@ -83,13 +83,11 @@ jobs:
 
                   echo "status_field_id is $status_field_id"
                   # Extract the current status of the issue
-                  #current_status=$(echo "$detailed_project" | jq -r --arg PVII_id "$PVII_id" '.data.node.items.nodes[] | select(.id == $PVII_id) | .fieldValues.nodes[] | select(.field.name == "Status") | .name')
                   current_status=$(echo $project_fields_and_issues | jq -r --arg PVII_id "$PVII_id" '.data.node.items.nodes[] | select(.id == $PVII_id) | .fieldValues.nodes[] | select(.field.name == "Status") | .name')
 
                   echo "current_status is $current_status"
                   if [[ "$current_status" == "$CURRENT_COLUMN_NAME" || "$CURRENT_COLUMN_NAME" == "IGNORE" ]]; then
                     # Extract the option id for the new status
-                    #Option_id=$(echo $detailed_project | jq -r --arg COLUMN_NAME "$COLUMN_NAME" '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == $COLUMN_NAME) | .id')
                     Option_id=$(echo $project_fields_and_issues | jq -r --arg COLUMN_NAME "$COLUMN_NAME" '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == $COLUMN_NAME) | .id')
                     echo "Option_id is $Option_id"
                     # Change the status of the issue to the new status

--- a/.github/workflows/pr_event_moves_card.yml
+++ b/.github/workflows/pr_event_moves_card.yml
@@ -11,6 +11,10 @@ on:
         type: string
         default: 'In Progress'
         description: 'The name of the column to move the issue card to'
+      CURRENT_COLUMN_NAME:
+        type: string
+        default: 'In-Box'
+        description: 'The name of the column the issue card was in before'
       REPO_NODE_ID:
         type: string
         required: true
@@ -28,8 +32,14 @@ jobs:
         run: |
           ISSUE_NUMBER="${{ inputs.ISSUE_NUMBER }}"
           COLUMN_NAME="${{ inputs.COLUMN_NAME }}"
+          CURRENT_COLUMN_NAME="${{ inputs.CURRENT_COLUMN_NAME }}"
           echo "ISSUE_NUMBER=$ISSUE_NUMBER"
           echo "COLUMN_NAME=$COLUMN_NAME"
+          echo "CURRENT_COLUMN_NAME=$CURRENT_COLUMN_NAME"
+
+          #ISSUE_NUMBER can be a list of referenced issue numbers separated by ","
+          # Split ISSUE_NUMBER into an array
+            IFS=',' read -r -a issue_numbers_array <<< "$ISSUE_NUMBER"
 
           # Get the projects associated with the organization
           projects=$(curl --request POST \
@@ -43,14 +53,19 @@ jobs:
           for project_id in $project_ids; do
               echo "project_id is $project_id"
               # Get the issues within the project
-              issues=$(curl --request POST \
-                      --url https://api.github.com/graphql \
-                      --header "Authorization: Bearer ${{ secrets.PAT }}" \
-                      --data "{\"query\":\"{ node(id: \\\"$project_id\\\") { ... on ProjectV2 { items(first: 100) { nodes { id fieldValues(first: 8) { nodes { ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldDateValue { date field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } } } } content { ... on Issue { id number repository { id } } } } } } } }\"}")
-              echo "issues=$issues"
-             # Extract the issue ids, PVII ids, and issue numbers. The issue_id is the global_id, the PVII id is the project specific id, and the issue number is the issue number (eg. #123)
+              #issues=$(curl --request POST \
+              #        --url https://api.github.com/graphql \
+              #        --header "Authorization: Bearer ${{ secrets.PAT }}" \
+              #        --data "{\"query\":\"{ node(id: \\\"$project_id\\\") { ... on ProjectV2 { items(first: 100) { nodes { id fieldValues(first: 8) { nodes { ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldDateValue { date field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } } } } content { ... on Issue { id number repository { id } } } } } } } }\"}")
+              #echo "issues=$issues"
+              project_fields_and_issues=$(curl --request POST \
+                --url https://api.github.com/graphql \
+                --header "Authorization: Bearer ${{ secrets.PAT }}" \
+                --data "{\"query\":\"{ node(id: \\\"$project_id\\\") { ... on ProjectV2 { items(first: 100) { nodes { id fieldValues(first: 8) { nodes { ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldDateValue { date field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } } } } content { ... on Issue { id number repository { id } } } } } fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }\"}")
+              echo "issues=$project_fields_and_issues"
+              # Extract the issue ids, PVII ids, and issue numbers. The issue_id is the global_id, the PVII id is the project specific id, and the issue number is the issue number (eg. #123)
               # The issue number is not unique over all projects. So we check if the repository of the issue and the PR are the same.
-              issue_numbers=$(echo $issues | jq -r '.data.node.items.nodes[].content.number')
+              issue_numbers=$(echo $project_fields_and_issues | jq -r '.data.node.items.nodes[].content.number')
               issue_ids=$(echo $issues | jq -r '.data.node.items.nodes[].content.id')
               PVII_ids=$(echo $issues | jq -r '.data.node.items.nodes[].id')
               # extract the repository id from the issue
@@ -67,26 +82,41 @@ jobs:
                 echo "issue_number is $issue_number"
                 echo "repository_id is $repository_id"
                 # Check if the issue number matches the cleaned issue number from the pull request
-                if [ "$issue_number" = "$ISSUE_NUMBER" ] && [ "$repository_id" = "${{ inputs.REPO_NODE_ID }}" ]; then
-                  # An Issue number is not unique per project. We need to check if the issue is in the correct project
-                  detailed_project=$(curl --request POST \
-                        --url https://api.github.com/graphql \
-                        --header "Authorization: Bearer ${{ secrets.PAT }}" \
-                        --data "{\"query\":\"{ node(id: \\\"$project_id\\\") { ... on ProjectV2 { fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } items(first: 100) { nodes { content { ... on Issue { id number } } } } } } }\"}")
-                  echo "detailed_project=$detailed_project"
+                # An Issue number is not unique per project. We need to check if the issue is in the correct project
+                if [[ " ${issue_numbers_array[@]} " =~ " $issue_number " ]] && [ "$repository_id" = "${{ inputs.REPO_NODE_ID }}" ]; then
+                  # Remove the issue_number from issue_numbers_array
+                  issue_numbers_array=("${issue_numbers_array[@]/$issue_number}")
+                  
+                  #detailed_project=$(curl --request POST \
+                  #      --url https://api.github.com/graphql \
+                  #      --header "Authorization: Bearer ${{ secrets.PAT }}" \
+                  #      --data "{\"query\":\"{ node(id: \\\"$project_id\\\") { ... on ProjectV2 { fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } items(first: 100) { nodes { content { ... on Issue { id number } } fieldValues(first: 8) { nodes { ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } } } } } } } } }\"}")
+                  #echo "detailed_project=$detailed_project"
                   # Extract the status field id
-                  status_field_id=$(echo $detailed_project | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
+                  #status_field_id=$(echo $detailed_project | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
+                  status_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
+
                   echo "status_field_id is $status_field_id"
-                  # Extract the option id for the new status
-                  Option_id=$(echo $detailed_project | jq -r --arg COLUMN_NAME "$COLUMN_NAME" '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == $COLUMN_NAME) | .id')
-                  echo "Option_id is $Option_id"
-                  # Change the status of the issue to the new status
-                  echo "change field $status_field_id of issue $issue_id in project $project_id to $COLUMN_NAME"
-                  response=$(curl --request POST \
-                    --url https://api.github.com/graphql \
-                    --header "Authorization: Bearer ${{ secrets.PAT }}" \
-                    --data '{"query":"mutation {updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$status_field_id'\", value: { singleSelectOptionId: \"'$Option_id'\"}}) {projectV2Item {id}}}"}')
-                  echo "response=$response"
+                  # Extract the current status of the issue
+                  #current_status=$(echo "$detailed_project" | jq -r --arg PVII_id "$PVII_id" '.data.node.items.nodes[] | select(.id == $PVII_id) | .fieldValues.nodes[] | select(.field.name == "Status") | .name')
+                  current_status=$(echo $project_fields_and_issues | jq -r --arg PVII_id "$PVII_id" '.data.node.items.nodes[] | select(.id == $PVII_id) | .fieldValues.nodes[] | select(.field.name == "Status") | .text')
+
+                  echo "current_status is $current_status"
+                  if [[ "$current_status" == "$CURRENT_COLUMN_NAME" || "$CURRENT_COLUMN_NAME" == "IGNORE" ]]; then
+                    # Extract the option id for the new status
+                    #Option_id=$(echo $detailed_project | jq -r --arg COLUMN_NAME "$COLUMN_NAME" '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == $COLUMN_NAME) | .id')
+                    Option_id=$(echo $project_fields_and_issues | jq -r --arg COLUMN_NAME "$COLUMN_NAME" '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == $COLUMN_NAME) | .id')
+                    echo "Option_id is $Option_id"
+                    # Change the status of the issue to the new status
+                    echo "change field $status_field_id of issue $issue_id in project $project_id to $COLUMN_NAME"
+                    response=$(curl --request POST \
+                      --url https://api.github.com/graphql \
+                      --header "Authorization: Bearer ${{ secrets.PAT }}" \
+                      --data '{"query":"mutation {updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$status_field_id'\", value: { singleSelectOptionId: \"'$Option_id'\"}}) {projectV2Item {id}}}"}')
+                    echo "response=$response"
+                  else
+                    echo "The issue is not in the correct column"
+                  fi
                 fi
               done
             done

--- a/.github/workflows/pr_event_moves_card.yml
+++ b/.github/workflows/pr_event_moves_card.yml
@@ -72,15 +72,11 @@ jobs:
                 PVII_id=$(echo $combined_id | cut -d, -f2)
                 issue_number=$(echo $combined_id | cut -d, -f3)
                 repository_id=$(echo $combined_id | cut -d, -f4)
-                echo "issue_id is $issue_id"
-                echo "PVII_id is $PVII_id"
-                echo "issue_number is $issue_number"
-                echo "repository_id is $repository_id"
                 # Check if the issue number matches the cleaned issue number from the pull request
                 # An Issue number is not unique per project. We need to check if the issue is in the correct project
                 if [[ " ${issue_numbers_array[@]} " =~ " $issue_number " ]] && [ "$repository_id" = "${{ inputs.REPO_NODE_ID }}" ]; then                 
+                  echo "found issue $issue_id in project $project_id"
                   status_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
-
                   echo "status_field_id is $status_field_id"
                   # Extract the current status of the issue
                   current_status=$(echo $project_fields_and_issues | jq -r --arg PVII_id "$PVII_id" '.data.node.items.nodes[] | select(.id == $PVII_id) | .fieldValues.nodes[] | select(.field.name == "Status") | .name')

--- a/.github/workflows/pr_event_moves_card.yml
+++ b/.github/workflows/pr_event_moves_card.yml
@@ -1,0 +1,92 @@
+name: "Move the Issue Card to a different Column triggered by a PR event"
+
+on:
+  workflow_call:
+    inputs:
+      ISSUE_NUMBER:
+        required: true
+        type: string
+        description: 'The number of the issue that triggered the workflow'
+      COLUMN_NAME:
+        type: string
+        default: 'In Progress'
+        description: 'The name of the column to move the issue card to'
+      REPO_NODE_ID:
+        type: string
+        required: true
+        description: 'The node id of the repository that triggered the workflow'
+    secrets:
+        PAT:
+          required: true
+
+jobs:
+  Move_card:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Move card in projects"
+        id: move_cards
+        run: |
+          ISSUE_NUMBER="${{ inputs.ISSUE_NUMBER }}"
+          COLUMN_NAME="${{ inputs.COLUMN_NAME }}"
+          echo "ISSUE_NUMBER=$ISSUE_NUMBER"
+          echo "COLUMN_NAME=$COLUMN_NAME"
+
+          # Get the projects associated with the organization
+          projects=$(curl --request POST \
+                            --url https://api.github.com/graphql \
+                            --header "Authorization: Bearer ${{ secrets.PAT }}" \
+                            --data '{"query":"{organization(login: \"DLR-AMR\") {projectsV2(first: 20) {nodes {id title}}}}"}')
+          echo "projects=$projects">> $GITHUB_OUTPUT
+          # Get the project IDs
+          project_ids=$(echo $projects | jq -r '.data.organization.projectsV2.nodes[].id')
+          # Iterate over the project Ids and find the issue within the project
+          for project_id in $project_ids; do
+              echo "project_id is $project_id"
+              # Get the issues within the project
+              issues=$(curl --request POST \
+                      --url https://api.github.com/graphql \
+                      --header "Authorization: Bearer ${{ secrets.PAT }}" \
+                      --data "{\"query\":\"{ node(id: \\\"$project_id\\\") { ... on ProjectV2 { items(first: 100) { nodes { id fieldValues(first: 8) { nodes { ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldDateValue { date field { ... on ProjectV2FieldCommon { name } } } ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } } } } content { ... on Issue { id number repository { id } } } } } } } }\"}")
+              echo "issues=$issues"
+             # Extract the issue ids, PVII ids, and issue numbers. The issue_id is the global_id, the PVII id is the project specific id, and the issue number is the issue number (eg. #123)
+              # The issue number is not unique over all projects. So we check if the repository of the issue and the PR are the same.
+              issue_numbers=$(echo $issues | jq -r '.data.node.items.nodes[].content.number')
+              issue_ids=$(echo $issues | jq -r '.data.node.items.nodes[].content.id')
+              PVII_ids=$(echo $issues | jq -r '.data.node.items.nodes[].id')
+              # extract the repository id from the issue
+              repository_ids=$(echo $issues | jq -r '.data.node.items.nodes[].content.repository.id')
+              # In the following loop we need all three values, so we combine them into a single string
+              combined_ids=$(paste -d, <(echo "$issue_ids") <(echo "$PVII_ids") <(echo "$issue_numbers") <(echo "$repository_ids"))
+              for combined_id in $combined_ids; do
+                issue_id=$(echo $combined_id | cut -d, -f1)
+                PVII_id=$(echo $combined_id | cut -d, -f2)
+                issue_number=$(echo $combined_id | cut -d, -f3)
+                repository_id=$(echo $combined_id | cut -d, -f4)
+                echo "issue_id is $issue_id"
+                echo "PVII_id is $PVII_id"
+                echo "issue_number is $issue_number"
+                echo "repository_id is $repository_id"
+                # Check if the issue number matches the cleaned issue number from the pull request
+                if [ "$issue_number" = "$ISSUE_NUMBER" ] && [ "$repository_id" = "${{ inputs.REPO_NODE_ID }}" ]; then
+                  # An Issue number is not unique per project. We need to check if the issue is in the correct project
+                  detailed_project=$(curl --request POST \
+                        --url https://api.github.com/graphql \
+                        --header "Authorization: Bearer ${{ secrets.PAT }}" \
+                        --data "{\"query\":\"{ node(id: \\\"$project_id\\\") { ... on ProjectV2 { fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } items(first: 100) { nodes { content { ... on Issue { id number } } } } } } }\"}")
+                  echo "detailed_project=$detailed_project"
+                  # Extract the status field id
+                  status_field_id=$(echo $detailed_project | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
+                  echo "status_field_id is $status_field_id"
+                  # Extract the option id for the new status
+                  Option_id=$(echo $detailed_project | jq -r --arg COLUMN_NAME "$COLUMN_NAME" '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == $COLUMN_NAME) | .id')
+                  echo "Option_id is $Option_id"
+                  # Change the status of the issue to the new status
+                  echo "change field $status_field_id of issue $issue_id in project $project_id to $COLUMN_NAME"
+                  response=$(curl --request POST \
+                    --url https://api.github.com/graphql \
+                    --header "Authorization: Bearer ${{ secrets.PAT }}" \
+                    --data '{"query":"mutation {updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$status_field_id'\", value: { singleSelectOptionId: \"'$Option_id'\"}}) {projectV2Item {id}}}"}')
+                  echo "response=$response"
+                fi
+              done
+            done

--- a/.github/workflows/quick_pr.yml
+++ b/.github/workflows/quick_pr.yml
@@ -1,0 +1,64 @@
+name: "Create an issue in the repository for a PR that does not have one yet"
+
+on:
+  workflow_call:
+    secrets:
+        PAT:
+          required: true
+    outputs:
+        ISSUE_NUMBER:
+            description: 'The number of the issue that was created'
+            value: ${{ jobs.create_issue.outputs.ISSUE_NUMBER }}
+
+jobs:
+    create_issue:
+        runs-on: ubuntu-latest
+        outputs:
+            ISSUE_NUMBER: ${{ steps.create_issue_and_output_number.outputs.ISSUE_NUMBER }}
+        steps:
+        - uses: actions/checkout@v4
+          with:
+                repository: ${{ github.event.repository.full_name }}
+                ref: ${{ github.event.pull_request.head.ref }}
+                fetch-depth: 0
+
+        - name: "Set up environment"
+          run: echo "GITHUB_TOKEN=${{ secrets.PAT }}" >> $GITHUB_ENV
+
+        - name: "Create Issue"
+          id: create_issue_and_output_number
+          run: |
+                # Get the title of the triggering PR
+                TITLE="${{ github.event.pull_request.title }}"
+                AUTHOR="${{ github.event.pull_request.user.login }}"
+                echo "TITLE=$TITLE"
+                echo "AUTHOR=$AUTHOR"
+                new_issue_url=$(gh issue create \
+                    --title "$TITLE" \
+                    --assignee "$AUTHOR" \
+                    --body "This Issue was created because the PR did not reference an Issue."
+                )
+                echo "new_issue_url=$new_issue_url"
+                # Extract the issue number from the URL. 
+                # The URL is in the format https://github.com/orga-name/repo-name/issues/issues_number
+                ISSUE_NUMBER=$(echo "$new_issue_url" | awk -F'/' '{print $NF}')
+                echo "ISSUE_NUMBER=$ISSUE_NUMBER"
+                echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+
+        - name: "Link Issue to PR"
+          id: link_issue
+          run: |
+                # Add "Closes #ISSUE_NUMBER" to the PR body
+                ISSUE_NUMBER="${{ steps.create_issue_and_output_number.outputs.ISSUE_NUMBER }}"
+                PR_NUMBER="${{ github.event.pull_request.number }}"
+                echo "ISSUE_NUMBER=$ISSUE_NUMBER"
+                echo "PR_NUMBER=$PR_NUMBER"
+                # Get the PR body
+                pr_body=$(jq -r '.pull_request.body // ""' < $GITHUB_EVENT_PATH)
+                echo "pr_body=$pr_body"
+                # Add the issue number to the PR body
+                # Add "Closes #ISSUE_NUMBER" to the top of the PR body
+                new_pr_body=$(printf "Closes #%s\n\n%s" "$ISSUE_NUMBER" "$pr_body")
+                echo "new_pr_body=$new_pr_body"
+                # Update the PR body
+                gh pr edit "$PR_NUMBER" --body "$new_pr_body"


### PR DESCRIPTION
Closes #1510

This adds 4 files to automize project boards. A full documentation of what they do can be found [here](https://github.com/DLR-AMR/workflows_for_GH_projects). 

The file move_card evaluates issue and PR triggered events and decides where a card that is related to the issue/PR should be moved. 
Issue_event_moves_card is called by move_card if an issue-event has been triggered and moves the card to a specified column. 
PR_event is called by move_card if a pr_event has been triggered. It also checks if the issue and PR are realy related, because issue-numbers are only unique on repository level, not on organization level. 
Quick_PR is called if a PR does not reference an issue. A new Issue is opened and referenced by the PR. 

It also introduces one major change to our general workflow, which would otherwise be confusing to the automatization. 
If somebody is assigned to do a review, they should not be assigned to the PR. Instead a review should be requested from them. (They can also be assigned to the PR, but we usually switch assignments a couple of times until a PR is merged. That way we can not figure out the meaning of the assignement, especially during work that is done before the review. To avoid this I propose this change in our workflow). 

To fully enable the workflow we need to: 
- [x] add read/write access for projects on organization level for T8DDY
- [x] add read/write access for issues on repository level for T8DDY 
- [x] add read/write access for PR on repository level for T8DDY
- [x] open up a base project board to move issue cards.
- [x] Test if PR access works by closing and reopening the PR, as soon as a landing-board has been established. 

The wf is currently failing, because there is no base project board where the wf could act on.  


**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [x] The reviewer executed the new code features at least once and checked the results manually.
- [x] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [x] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### Tag Label
- [ ] The author added the patch/minor/major label in accordance to semantic versioning.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).