### PR TITLE
Improvement: Improve test pretty print

### DIFF
--- a/test/t8_cmesh_generator/t8_cmesh_example_sets.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_example_sets.hxx
@@ -52,8 +52,12 @@ auto pretty_print_base_example = [] (const testing::TestParamInfo<cmesh_example_
 auto pretty_print_base_example_scheme = [] (const testing::TestParamInfo<std::tuple<int, cmesh_example_base *>> &info) {
   std::string name;
   std::get<1> (info.param)->param_to_string (name);
-  name += std::string ("_scheme_") + std::to_string (std::get<0> (info.param));
-  name += std::string ("_") + std::to_string (info.index);
+  if (std::get<0> (info.param) == 0) {
+    name += std::string ("_Default_Scheme");
+  }
+  else {
+    name += std::string ("_Standalone_Scheme");
+  }
   return name;
 };
 

--- a/test/t8_cmesh_generator/t8_cmesh_example_sets.hxx
+++ b/test/t8_cmesh_generator/t8_cmesh_example_sets.hxx
@@ -36,6 +36,7 @@
 #include "test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_periodic.hxx"
 #include "test/t8_cmesh_generator/t8_gtest_cmesh_cartestian_product.hxx"
 #include "test/t8_cmesh_generator/t8_gtest_cmesh_sum_of_sets.hxx"
+#include "test/t8_gtest_schemes.hxx"
 
 T8_EXTERN_C_BEGIN ();
 
@@ -52,12 +53,7 @@ auto pretty_print_base_example = [] (const testing::TestParamInfo<cmesh_example_
 auto pretty_print_base_example_scheme = [] (const testing::TestParamInfo<std::tuple<int, cmesh_example_base *>> &info) {
   std::string name;
   std::get<1> (info.param)->param_to_string (name);
-  if (std::get<0> (info.param) == 0) {
-    name += std::string ("_Default_Scheme");
-  }
-  else {
-    name += std::string ("_Standalone_Scheme");
-  }
+  name += std::string ("_") + t8_scheme_to_string[std::get<0> (info.param)];
   return name;
 };
 

--- a/test/t8_forest/t8_gtest_element_is_leaf.cxx
+++ b/test/t8_forest/t8_gtest_element_is_leaf.cxx
@@ -161,12 +161,7 @@ auto pretty_print_level_and_cmesh_params
       std::string cmesh_name;
       std::get<2> (info.param)->param_to_string (cmesh_name);
       name += std::string ("_") + cmesh_name;
-      if (std::get<0> (info.param) == 0) {
-        name += std::string ("_Default_Scheme");
-      }
-      else {
-        name += std::string ("_Standalone_Scheme");
-      }
+      name += std::string ("_") + t8_scheme_to_string[std::get<0> (info.param)];
       return name;
     };
 

--- a/test/t8_forest/t8_gtest_element_is_leaf.cxx
+++ b/test/t8_forest/t8_gtest_element_is_leaf.cxx
@@ -161,8 +161,12 @@ auto pretty_print_level_and_cmesh_params
       std::string cmesh_name;
       std::get<2> (info.param)->param_to_string (cmesh_name);
       name += std::string ("_") + cmesh_name;
-      name += std::string ("scheme_") + std::to_string (std::get<0> (info.param));
-      name += std::string ("_") + std::to_string (info.index);
+      if (std::get<0> (info.param) == 0) {
+        name += std::string ("_Default_Scheme");
+      }
+      else {
+        name += std::string ("_Standalone_Scheme");
+      }
       return name;
     };
 


### PR DESCRIPTION
Closes #1671

**_Describe your changes here:_**

With the introduction of the standalone scheme, I modified the pretty print for some tests. But this was more of a quickfix.
Now the pretty print can be proud to call itself pretty again. 

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).