### PR TITLE
Automatically mark sc and p4est options as advanced

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,20 +122,20 @@ else()
     set( SC_BUILD_TESTING ${T8CODE_BUILD_TPL_TESTS} )
     
     # Capture the list of variables before adding the subdirectory to mark the added ones as advanced.
-    get_cmake_property(_vars_before_sc VARIABLES)
+    get_cmake_property(_vars_before_sc VARIABLES )
     add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/sc )
     # Capture the list of variables after adding the subdirectory
-    get_cmake_property(_vars_after_sc VARIABLES)
+    get_cmake_property(_vars_after_sc VARIABLES )
     # Compute the difference (new variables added by the subdirectory)
-    set(_new_sc_vars)
-    foreach(_var IN LISTS _vars_after_sc)
-        if(NOT _var IN_LIST _vars_before_sc)
-            list(APPEND _new_sc_vars ${_var})
+    set( _new_sc_vars)
+    foreach( _var IN LISTS _vars_after_sc )
+        if( NOT _var IN_LIST _vars_before_sc )
+            list( APPEND _new_sc_vars ${_var} )
         endif()
     endforeach()
     
     # Mark the new variables as advanced
-    mark_as_advanced(${_new_sc_vars})
+    mark_as_advanced( FORCE ${_new_sc_vars} )
 endif()
 
 if ( T8CODE_USE_SYSTEM_P4EST )
@@ -145,20 +145,20 @@ else()
     set( P4EST_BUILD_TESTING ${T8CODE_BUILD_TPL_TESTS} )
     
     # Capture the list of variables before adding the subdirectory to mark the added ones as advanced.
-    get_cmake_property(_vars_before_p4est VARIABLES)
+    get_cmake_property( _vars_before_p4est VARIABLES )
     add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/p4est )
     # Capture the list of variables after adding the subdirectory
-    get_cmake_property(_vars_after_p4est VARIABLES)
+    get_cmake_property( _vars_after_p4est VARIABLES )
     # Compute the difference (new variables added by the subdirectory)
-    set(_new_p4est_vars)
-    foreach(_var IN LISTS _vars_after_p4est)
-        if(NOT _var IN_LIST _vars_before_p4est)
-            list(APPEND _new_p4est_vars ${_var})
+    set( _new_p4est_vars )
+    foreach( _var IN LISTS _vars_after_p4est )
+        if( NOT _var IN_LIST _vars_before_p4est )
+            list( APPEND _new_p4est_vars ${_var} )
         endif()
     endforeach()
     
     # Mark the new variables as advanced
-    mark_as_advanced(${_new_p4est_vars})
+    mark_as_advanced( FORCE ${_new_p4est_vars} )
 endif()
 
 add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/src )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,21 @@ if ( T8CODE_USE_SYSTEM_SC )
 else()
     set( SC_BUILD_EXAMPLES ${T8CODE_BUILD_TPL_EXAMPLES} )
     set( SC_BUILD_TESTING ${T8CODE_BUILD_TPL_TESTS} )
-    add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/sc )
+    
+    # Capture the list of variables before adding the subdirectory to mark the added ones as advanced.
+    get_cmake_property(_vars_before_sc VARIABLES)
+    add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/sc )# Compute the difference (new variables added by the subdirectory)
+    # Capture the list of variables after adding the subdirectory
+    get_cmake_property(_vars_after_sc VARIABLES)
+    set(_new_sc_vars)
+    foreach(_var IN LISTS _vars_after_sc)
+        if(NOT _var IN_LIST _vars_before_sc)
+            list(APPEND _new_sc_vars ${_var})
+        endif()
+    endforeach()
+    
+    # Mark the new variables as advanced
+    mark_as_advanced(${_new_sc_vars})
 endif()
 
 if ( T8CODE_USE_SYSTEM_P4EST )
@@ -128,7 +142,21 @@ if ( T8CODE_USE_SYSTEM_P4EST )
 else()
     set( P4EST_BUILD_EXAMPLES ${T8CODE_BUILD_TPL_EXAMPLES} )
     set( P4EST_BUILD_TESTING ${T8CODE_BUILD_TPL_TESTS} )
+    
+    # Capture the list of variables before adding the subdirectory to mark the added ones as advanced.
+    get_cmake_property(_vars_before_p4est VARIABLES)
     add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/p4est )
+    # Capture the list of variables after adding the subdirectory
+    get_cmake_property(_vars_after_p4est VARIABLES)
+    set(_new_p4est_vars)
+    foreach(_var IN LISTS _vars_after_p4est)
+        if(NOT _var IN_LIST _vars_before_p4est)
+            list(APPEND _new_p4est_vars ${_var})
+        endif()
+    endforeach()
+    
+    # Mark the new variables as advanced
+    mark_as_advanced(${_new_p4est_vars})
 endif()
 
 add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/src )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,9 +123,10 @@ else()
     
     # Capture the list of variables before adding the subdirectory to mark the added ones as advanced.
     get_cmake_property(_vars_before_sc VARIABLES)
-    add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/sc )# Compute the difference (new variables added by the subdirectory)
+    add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/sc )
     # Capture the list of variables after adding the subdirectory
     get_cmake_property(_vars_after_sc VARIABLES)
+    # Compute the difference (new variables added by the subdirectory)
     set(_new_sc_vars)
     foreach(_var IN LISTS _vars_after_sc)
         if(NOT _var IN_LIST _vars_before_sc)
@@ -148,6 +149,7 @@ else()
     add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/p4est )
     # Capture the list of variables after adding the subdirectory
     get_cmake_property(_vars_after_p4est VARIABLES)
+    # Compute the difference (new variables added by the subdirectory)
     set(_new_p4est_vars)
     foreach(_var IN LISTS _vars_after_p4est)
         if(NOT _var IN_LIST _vars_before_p4est)


### PR DESCRIPTION
Closes #1571
Closes #1558 

**_Describe your changes here:_**
Alternative solution to https://github.com/DLR-AMR/t8code/pull/1567

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).