### PR TITLE
Feature: strong type conversion [1/2]

### DIFF
--- a/src/t8_types/t8_type.hxx
+++ b/src/t8_types/t8_type.hxx
@@ -88,6 +88,20 @@ class T8Type: public competence<T8Type<T, Parameter, competence...>>... {
     return std::move (value_);
   }
 
+  /** Implicit conversion to value type
+   * to cast a variable instance of this class into its
+   * value_type for example for printing.
+   * 
+   * \note to future devs: If this causes trouble in the future when we create a
+   *  type that is not easily (or should not be) convertible to its base type,
+   *  we can wrap this inside an enable_if condition and only allow the conversion
+   *  if explicitly stated. */
+  constexpr
+  operator value_type () const
+  {
+    return get ();
+  }
+
  private:
   T value_;
 };

--- a/test/t8_types/t8_gtest_type.cxx
+++ b/test/t8_types/t8_gtest_type.cxx
@@ -180,6 +180,10 @@ TEST (t8_gtest_type, use_constexpr)
   constexpr DummyInt my_int_eq (5);
   static_assert (my_int_eq == my_int, "constexpr operator== failed");
   static_assert (my_int_eq != my_other_int, "constexpr operator!= failed");
+  // Check type conversion
+  constexpr int five = static_cast<int> (my_int);
+  static_assert (five == 5);
+  static_assert (five == my_int);
 }
 
 /**


### PR DESCRIPTION
Closes #1664

**_Describe your changes here:_**

Added implicit type conversion to base type to our strong types.

Marked [1/2] since it has to be merged before #1656 which uses this feature.

**Why?**
In some scenarios, in particular when we want to print out values for our strong types, we need to cast them back into their base type.
For example when strong types are used in GoogleTest assertion, GoogleTest requires the "<<" operator to work.
It happened to me when switching to a strong type for geometry hash usage (see #1656) and a part of the code was doing
`t8_debug_f ("Hash %lu not found\n", hash);` which did not compile since "hash" as a strong type was not convertible to "long unsigned".

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).