### PR TITLE
Improvement: Better handling of hashes and errors in t8_geometry

### DIFF
--- a/src/t8_cmesh/t8_cmesh_geometry.cxx
+++ b/src/t8_cmesh/t8_cmesh_geometry.cxx
@@ -58,6 +58,12 @@ t8_cmesh_get_tree_geometry (const t8_cmesh_t cmesh, const t8_gloidx_t gtreeid)
   T8_ASSERT (t8_cmesh_is_committed (cmesh));
   t8_geometry_handler *geom_handler = cmesh->geometry_handler;
 
+  if (geom_handler == nullptr) {
+    /* If no geometry handler is present, no geometries have been registered and 
+    * the tree does not have a geometry. */
+    return nullptr;
+  }
+
   if (geom_handler->get_num_geometries () == 1) {
     /* The geometry handler only has one geometry and the trees 
      * thus do not need to store their geometry's hash
@@ -78,7 +84,7 @@ t8_cmesh_get_tree_geom_hash (const t8_cmesh_t cmesh, const t8_gloidx_t gtreeid)
   t8_geometry_handler *geom_handler = cmesh->geometry_handler;
 
   if (geom_handler == nullptr) {
-    /* If no geometry handler is present, no geometries have beed registered and 
+    /* If no geometry handler is present, no geometries have been registered and 
     * the tree does not have a geometry. */
     return t8_geometry_empty_hash;
   }

--- a/src/t8_cmesh/t8_cmesh_geometry.h
+++ b/src/t8_cmesh/t8_cmesh_geometry.h
@@ -37,7 +37,7 @@ T8_EXTERN_C_BEGIN ();
 /** Get the hash of the geometry stored for a tree in a cmesh.
  * \param [in] cmesh   A committed cmesh.
  * \param [in] gtreeid A global tree in \a cmesh.
- * \return             The hash of the tree's geometry or if only one geometry exists, its hash.
+ * \return             The hash of the tree's geometry. If the tree does not have a geometry, returns \ref t8_geometry_empty_hash.
  */
 size_t
 t8_cmesh_get_tree_geom_hash (t8_cmesh_t cmesh, t8_gloidx_t gtreeid);

--- a/src/t8_geometry/t8_geometry_base.hxx
+++ b/src/t8_geometry/t8_geometry_base.hxx
@@ -32,8 +32,8 @@
 #include <t8_cmesh.h>
 #include <t8_forest/t8_forest.h>
 #include <t8_geometry/t8_geometry.h>
+#include <t8_geometry/t8_geometry_hash.hxx>
 
-#include <string>
 #include <functional>
 
 T8_EXTERN_C_BEGIN ();
@@ -48,8 +48,11 @@ struct t8_geometry
 {
  public:
   /* Basic constructor that sets the name. */
-  t8_geometry (std::string name): name (name), hash (std::hash<std::string> {}(name))
+  t8_geometry (std::string name): name (name), hash (t8_geometry_compute_hash (name))
   {
+    if (t8_geometry_hash_is_null (hash)) {
+      SC_ABORTF ("Registering geometry with invalid name\"%s\"\n.", name.c_str ());
+    }
   }
 
   /* Base constructor with no arguments. We need this since it
@@ -163,7 +166,7 @@ struct t8_geometry
     return name;
   }
 
-  inline size_t
+  inline t8_geometry_hash_t
   t8_geom_get_hash () const
   {
     return hash;
@@ -179,7 +182,7 @@ struct t8_geometry
 
  protected:
   std::string name;              /**< The name of this geometry. */
-  size_t hash;                   /**< The hash of the name of this geometry. */
+  t8_geometry_hash_t hash;       /**< The hash of the name of this geometry. See also \ref t8_geometry_compute_hash */
   t8_gloidx_t active_tree;       /**< The tree of which currently vertices are loaded. */
   t8_eclass_t active_tree_class; /**< The class of the currently active tree. */
 };

