### PR TITLE
Improvement: Reduce depth of descendant test

### DIFF
--- a/test/t8_schemes/t8_gtest_face_descendant.cxx
+++ b/test/t8_schemes/t8_gtest_face_descendant.cxx
@@ -107,7 +107,8 @@ class class_descendant: public TestDFS {
     dfs_test_teardown ();
   }
 #if T8CODE_TEST_LEVEL == 0
-  int additional_test_lvl = 3; // For level 0 additional_test_lvl is unused and we always test up to the maximum possible refinement level.
+  int additional_test_lvl
+    = 3;  // For level 0 additional_test_lvl is unused and we always test up to the maximum possible refinement level.
 #elif T8CODE_TEST_LEVEL == 1
   int additional_test_lvl = 2;
 #elif T8CODE_TEST_LEVEL == 2


### PR DESCRIPTION
**_Describe your changes here:_**
Closes #1645 
Reduce the depth of the computation of the first and last face descendant of an element. 
Furthermore it is now depending on the test level that has been set. 

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [x] The reviewer executed the new code features at least once and checked the results manually.
- [x] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [x] New source/header files are properly added to the CMake files.
- [x] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [x] The code is covered in an existing or new test case using Google Test.
- [x] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [x] Should this use case be added to the github action?
  - [x] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [x] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).