### PR TITLE
Bugfix: is_refinable usage

### DIFF
--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -345,8 +345,9 @@ t8_forest_adapt_refine_recursive (t8_forest_t forest, t8_locidx_t ltreeid, t8_ec
     T8_ASSERT (refine != -1);
     if (refine == 1) {
       /* The element should be refined */
-      if (scheme->element_get_level (tree_class, el_buffer[0]) < forest->maxlevel) {
-        /* only refine, if we do not exceed the maximum allowed level */
+      if (scheme->element_get_level (tree_class, el_buffer[0]) < forest->maxlevel
+          && scheme->element_is_refinable (tree_class, el_buffer[0])) {
+        /* only refine if element is refinable and if we do not exceed the maximum allowed level */
         /* Create the children and add them to the list */
         scheme->element_new (tree_class, num_children - 1, el_buffer + 1);
         scheme->element_get_children (tree_class, el_buffer[0], num_children, el_buffer);


### PR DESCRIPTION
Closes #1599

**_Describe your changes here:_**
The `element_is_refinable` usage was wrong.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).