### PR TITLE
Other: Remove deprecated indent macro

### DIFF
--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.cxx
@@ -539,8 +539,6 @@ t8_geometry_cad::t8_geom_evaluate_cad_quad (t8_cmesh_t cmesh, t8_gloidx_t gtreei
         if (edges[i_edge] > 0) {
           /* Get curve */
           T8_ASSERT (edges[i_edge] <= cad_shape_edge_map.Size ());
-          /* Infinite indent loop */
-          /* *INDENT-OFF* */
           curve = BRep_Tool::Curve (TopoDS::Edge (cad_shape_edge_map.FindKey (edges[i_edge])), first, last);
 
           /* Check if curve are valid */

--- a/test/t8_geometry/t8_gtest_point_inside.cxx
+++ b/test/t8_geometry/t8_gtest_point_inside.cxx
@@ -116,7 +116,6 @@ TEST (t8_point_inside, test_point_inside_specific_quad)
   t8_forest_unref (&forest);
 }
 
-/* *INDENT-OFF* */
 class geometry_point_inside: public testing::TestWithParam<std::tuple<t8_eclass, int, int>> {
  protected:
   void


### PR DESCRIPTION
Closes #1627

**_Describe your changes here:_**
Found an old indent guard

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).