--- a/src/t8_geometry/t8_geometry_handler.cxx
+++ b/src/t8_geometry/t8_geometry_handler.cxx
@@ -60,7 +60,7 @@ t8_geometry_handler::update_tree (t8_cmesh_t cmesh, t8_gloidx_t gtreeid)
     if (num_geoms > 1) {
       /* Find and load the geometry of that tree. 
        * Only necessary if we have more than one geometry. */
-      const size_t geom_hash = t8_cmesh_get_tree_geom_hash (cmesh, gtreeid);
+      const t8_geometry_hash_t geom_hash = t8_cmesh_get_tree_geom_hash (cmesh, gtreeid);
       active_geometry = get_geometry (geom_hash);
       SC_CHECK_ABORTF (active_geometry != nullptr,
                        "Could not find geometry with hash %zu or tree %ld has no registered geometry.", geom_hash,

--- a/src/t8_geometry/t8_geometry_handler.hxx
+++ b/src/t8_geometry/t8_geometry_handler.hxx
@@ -40,7 +40,7 @@ struct t8_geometry_handler
   /**
    * Constructor.
    */
-  t8_geometry_handler (): active_geometry (nullptr), active_tree (-1)
+  t8_geometry_handler ()
   {
     t8_refcount_init (&rc);
     t8_debugf ("Constructed the geometry_handler.\n");
@@ -289,11 +289,11 @@ struct t8_geometry_handler
   update_tree (t8_cmesh_t cmesh, t8_gloidx_t gtreeid);
 
   /** Stores all geometries that are handled by this geometry_handler. */
-  std::unordered_map<size_t, std::unique_ptr<t8_geometry>> registered_geometries;
+  std::unordered_map<size_t, std::unique_ptr<t8_geometry>> registered_geometries = {};
   /** Points to the currently loaded geometry (the geometry that was used last and is likely to be used next). */
-  t8_geometry *active_geometry;
+  t8_geometry *active_geometry = nullptr;
   /** The global tree id of the last tree for which geometry was used. */
-  t8_gloidx_t active_tree;
+  t8_gloidx_t active_tree = -1;
   /** The reference count of the geometry handler. TODO: Replace by shared_ptr when cmesh becomes a class. */
   t8_refcount_t rc;
 };

--- a/src/t8_geometry/t8_geometry_handler.hxx
+++ b/src/t8_geometry/t8_geometry_handler.hxx
@@ -89,7 +89,7 @@ struct t8_geometry_handler
   inline t8_geometry *
   get_geometry (const std::string &name)
   {
-    const size_t hash = std::hash<std::string> {}(name);
+    const t8_geometry_hash_t hash = std::hash<std::string> {}(name);
     return t8_geometry_handler::get_geometry (hash);
   }
 
@@ -99,12 +99,17 @@ struct t8_geometry_handler
    * \return            An iterator to the geometry if found, NULL otherwise.
    */
   inline t8_geometry *
-  get_geometry (const size_t hash)
+  get_geometry (const t8_geometry_hash_t hash)
   {
+    if (t8_geometry_hash_is_null (hash)) {
+      /* The hash belongs to a non-existing geometry. */
+      return nullptr;
+    }
     auto found = registered_geometries.find (hash);
     if (found != registered_geometries.end ()) {
       return found->second.get ();
     }
+    t8_errorf ("Geometry with hash value %lu was not found.\n", hash);
     return nullptr;
   }
 
@@ -259,7 +264,7 @@ struct t8_geometry_handler
   add_geometry (std::unique_ptr<t8_geometry> geom)
   {
     t8_debugf ("Registering geometry with name %s\n", geom->t8_geom_get_name ().c_str ());
-    const size_t hash = geom->t8_geom_get_hash ();
+    const t8_geometry_hash_t hash = geom->t8_geom_get_hash ();
     if (registered_geometries.find (hash) == registered_geometries.end ()) {
       registered_geometries.emplace (hash, std::move (geom));
     }

--- a/src/t8_geometry/t8_geometry_hash.hxx
+++ b/src/t8_geometry/t8_geometry_hash.hxx
@@ -1,0 +1,71 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_geometry_hash.hxx
+ * Defines data types and functions for handling hash values of 
+ * geometries.
+ */
+
+#ifndef T8_GEOMETRY_HASH_HXX
+#define T8_GEOMETRY_HASH_HXX
+
+#include <string>
+
+T8_EXTERN_C_BEGIN ();
+
+/** Data type used for storing hash values of geometries. */
+using t8_geometry_hash_t = size_t;
+
+/** Constant that we use for hashes of non-existing geometries. */
+static const t8_geometry_hash_t t8_geometry_empty_hash = std::hash<std::string> {}("");
+
+/**
+ * Compute the hash value of a geometry's name.
+ *  
+ * \param [in] name The name of a geoemetry/
+ * \return The hash value of \a name.
+ * \note \a name being empty here is explicitly allowed and used as hash values for non-existing geometries.
+ */
+inline t8_geometry_hash_t
+t8_geometry_compute_hash (const std::string &name)
+{
+  t8_geometry_hash_t hash = std::hash<std::string> {}(name);
+  return hash;
+}
+
+/**
+ * Query wheyher a given hash value corresponds to en empty string and hence
+ * a non-existing geometry.
+ * 
+ * \param [in] hash A hash value of a geometry.
+ * \return true If \a hash corresponds to e non-existing geometry,i.e. if \a hash == \a t8_geometry_empty_hash.
+ * \return false If \a hash corresponds to an existing geometry.
+ */
+inline bool
+t8_geometry_hash_is_null (const t8_geometry_hash_t &hash)
+{
+  return hash == t8_geometry_empty_hash;
+}
+
+T8_EXTERN_C_END ();
+
+#endif /* !T8_GEOMETRY_HASH_HXX */

--- a/test/t8_geometry/t8_gtest_geometry_handling.cxx
+++ b/test/t8_geometry/t8_gtest_geometry_handling.cxx
@@ -169,3 +169,18 @@ TEST (test_geometry, cmesh_geometry_unique)
   /* clean-up */
   t8_cmesh_destroy (&cmesh);
 }
+
+TEST (test_geometry, cmesh_no_geometry)
+{
+  /* Build a simple 1 tree cmesh with no geometry. */
+  t8_cmesh_t cmesh;
+  t8_cmesh_init (&cmesh);
+  t8_cmesh_set_tree_class (cmesh, 0, T8_ECLASS_QUAD);
+  t8_cmesh_commit (cmesh, sc_MPI_COMM_WORLD);
+
+  const t8_geometry_hash_t hash = t8_cmesh_get_tree_geom_hash (cmesh, 0);
+  EXPECT_TRUE (t8_geometry_hash_is_null (hash));
+  const t8_geometry_c *should_be_null = t8_cmesh_get_tree_geometry (cmesh, 0);
+  EXPECT_EQ (should_be_null, nullptr);
+  t8_cmesh_destroy (&cmesh);
+}


### PR DESCRIPTION
**_Describe your changes here:_**

I stumbled on this while testing something else and noticed that if a tree has no geometry, but we query for it (for example when trying to print VTK), we run into a segfault.
While working on this i noticed that the handling of hash values of geometries should be improved.

- Added new header that defines hash handling functions.
- New data type for hashes (a typedef of *size_t*)
- Definition of empty hash, that is a hash for the string "" which we do not allow as name of a geometry and use as hash for a non-existing geometry
- proper error handling when no geometry is registered but asked for. In that case the functions return *nullptr*
- Added a test with a cmesh with no geometry to check that *nullptr* is returned.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).