### PR TITLE
Bugfix: Change strategy to find test binaries for valgrind ci

### DIFF
--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -184,7 +184,7 @@ jobs:
 
   # Run Valgrind check for every t8code test binary.
   t8code_valgrind_tests:
-    #if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') # Only run the Valgrind check in the scheduled run.
+    if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') # Only run the Valgrind check in the scheduled run.
     needs: preparation
     uses: ./.github/workflows/tests_cmake_valgrind.yml
     with:

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -184,7 +184,7 @@ jobs:
 
   # Run Valgrind check for every t8code test binary.
   t8code_valgrind_tests:
-    if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') # Only run the Valgrind check in the scheduled run.
+    #if: (github.event_name == 'schedule' && github.repository == 'DLR-AMR/t8code') # Only run the Valgrind check in the scheduled run.
     needs: preparation
     uses: ./.github/workflows/tests_cmake_valgrind.yml
     with:

--- a/.github/workflows/tests_cmake_valgrind.yml
+++ b/.github/workflows/tests_cmake_valgrind.yml
@@ -42,7 +42,7 @@ on:
 
 jobs:  
   valgrind_check:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     container: dlramr/t8code-ubuntu:t8-dependencies
     steps:

--- a/.github/workflows/tests_cmake_valgrind.yml
+++ b/.github/workflows/tests_cmake_valgrind.yml
@@ -42,7 +42,7 @@ on:
 
 jobs:  
   valgrind_check:
-    timeout-minutes: 120
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     container: dlramr/t8code-ubuntu:t8-dependencies
     steps:

--- a/.github/workflows/tests_cmake_valgrind.yml
+++ b/.github/workflows/tests_cmake_valgrind.yml
@@ -42,7 +42,7 @@ on:
 
 jobs:  
   valgrind_check:
-    timeout-minutes: 180
+    timeout-minutes: 95
     runs-on: ubuntu-latest
     container: dlramr/t8code-ubuntu:t8-dependencies
     steps:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,8 +40,7 @@ This script runs Valgrind on a binary path provided as a parameter with specifie
 
 #### find_all_test_binary_paths.sh
 
-This file lists all binary paths to test files, except for the tests for the api (as the Fortran interface needs to be built for that).
-The [CMakeLists.txt file in the test folder](../test/CMakeLists.txt) is used to generate the list of binary paths.
+This file lists all paths to test binaries that exist in the build/test directory.
 The paths are relative paths assuming an execution from the test/ folder in the build directory.
 
 #### check_all_test_binaries_valgrind.sh

--- a/scripts/check_all_test_binaries_valgrind.sh
+++ b/scripts/check_all_test_binaries_valgrind.sh
@@ -58,6 +58,7 @@ counter=0
 valgrind_suppressions_file=../../scripts/valgrind_suppressions_file.supp
 
 for bin_path in $test_bin_paths; do
+  echo "[$counter/$num_paths] Valgrind check of $bin_path..."
   # Run check_valgrind script for each test binary.
   bash ../../scripts/check_valgrind.sh $bin_path $valgrind_suppressions_file 2>&1
   status=$?
@@ -67,7 +68,6 @@ for bin_path in $test_bin_paths; do
     exit 1
   fi
   counter=$(( $counter + 1 ))
-  echo "Checked $counter of $num_paths files."
 done
 
 echo "Valgrind found no errors in the test executables."

--- a/scripts/check_all_test_binaries_valgrind.sh
+++ b/scripts/check_all_test_binaries_valgrind.sh
@@ -58,6 +58,7 @@ counter=0
 valgrind_suppressions_file=../../scripts/valgrind_suppressions_file.supp
 
 for bin_path in $test_bin_paths; do
+  counter=$(( $counter + 1 ))
   echo "[$counter/$num_paths] Valgrind check of $bin_path..."
   # Run check_valgrind script for each test binary.
   bash ../../scripts/check_valgrind.sh $bin_path $valgrind_suppressions_file 2>&1
@@ -67,7 +68,6 @@ for bin_path in $test_bin_paths; do
     echo "Error occurred during the valgrind check of $bin_path."
     exit 1
   fi
-  counter=$(( $counter + 1 ))
 done
 
 echo "Valgrind found no errors in the test executables."

--- a/scripts/find_all_test_binary_paths.sh
+++ b/scripts/find_all_test_binary_paths.sh
@@ -21,53 +21,21 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 #
-# This file lists all binary paths to test files, except for the tests for the api 
-# (as the Fortran interface needs to be built for that).
-# The script can be used to run the check_valgrind script for every test binary. 
-# The CMakeLists.txt file in the test folder is used to generate the list of binary paths.
+# This file lists all paths to test binaries that exist in the build/test directory.
+# The script can be used to run the check_valgrind script for every test binary.
 # The paths are relative paths assuming an execution from the test/ folder in the build directory.
 #
 
-cmake_file="../test/CMakeLists.txt"
+build_test_directory="../build/test/"
 
-# Check that path to cmake_file is correct.
-if [ ! -f "$cmake_file" ]; then
-  echo "CMakeLists.txt not found!"
+# Check that path to test folder in build directory is correct.
+if [ ! -d "$build_test_directory" ]; then
+  echo "Directory build/test/ not found!"
   exit 1
 fi
 
-# List with test binary paths.
-test_bin_paths=""
-name=""
-
-# Iterate over the lines of the cmake file. 
-while IFS= read -r line; do
-  # Consider line if it contains “add_t8_test(”.
-  if [[ "$line" == *"add_t8_test("* ]]; then
-    # Extract the name of the executable.
-    [[ "$line" =~ NAME[[:space:]]+([a-zA-Z0-9_]+) ]]
-    name="${BASH_REMATCH[1]}"
-
-    # Extract the subfolder of the executable.
-    [[ "$line" =~ SOURCES[[:space:]]+([a-zA-Z0-9_/.-]+) ]]
-    related_source="${BASH_REMATCH[1]}"
-    # Check if the first argument is 't8_gtest_main.cxx'.
-    if [[ "$related_source" == "t8_gtest_main.cxx" ]]; then
-      # Extract the second argument if the first one is 't8_gtest_main.cxx'.
-      if [[ "$line" =~ SOURCES[[:space:]]+[a-zA-Z0-9_/.-]+[[:space:]]+([a-zA-Z0-9_/.-]+) ]]; then
-        related_source="${BASH_REMATCH[1]}"
-      fi
-    fi
-    # Add folder location if file is in a subfolder.
-    if [[ "$related_source" =~ ^(.*)/ ]]; then
-      name="${BASH_REMATCH[1]}/${name}"
-    fi
-    
-    # Do not include api in the binary paths as we do not want to check them with valgrind.
-    if ! [[ "$name" =~ "api/" ]]; then
-      test_bin_paths="${test_bin_paths} ./${name}"
-    fi
-  fi
-done < "$cmake_file"
+# Find all executables in the build/test/ directory (that do not have a .so file ending) 
+# and store the relative paths to the build_test_directory with leading "./".
+test_bin_paths=$(find "$build_test_directory" -type f -executable -not -name "*.so" -exec realpath --relative-to="$build_test_directory" {} \; | sed 's|^|./|')
 
 echo $test_bin_paths


### PR DESCRIPTION
**_Describe your changes here:_**
Previously, the find_all_test_binaries file found a file that was not built with all options, resulting in an error. The new implementation actually lists the executables in the build/test/ directory. 
Also, the timeout had to be increased as the time of the test suite at test level 2 increased.
Closes #1441 

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).