### PR TITLE
Other: Improved documentation, more assertions

### DIFF
--- a/src/t8_data/t8_shmem.c
+++ b/src/t8_data/t8_shmem.c
@@ -206,6 +206,9 @@ t8_shmem_array_prefix (const void *sendbuf, t8_shmem_array_t recvarray, const in
 {
   T8_ASSERT (t8_shmem_array_is_initialized (recvarray));
   T8_ASSERT (!t8_shmem_array_is_writing_possible (recvarray));
+  T8_ASSERT (recvarray != NULL);
+  T8_ASSERT (recvarray->array != NULL);
+  T8_ASSERT (sendbuf != NULL);
 
   sc_shmem_prefix ((void *) sendbuf, recvarray->array, count, type, op, comm);
 }

--- a/src/t8_data/t8_shmem.h
+++ b/src/t8_data/t8_shmem.h
@@ -177,12 +177,12 @@ t8_shmem_array_allgatherv (void *sendbuf, const int sendcount, sc_MPI_Datatype s
  * \note the first entry of \a recvarray will be set to 0 using memset. 
  * The entry can be changed after calling t8_shmem_array_prefix 
  * 
- * @param sendbuf 
- * @param recvarray 
- * @param count 
- * @param type 
- * @param op 
- * @param comm 
+ * \param[in] sendbuf           The source from this process
+ * \param[in, out] recvarray    The destination shmem array
+ * \param[in] count             The number of items to gather
+ * \param[in] type              The type of items to gather
+ * \param[in] op                The operation to be used
+ * \param[in] comm              The MPI communicator
  */
 void
 t8_shmem_array_prefix (const void *sendbuf, t8_shmem_array_t recvarray, const int count, sc_MPI_Datatype type,


### PR DESCRIPTION
Closes #1590

Improved the documentation of shmem_prefix-wrapper and added some assertions. 


**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [x] The reviewer executed the new code features at least once and checked the results manually.
- [x] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [x] New source/header files are properly added to the CMake files.
- [x] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [x] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [x] Should this use case be added to the github action?
  - [x] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [x] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).