### PR TITLE
Bugfix: More robust handling of labels

### DIFF
--- a/.github/workflows/move_card.yml
+++ b/.github/workflows/move_card.yml
@@ -27,6 +27,7 @@ jobs:
             # Set WORKLOAD_SET to true
             WORKLOAD_SET=true
             echo "WORKLOAD_SET=$WORKLOAD_SET" >> $GITHUB_OUTPUT
+            # extract the workload value. Suppresses error messages from jq. If the label can not be found, an empty string is added.
             labels=$(echo '${{ toJSON(github.event.issue.labels) }}' | jq -r '.[]?.name' 2>/dev/null || echo "")
             workload=$(echo "$labels" | grep -oE 'workload:(high|medium|low)' | cut -d: -f2)
             echo "WORKLOAD=$workload"
@@ -57,7 +58,6 @@ jobs:
             # Set PRIORITY_SET to true
             PRIORITY_SET=true
             echo "PRIORITY_SET=$PRIORITY_SET" >> $GITHUB_OUTPUT
-            # extract the priority value
             # extract the priority value. Suppresses error messages from jq. If the label can not be found, an empty string is added.
             labels=$(echo '${{ toJSON(github.event.issue.labels) }}' | jq -r '.[]?.name' 2>/dev/null || echo "")
             priority=$(echo "$labels" | grep -oE 'priority:(high|medium|low)' | cut -d: -f2)

--- a/.github/workflows/move_card.yml
+++ b/.github/workflows/move_card.yml
@@ -27,8 +27,7 @@ jobs:
             # Set WORKLOAD_SET to true
             WORKLOAD_SET=true
             echo "WORKLOAD_SET=$WORKLOAD_SET" >> $GITHUB_OUTPUT
-            # extract the workload value
-            labels=$(echo '${{ toJSON(github.event.issue.labels) }}' | jq -r '.[].name')
+            labels=$(echo '${{ toJSON(github.event.issue.labels) }}' | jq -r '.[]?.name' 2>/dev/null || echo "")
             workload=$(echo "$labels" | grep -oE 'workload:(high|medium|low)' | cut -d: -f2)
             echo "WORKLOAD=$workload"
             WORKLOAD=$workload
@@ -59,7 +58,8 @@ jobs:
             PRIORITY_SET=true
             echo "PRIORITY_SET=$PRIORITY_SET" >> $GITHUB_OUTPUT
             # extract the priority value
-            labels=$(echo '${{ toJSON(github.event.issue.labels) }}' | jq -r '.[].name')
+            # extract the priority value. Suppresses error messages from jq. If the label can not be found, an empty string is added.
+            labels=$(echo '${{ toJSON(github.event.issue.labels) }}' | jq -r '.[]?.name' 2>/dev/null || echo "")
             priority=$(echo "$labels" | grep -oE 'priority:(high|medium|low)' | cut -d: -f2)
             echo "PRIORITY=$priority"
             PRIORITY=$priority


### PR DESCRIPTION
Special signs, empty spaces, etc could cause an error while processing the labels. 
If that happens we suppress the error-message (which lead to a failing wf) and add an empty string to the "labels"-variable instead. That way all following labels can be processed without the wf failing. 
Closes #1532 

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).