### PR TITLE
Improvement: Replace t8 assert

### DIFF
--- a/src/t8.h
+++ b/src/t8.h
@@ -28,6 +28,7 @@
 
 #ifndef T8_H
 #define T8_H
+#include <assert.h>
 
 /* include config headers */
 #ifndef T8_CMAKE_BUILD
@@ -67,18 +68,10 @@ T8_EXTERN_C_BEGIN ();
  * since then the assertion would not trigger if sc is not configured in debugging mode.
  * However, we want it to trigger any time t8code is in debugging mode, independent of sc.
  */
-#if T8_ENABLE_DEBUG
-#define T8_ASSERT(c) SC_CHECK_ABORT ((c), "Assertion '" #c "'")
-#else
-#define T8_ASSERT(c) SC_NOOP ()
-#endif
+#define T8_ASSERT(c) assert ((c))
 
 /**Extended T8_ASSERT assertion with custom error message. Only active in debug-mode. */
-#if T8_ENABLE_DEBUG
-#define T8_ASSERTF(c, msg) SC_CHECK_ABORT ((c), "Assertion '" #c "': " msg)
-#else
-#define T8_ASSERTF(c, msg) SC_NOOP ()
-#endif
+#define T8_ASSERTF(c, msg) assert ((c) && msg)
 
 /** Allocate a \a t-array with \a n elements. */
 #define T8_ALLOC(t, n) (t *) sc_malloc (t8_get_package_id (), (n) * sizeof (t))


### PR DESCRIPTION
Closes #1613 

Replaces the T8_ASSERT-Macro by the c-implementation of assert given by the assert.h


**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).