### PR TITLE
Local cmesh bounds

### DIFF
--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -816,6 +816,22 @@ t8_cmesh_new_translate_vertices_to_attributes (const t8_locidx_t *tvertices, con
  */
 void
 t8_cmesh_debug_print_trees (const t8_cmesh_t cmesh, sc_MPI_Comm comm);
+
+/**
+ * Compute the process local bounding box of the cmesh.
+ * The bounding box is stored in the array \a bounds in the following order:
+ * bounds[0] = x_min
+ * bounds[1] = x_max
+ * bounds[2] = y_min
+ * bounds[3] = y_max
+ * bounds[4] = z_min
+ * bounds[5] = z_max
+ * 
+ * \param [in] cmesh    The cmesh to be considered.
+ * \param [out] bounds  The bounding box of the cmesh.
+ */
+void
+t8_cmesh_get_local_bounding_box (const t8_cmesh_t cmesh, double bounds[6]);
 T8_EXTERN_C_END ();
 
 #endif /* !T8_CMESH_H */

--- a/src/t8_cmesh/t8_cmesh.cxx
+++ b/src/t8_cmesh/t8_cmesh.cxx
@@ -1536,3 +1536,50 @@ t8_cmesh_uniform_bounds (t8_cmesh_t cmesh, const int level, const t8_scheme *sch
     *last_local_tree = *first_local_tree - 1;
   }
 }
+
+void
+t8_cmesh_get_local_bounding_box (const t8_cmesh_t cmesh, double bounds[6])
+{
+  T8_ASSERT (t8_cmesh_is_committed (cmesh));
+  T8_ASSERT (cmesh->num_local_trees > 0);
+  const t8_locidx_t num_local_trees = t8_cmesh_get_num_local_trees (cmesh);
+
+  t8_eclass_t tree_class = t8_cmesh_get_tree_class (cmesh, 0);
+  const int num_vertices = t8_eclass_num_vertices[tree_class];
+
+  double *vertices = t8_cmesh_get_tree_vertices (cmesh, 0);
+  bounds[0] = vertices[0];  // min x
+  bounds[1] = vertices[0];  // max x
+  bounds[2] = vertices[1];  // min y
+  bounds[3] = vertices[1];  // max y
+  bounds[4] = vertices[2];  // min z
+  bounds[5] = vertices[2];  // max z
+  for (t8_locidx_t itree = 0; itree < num_local_trees; itree++) {
+    tree_class = t8_cmesh_get_tree_class (cmesh, itree);
+    vertices = t8_cmesh_get_tree_vertices (cmesh, itree);
+    num_vertices = t8_eclass_num_vertices[tree_class];
+    for (int ivertex = 0; ivertex < num_vertices; ivertex++) {
+      const int vert_x = 3 * ivertex;
+      const int vert_y = 3 * ivertex + 1;
+      const int vert_z = 3 * ivertex + 2;
+      if (vertices[vert_x] < bounds[0]) {
+        bounds[0] = vertices[vert_x];
+      }
+      if (vertices[vert_x] > bounds[1]) {
+        bounds[1] = vertices[vert_x];
+      }
+      if (vertices[vert_y] < bounds[2]) {
+        bounds[2] = vertices[vert_y];
+      }
+      if (vertices[vert_y] > bounds[3]) {
+        bounds[3] = vertices[vert_y];
+      }
+      if (vertices[vert_z] < bounds[4]) {
+        bounds[4] = vertices[vert_z];
+      }
+      if (vertices[vert_z] > bounds[5]) {
+        bounds[5] = vertices[vert_z];
+      }
+    }
+  }
+}

--- a/src/t8_cmesh/t8_cmesh.cxx
+++ b/src/t8_cmesh/t8_cmesh.cxx
@@ -1558,28 +1558,13 @@ t8_cmesh_get_local_bounding_box (const t8_cmesh_t cmesh, double bounds[6])
     tree_class = t8_cmesh_get_tree_class (cmesh, itree);
     vertices = t8_cmesh_get_tree_vertices (cmesh, itree);
     num_vertices = t8_eclass_num_vertices[tree_class];
-    for (int ivertex = 0; ivertex < num_vertices; ivertex++) {
-      const int vert_x = 3 * ivertex;
-      const int vert_y = 3 * ivertex + 1;
-      const int vert_z = 3 * ivertex + 2;
-      if (vertices[vert_x] < bounds[0]) {
-        bounds[0] = vertices[vert_x];
-      }
-      if (vertices[vert_x] > bounds[1]) {
-        bounds[1] = vertices[vert_x];
-      }
-      if (vertices[vert_y] < bounds[2]) {
-        bounds[2] = vertices[vert_y];
-      }
-      if (vertices[vert_y] > bounds[3]) {
-        bounds[3] = vertices[vert_y];
-      }
-      if (vertices[vert_z] < bounds[4]) {
-        bounds[4] = vertices[vert_z];
-      }
-      if (vertices[vert_z] > bounds[5]) {
-        bounds[5] = vertices[vert_z];
-      }
-    }
+    std::for_each (vertices, vertices + 3 * num_vertices, [&bounds] (double coord) {
+      bounds[0] = std::min (bounds[0], coord);
+      bounds[1] = std::max (bounds[1], coord);
+      bounds[2] = std::min (bounds[2], coord);
+      bounds[3] = std::max (bounds[3], coord);
+      bounds[4] = std::min (bounds[4], coord);
+      bounds[5] = std::max (bounds[5], coord);
+    });
   }
 }


### PR DESCRIPTION
Closes #1658 

implements a function that computes the local bounds of a cmesh. 
iterates over all trees, gets the vertices of that trees and compares it with the current bounds. 


**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).