### PR TITLE
T8_WITH_ macros that will throw an error when used

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,4 +3,4 @@ eles = "eles"
 packageid = "packageid"
 
 [files]
-extend-exclude = ["scripts/t8indent.sh", "thirdparty/", "t8code_logo.png", "cmake/FindOpenCASCADE.cmake"]
+extend-exclude = ["scripts/t8indent.sh", "thirdparty/", "t8code_logo.png", "cmake/FindOpenCASCADE.cmake", "src/t8_with_macro_error.h"]

--- a/src/t8.h
+++ b/src/t8.h
@@ -29,6 +29,7 @@
 #ifndef T8_H
 #define T8_H
 
+#include <t8_with_macro_error.h>
 /* include config headers */
 #ifndef T8_CMAKE_BUILD
 #include <t8_config.h>

--- a/src/t8_with_macro_error.h
+++ b/src/t8_with_macro_error.h
@@ -1,0 +1,74 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2025 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_with_macro_error.h
+ * This file defines macros to cause an error in user code when using
+ * deprecated "T8_WITH_*" macros.
+ * Unfortunately, the error will not be raised in #ifdef constructions (This is still an open TODO.).
+ * With https://github.com/DLR-AMR/t8code/issues/1370 we switched all our macros
+ * that control settings and external libraries to "T8_ENABLE_*".
+ * Users might not have implmented that change and left "T8_WITH_*" in their code.
+ * This could lead to unintentionally behaviour if the macros are ignored even if the
+ * setting would have been enabled.
+ * Hence, we define a macro that throws an error, whenever a "T8_WITH_*" is called.
+ * This macro is defined for each "T8_ENABLE_*" option.
+ */
+
+
+#ifndef T8_WITH_MACRO_ERROR_H
+#define T8_WITH_MACRO_ERROR_H
+
+// clang-format off
+// Since we use a symbol that is not part of C/C++ syntax, clang-format would not indent the file.
+/** This macro defines the macro "T8_THROW_ERROR_WITH" to cause an error
+ * whenever it is evaluated. Inlcuding #if usage. (But not including #ifdef usage).
+ * Example usage: 
+ *  #define T8_WITH_DEBUG T8_THROW_ERROR_WITH
+ * 
+ * Using this with
+ * #if T8_WITH_DEBUG
+ * will throw a compile-time error.
+*/
+#define T8_THROW_ERROR_WITH @"Invalid usage of T8_WITH_*. Use T8_ENABLE_* instead."
+// clang-format on
+
+// We would like to use #error here to cause a compile time error message,
+// however, expanding "#error" in macros is not supported.
+// Instead, we use the symbol "@" which is not part of C/C++ syntax and will throw
+// an error when evaluated. See also https://stackoverflow.com/questions/21055507/forcing-preprocessor-error-with-macro
+
+// We now define all T8_ENABLE_* macros that existed at 28 March 2025 to throw an error
+// when called in a T8_WITH_* version.
+#define T8_WITH_DEBUG T8_THROW_ERROR_WITH
+#define T8_WITH_VTK T8_THROW_ERROR_WITH
+#define T8_WITH_NETCDF T8_THROW_ERROR_WITH
+#define T8_WITH_NETCDF_PAR T8_THROW_ERROR_WITH
+#define T8_WITH_OCC T8_THROW_ERROR_WITH
+#define T8_WITH_METIS T8_THROW_ERROR_WITH
+#define T8_WITH_MPI T8_THROW_ERROR_WITH
+#define T8_WITH_MPIIO T8_THROW_ERROR_WITH
+#define T8_WITH_FORTRAN T8_THROW_ERROR_WITH
+#define T8_WITH_CPPSTD T8_THROW_ERROR_WITH
+#define T8_WITH_MODDIR T8_THROW_ERROR_WITH
+#define T8_WITH_CUSTOM_TEST_COMMAND T8_THROW_ERROR_WITH
+
+#endif // T8_WITH_MACRO_ERROR_H


### PR DESCRIPTION
**_Describe your changes here:_**

Since #1468 all our macros have been renamed from T8_WITH* to T8_ENABLE*.
We have an internal check_macros script to find all wrongly used T8_WITH in our code base.
However, user code may not be aware of the changes and still use code like
```C++
#if T8_WITH_MPI
// something
#endif
```
This code will still compile after the update and if users do not read and implement the update news, they will run into behaviour that is
a) undesired and
b) very hard to track down

I propose a solution that overwrites the old T8_WITH_ macros so that using them with "#if"  will throw a compile time error.
Thus, users will be immediately warned and informed to use T8_ENABLE instead.

I put this up for discussion.

The following points are still open:
- Using the macros with #ifdef still does not produce an error. #ifdef just checks whether or not the macro is defined and does not care about the actual definition. Would there even be a solution to throw an error of #ifdef?
- clang-format throws the error "Configuration file(s) do(es) not support Objective-C: /localdata1/holk_jo/coding/source/t8code/1370-warn_users_if_WITH_macro_is_used/.clang-format" 
 Even when using "// clang-format off" comments. Hence, we must somehow make the automatic indent script ignore this file.
- I tried several approaches, including the #error directive, but all of them did not work. So i had to use a slightly hacky solution.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).