### PR TITLE
Bugfix: Fix geometry example

### DIFF
--- a/example/geometry/t8_example_geometries.cxx
+++ b/example/geometry/t8_example_geometries.cxx
@@ -125,14 +125,6 @@ struct t8_geometry_sincos: public t8_geometry
     SC_ABORT_NOT_REACHED ();
   }
 
-  /* Load tree data is empty since we have no tree data.
-   * We need to provide an implementation anyways. */
-  void
-  t8_geom_load_tree_data ([[maybe_unused]] t8_cmesh_t cmesh, [[maybe_unused]] t8_gloidx_t gtreeid)
-  {
-    /* Do nothing */
-  }
-
   /** Check if  the currently active tree has a negative volume. In this case return zero. */
   bool
   t8_geom_tree_negative_volume () const
@@ -291,14 +283,6 @@ struct t8_geometry_cylinder: public t8_geometry
                              [[maybe_unused]] double *jacobian) const
   {
     SC_ABORT_NOT_REACHED ();
-  }
-
-  /* Load tree data is empty since we have no tree data.
-   * We need to provide an implementation anyways. */
-  void
-  t8_geom_load_tree_data ([[maybe_unused]] t8_cmesh_t cmesh, [[maybe_unused]] t8_gloidx_t gtreeid)
-  {
-    /* Do nothing */
   }
 
   /** Check if  the currently active tree has a negative volume. In this case return zero. */
@@ -488,14 +472,6 @@ struct t8_geometry_moving: public t8_geometry
     SC_ABORT_NOT_REACHED ();
   }
 
-  /* Load tree data is empty since we have no tree data.
-   * We need to provide an implementation anyways. */
-  void
-  t8_geom_load_tree_data ([[maybe_unused]] t8_cmesh_t cmesh, [[maybe_unused]] t8_gloidx_t gtreeid)
-  {
-    /* Do nothing */
-  }
-
   /** Check if  the currently active tree has a negative volume. In this case return zero. */
   bool
   t8_geom_tree_negative_volume () const
@@ -573,14 +549,6 @@ struct t8_geometry_cube_zdistorted: public t8_geometry
                              [[maybe_unused]] double *jacobian) const
   {
     SC_ABORT_NOT_REACHED ();
-  }
-
-  /* Load tree data is empty since we have no tree data.
-   * We need to provide an implementation anyways. */
-  void
-  t8_geom_load_tree_data ([[maybe_unused]] t8_cmesh_t cmesh, [[maybe_unused]] t8_gloidx_t gtreeid)
-  {
-    /* Do nothing */
   }
 
   /** Check if  the currently active tree has a negative volume. In this case return zero. */


### PR DESCRIPTION
**_Describe your changes here:_**
Closes #1517
The tutorial did overwrite the `t8_geom_load_tree_data` function which loaded the active tree. Therefore, the active tree and compatible trees mismatched.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).