### PR TITLE
Improvement: Runtime of nca test

### DIFF
--- a/test/t8_schemes/t8_gtest_nca.cxx
+++ b/test/t8_schemes/t8_gtest_nca.cxx
@@ -226,11 +226,8 @@ TEST_P (nca, recursive_check)
 {
 #if T8CODE_TEST_LEVEL >= 2
   const int recursion_depth = 2;
-#elif T8CODE_TEST_LEVEL >= 1
-  const int recursion_depth = 3;
 #else
-  /* User lower recursion depth for pyramids, it takes to much time otherwise */
-  const int recursion_depth = 4;
+  const int recursion_depth = 3;
 #endif
   t8_element_t *parent_a, *parent_b;
   int num_children;
@@ -263,29 +260,34 @@ TEST_P (nca, recursive_check)
 TEST_P (nca, recursive_check_higher_level)
 {
 #if T8CODE_TEST_LEVEL >= 2
-  const int recursion_depth = 2;
+  const int start_level = 2;
 #else
-  const int recursion_depth = 3;
+  const int start_level = 3;
 #endif
 
+#if T8CODE_TEST_LEVEL >= 1
+  const int max_lvl = scheme->get_maxlevel (tree_class) / 2;
+#else
   const int max_lvl = scheme->get_maxlevel (tree_class);
+#endif
+
   t8_element_t *parent_a;
   t8_element_t *parent_b;
   t8_element_t *correct_nca_high_level;
   int num_children;
   int i, k, l;
   t8_gloidx_t leaves_on_level;
-  EXPECT_TRUE (max_lvl - recursion_depth >= 0);
+  EXPECT_TRUE (max_lvl - start_level >= 0);
 
   scheme->element_new (tree_class, 1, &parent_a);
   scheme->element_new (tree_class, 1, &parent_b);
   scheme->element_new (tree_class, 1, &correct_nca_high_level);
 
   /* Test on different levels around the middle of the refinement tree */
-  for (i = recursion_depth; i < max_lvl; i++) {
-    leaves_on_level = scheme->element_count_leaves (tree_class, correct_nca, i - recursion_depth);
+  for (i = start_level; i < max_lvl; i++) {
+    leaves_on_level = scheme->element_count_leaves (tree_class, correct_nca, i - start_level);
     /* middle = leaves/2 */
-    scheme->element_set_linear_id (tree_class, correct_nca_high_level, i - recursion_depth, leaves_on_level / 2);
+    scheme->element_set_linear_id (tree_class, correct_nca_high_level, i - start_level, leaves_on_level / 2);
 
     /* Initialization for recursive_nca_check */
     num_children = scheme->element_get_num_children (tree_class, correct_nca_high_level);
@@ -320,5 +322,6 @@ TEST_P (nca, recursive_check_higher_level)
   scheme->element_destroy (tree_class, 1, &parent_b);
   scheme->element_destroy (tree_class, 1, &correct_nca_high_level);
 }
+
 
 INSTANTIATE_TEST_SUITE_P (t8_gtest_nca, nca, AllSchemes, print_all_schemes);

--- a/test/t8_schemes/t8_gtest_nca.cxx
+++ b/test/t8_schemes/t8_gtest_nca.cxx
@@ -323,5 +323,4 @@ TEST_P (nca, recursive_check_higher_level)
   scheme->element_destroy (tree_class, 1, &correct_nca_high_level);
 }
 
-
 INSTANTIATE_TEST_SUITE_P (t8_gtest_nca, nca, AllSchemes, print_all_schemes);

--- a/test/t8_schemes/t8_gtest_nca.cxx
+++ b/test/t8_schemes/t8_gtest_nca.cxx
@@ -256,7 +256,7 @@ TEST_P (nca, recursive_check)
 
 /* Test the nca recursively for elements in the middle of the uniform refinement tree
  * up to the maximal level. 
- * Be careful when increasing the recursion_depth, as it increases the number of test-cases exponentially. */
+ * Be careful when increasing the max_lvl, as it increases the number of test-cases exponentially. */
 TEST_P (nca, recursive_check_higher_level)
 {
 #if T8CODE_TEST_LEVEL >= 2


### PR DESCRIPTION
**_Describe your changes here:_**
Closes #1647 
changed a little the recursion depth. 
The most time was spend on the last test in the testsuite, because it always tested up to maxlvl. Reduced it down to maxlvl/2 for test levels other than 0. 

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).