### PR TITLE
Fix CI not checking external linkage properly [tests should fail until #1513 is merged]

### DIFF
--- a/.github/workflows/tests_cmake_preparation.yml
+++ b/.github/workflows/tests_cmake_preparation.yml
@@ -178,6 +178,10 @@ jobs:
       run: cd $P4EST_RELEASE && ninja $MAKEFLAGS && ninja $MAKEFLAGS install
       if: ${{ steps.p4est_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
     
+    ## deinit submodules
+    - name: deinit submodules
+      run: git submodule deinit --all -f
+
     ## output cache info
     - name: output cache info
       id: used_cache

--- a/.github/workflows/tests_cmake_preparation.yml
+++ b/.github/workflows/tests_cmake_preparation.yml
@@ -117,14 +117,14 @@ jobs:
       if: ${{ steps.sc_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
       ## sc debug
     - name: sc cmake debug
-      run: cd $SC_DEBUG && cmake ../../ -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$SC_DEBUG/install -Dmpi=$MPI -GNinja
+      run: cd $SC_DEBUG && cmake ../../sc/ -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$SC_DEBUG/install -Dmpi=$MPI -GNinja
       if: ${{ steps.sc_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
     - name: sc build debug
       run: cd $SC_DEBUG && ninja $MAKEFLAGS && ninja $MAKEFLAGS install
       if: ${{ steps.sc_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
       ## sc release
     - name: sc cmake release
-      run: cd $SC_RELEASE && cmake ../../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$SC_RELEASE/install -Dmpi=$MPI -GNinja
+      run: cd $SC_RELEASE && cmake ../../sc/ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$SC_RELEASE/install -Dmpi=$MPI -GNinja
       if: ${{ steps.sc_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
     - name: sc build release
       run: cd $SC_RELEASE && ninja $MAKEFLAGS && ninja $MAKEFLAGS install
@@ -165,14 +165,14 @@ jobs:
       run: mkdir -p $P4EST_DEBUG $P4EST_RELEASE
     ## p4est debug
     - name: p4est cmake debug
-      run: cd $P4EST_DEBUG && cmake ../../ -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$P4EST_DEBUG/install -DP4EST_USE_SYSTEM_SC=ON -DSC_DIR=$SC_DEBUG/install/cmake -DP4EST_ENABLE_MPI=$MPI -GNinja
+      run: cd $P4EST_DEBUG && cmake ../../p4est/ -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$P4EST_DEBUG/install -DP4EST_USE_SYSTEM_SC=ON -DSC_DIR=$SC_DEBUG/install/cmake -DP4EST_ENABLE_MPI=$MPI -GNinja
       if: ${{ steps.p4est_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
     - name: p4est build debug
       run: cd $P4EST_DEBUG && ninja $MAKEFLAGS && ninja $MAKEFLAGS install
       if: ${{ steps.p4est_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
     ## p4est release
     - name: p4est cmake release
-      run: cd $P4EST_RELEASE && cmake ../../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$P4EST_RELEASE/install -DP4EST_USE_SYSTEM_SC=ON -DSC_DIR=$SC_DEBUG/install/cmake -DP4EST_ENABLE_MPI=$MPI -GNinja
+      run: cd $P4EST_RELEASE && cmake ../../p4est/ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$P4EST_RELEASE/install -DP4EST_USE_SYSTEM_SC=ON -DSC_DIR=$SC_DEBUG/install/cmake -DP4EST_ENABLE_MPI=$MPI -GNinja
       if: ${{ steps.p4est_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
     - name: p4est build release
       run: cd $P4EST_RELEASE && ninja $MAKEFLAGS && ninja $MAKEFLAGS install

--- a/.github/workflows/tests_cmake_preparation.yml
+++ b/.github/workflows/tests_cmake_preparation.yml
@@ -85,9 +85,9 @@ jobs:
 #       SC installation
 #
     - name: store sc folders in var
-      run: echo SC_BUILD=$PWD/sc/build >> $GITHUB_ENV
-        && echo SC_DEBUG=$PWD/sc/build/Debug >> $GITHUB_ENV
-        && echo SC_RELEASE=$PWD/sc/build/Release >> $GITHUB_ENV
+      run: echo SC_BUILD=$PWD/sc_build >> $GITHUB_ENV
+        && echo SC_DEBUG=$PWD/sc_build/Debug >> $GITHUB_ENV
+        && echo SC_RELEASE=$PWD/sc_build/Release >> $GITHUB_ENV
     - name: Get sc commit hash
       run: hash=`git rev-parse HEAD:sc` && echo sc_commit=$hash >> $GITHUB_ENV
     - name: Check cache for previous sc installation
@@ -133,9 +133,9 @@ jobs:
 # P4EST
 #
     - name: store p4est folders in var
-      run: echo P4EST_BUILD=$PWD/p4est/build >> $GITHUB_ENV
-        && echo P4EST_DEBUG=$PWD/p4est/build/Debug >> $GITHUB_ENV
-        && echo P4EST_RELEASE=$PWD/p4est/build/Release >> $GITHUB_ENV
+      run: echo P4EST_BUILD=$PWD/p4est_build >> $GITHUB_ENV
+        && echo P4EST_DEBUG=$PWD/p4est_build/Debug >> $GITHUB_ENV
+        && echo P4EST_RELEASE=$PWD/p4est_build/Release >> $GITHUB_ENV
     - name: Get p4est commit hash
       run: hash=`git rev-parse HEAD:p4est` && echo p4est_commit=$hash >> $GITHUB_ENV
     - name: Check cache for previous p4est installation

--- a/.github/workflows/tests_cmake_sc_p4est.yml
+++ b/.github/workflows/tests_cmake_sc_p4est.yml
@@ -72,10 +72,10 @@ jobs:
 #
     ## save variables  
     - name: Save variables
-      run: export SC_DEBUG=$PWD/sc/build/Debug
-        && export SC_RELEASE=$PWD/sc/build/Release
-        && export P4EST_DEBUG=$PWD/p4est/build/Debug
-        && export P4EST_RELEASE=$PWD/p4est/build/Release
+      run: export SC_DEBUG=$PWD/sc_build/Debug
+        && export SC_RELEASE=$PWD/sc_build/Release
+        && export P4EST_DEBUG=$PWD/p4est_build/Debug
+        && export P4EST_RELEASE=$PWD/p4est_build/Release
         && echo SC_DEBUG="$SC_DEBUG" >> $GITHUB_ENV
         && echo SC_RELEASE="$SC_RELEASE" >> $GITHUB_ENV
         && echo P4EST_DEBUG="$P4EST_DEBUG" >> $GITHUB_ENV

--- a/.github/workflows/tests_cmake_t8code.yml
+++ b/.github/workflows/tests_cmake_t8code.yml
@@ -68,8 +68,8 @@ jobs:
       run: export MAKEFLAGS="${{ inputs.MAKEFLAGS }}"
         && export MPI="${{ inputs.MPI }}"
         && export BUILD_TYPE="${{ inputs.BUILD_TYPE }}"
-        && export SC_PATH=$PWD/sc/build/$BUILD_TYPE
-        && export P4EST_PATH=$PWD/p4est/build/$BUILD_TYPE
+        && export SC_PATH=$PWD/sc_build/$BUILD_TYPE
+        && export P4EST_PATH=$PWD/p4est_build/$BUILD_TYPE
         && echo MAKEFLAGS="$MAKEFLAGS" >> $GITHUB_ENV
         && echo MPI="$MPI" >> $GITHUB_ENV
         && echo BUILD_TYPE="$BUILD_TYPE" >> $GITHUB_ENV

--- a/.github/workflows/tests_cmake_t8code_api.yml
+++ b/.github/workflows/tests_cmake_t8code_api.yml
@@ -68,8 +68,8 @@ jobs:
       run: export MAKEFLAGS="${{ inputs.MAKEFLAGS }}"
         && export MPI="${{ inputs.MPI }}"
         && export BUILD_TYPE="${{ inputs.BUILD_TYPE }}"
-        && export SC_PATH=$PWD/sc/build/$BUILD_TYPE
-        && export P4EST_PATH=$PWD/p4est/build/$BUILD_TYPE
+        && export SC_PATH=$PWD/sc_build/$BUILD_TYPE
+        && export P4EST_PATH=$PWD/p4est_build/$BUILD_TYPE
         && echo MAKEFLAGS="$MAKEFLAGS" >> $GITHUB_ENV
         && echo MPI="$MPI" >> $GITHUB_ENV
         && echo BUILD_TYPE="$BUILD_TYPE" >> $GITHUB_ENV

--- a/.github/workflows/tests_cmake_t8code_linkage.yml
+++ b/.github/workflows/tests_cmake_t8code_linkage.yml
@@ -68,8 +68,8 @@ jobs:
       run: export MAKEFLAGS="${{ inputs.MAKEFLAGS }}"
         && export MPI="${{ inputs.MPI }}"
         && export BUILD_TYPE="${{ inputs.BUILD_TYPE }}"
-        && export SC_PATH=$PWD/sc/build/$BUILD_TYPE
-        && export P4EST_PATH=$PWD/p4est/build/$BUILD_TYPE
+        && export SC_PATH=$PWD/sc_build/$BUILD_TYPE
+        && export P4EST_PATH=$PWD/p4est_build/$BUILD_TYPE
         && echo MAKEFLAGS="$MAKEFLAGS" >> $GITHUB_ENV
         && echo MPI="$MPI" >> $GITHUB_ENV
         && echo BUILD_TYPE="$BUILD_TYPE" >> $GITHUB_ENV

--- a/.github/workflows/tests_cmake_testsuite.yml
+++ b/.github/workflows/tests_cmake_testsuite.yml
@@ -114,7 +114,7 @@ jobs:
     with:
       MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
       IGNORE_CACHE: false # Use this to force a new installation of sc and p4est for this specific workflow run
-      CACHE_COUNTER: 0 # Increase this number to force a new installation of sc and p4est and to update the cache once
+      CACHE_COUNTER: 1 # Increase this number to force a new installation of sc and p4est and to update the cache once
       MPI: ${{ matrix.MPI }}
   
   # Run parallel tests for sc and p4est with and without MPI

--- a/.github/workflows/tests_cmake_valgrind.yml
+++ b/.github/workflows/tests_cmake_valgrind.yml
@@ -64,8 +64,8 @@ jobs:
       run: export MAKEFLAGS="${{ inputs.MAKEFLAGS }}"
         && export MPI="${{ inputs.MPI }}"
         && export BUILD_TYPE="${{ inputs.BUILD_TYPE }}"
-        && export SC_PATH=$PWD/sc/build/$BUILD_TYPE
-        && export P4EST_PATH=$PWD/p4est/build/$BUILD_TYPE
+        && export SC_PATH=$PWD/sc_build/$BUILD_TYPE
+        && export P4EST_PATH=$PWD/p4est_build/$BUILD_TYPE
         && echo MAKEFLAGS="$MAKEFLAGS" >> $GITHUB_ENV
         && echo MPI="$MPI" >> $GITHUB_ENV
         && echo BUILD_TYPE="$BUILD_TYPE" >> $GITHUB_ENV


### PR DESCRIPTION
**_Describe your changes here:_**
The CI had the submodules still loaded while testing the external linkage. This PR moves the binaries of p4est and sc into another folder and deinits sc and p4est afterwards. This way t8code cannot use the header files from the loaded submodules. This change should catch the error fixed here:
https://github.com/DLR-AMR/t8code/pull/1513

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).