### PR TITLE
Fix set_linear_id for prisms

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -77,7 +77,7 @@ t8_dprism_init_linear_id (t8_dprism_t *p, int level, t8_linearidx_t id)
   t8_linearidx_t tri_id = 0;
   t8_linearidx_t line_id = 0;
   int i;
-  int triangles_of_size_i = 1;
+  t8_linearidx_t triangles_of_size_i = 1;
 
   T8_ASSERT (0 <= level && level <= T8_DPRISM_MAXLEVEL);
   T8_ASSERT (id < sc_intpow64u (T8_DPRISM_CHILDREN, level));


### PR DESCRIPTION
This PR addresses an issue with `element_set_linear_id` I encountered for the default prism scheme. For example, when running 
```
t8_element_t *element;
ts->element_new (eclass, 1, &element);
ts->element_set_linear_id (eclass, element, 21, 2305843009213693952);
t8_linearidx_t linearid = ts->element_get_linear_id (eclass, element, 21);
```
with the respective eclass and scheme and 2305843009213693952 being the global first descendant of child 2 on level 1, `linearid` would evaluate to 0 instead of the input linearid. This seems to be caused by `triangles_of_size_i` which overflows and evaluates to 0 at some point in `t8_dprism_init_linear_id`. By switching its type to t8_linearidx_t the above code yielded the expected results.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [x] Should this use case be added to the github action?
  - [x] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).