### PR TITLE
Bugfix: Missing utility header include

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common.hxx
@@ -31,6 +31,7 @@
 #include <t8_types/t8_operators.hxx>
 #include <sc_functions.h>
 #include <sc_containers.h>
+#include <utility>
 
 /* Macro to check whether a pointer (VAR) to a base class, comes from an
  * implementation of a child class (TYPE). */

--- a/src/t8_schemes/t8_standalone/t8_standalone_implementation.hxx
+++ b/src/t8_schemes/t8_standalone/t8_standalone_implementation.hxx
@@ -27,6 +27,7 @@
 #include <t8_eclass.h>
 #include <sc_functions.h>
 #include <t8_schemes/t8_standalone/t8_standalone_elements.hxx>
+#include <utility>
 
 template <t8_eclass TEclass>
 struct t8_standalone_scheme


### PR DESCRIPTION
Closes #1621
closes #1624

**_Describe your changes here:_**

The files t8_standalone_implementation.hxx and t8_default_common.hxx were missing an `#include <utitlity>` in order to use the function `std::exchange`.
This caused the code to not compile.

I added the includes to both headers.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [x] The reviewer executed the new code features at least once and checked the results manually.
- [x] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).