### PR TITLE
Improvement: Speed up element is leaf test

### DIFF
--- a/test/t8_forest/t8_gtest_element_is_leaf.cxx
+++ b/test/t8_forest/t8_gtest_element_is_leaf.cxx
@@ -69,22 +69,18 @@ t8_test_adapt_first_child (t8_forest_t forest, [[maybe_unused]] t8_forest_t fore
   return 0;
 }
 
-class element_is_leaf: public testing::TestWithParam<std::tuple<int, int, cmesh_example_base *>> {
+class element_is_leaf: public testing::TestWithParam<std::tuple<std::tuple<int, t8_eclass_t>, int>> {
  protected:
   void
   SetUp () override
   {
     /* Construct a cmesh */
-    const int scheme_id = std::get<0> (GetParam ());
+    const int scheme_id = std::get<0> (std::get<0> (GetParam ()));
     scheme = create_from_scheme_id (scheme_id);
+    const t8_eclass_t tree_class = std::get<1> (std::get<0> (GetParam ()));
     const int level = std::get<1> (GetParam ());
-    t8_cmesh_t cmesh = std::get<2> (GetParam ())->cmesh_create ();
-    if (t8_cmesh_is_empty (cmesh)) {
-      /* forest_commit does not support empty cmeshes, we skip this case */
-      scheme->unref ();
-      t8_cmesh_unref (&cmesh);
-      GTEST_SKIP ();
-    }
+    t8_cmesh_t cmesh = t8_cmesh_new_from_class (tree_class, sc_MPI_COMM_WORLD);
+
     forest = t8_forest_new_uniform (cmesh, scheme, level, 0, sc_MPI_COMM_WORLD);
     t8_forest_ref (forest);
     //const int maxlevel = t8_forest_get_maxlevel (forest);
@@ -155,17 +151,14 @@ TEST_P (element_is_leaf, element_is_leaf_adapt)
 
 /* Define a lambda to beatify gtest output for tuples <level, cmesh>.
  * This will set the correct level and cmesh name as part of the test case name. */
-auto pretty_print_level_and_cmesh_params
-  = [] (const testing::TestParamInfo<std::tuple<int, int, cmesh_example_base *>> &info) {
-      std::string name = std::string ("Level_") + std::to_string (std::get<1> (info.param));
-      std::string cmesh_name;
-      std::get<2> (info.param)->param_to_string (cmesh_name);
-      name += std::string ("_") + cmesh_name;
-      name += std::string ("_") + t8_scheme_to_string[std::get<0> (info.param)];
-      return name;
+auto pretty_print_eclass_scheme_and_level
+  = [] (const testing::TestParamInfo<std::tuple<std::tuple<int, t8_eclass_t>, int>> &info) {
+      std::string scheme = t8_scheme_to_string[std::get<0> (std::get<0> (info.param))];
+      std::string eclass = t8_eclass_to_string[std::get<1> (std::get<0> (info.param))];
+      std::string level = std::string ("_level_") + std::to_string (std::get<1> (info.param));
+      return scheme + "_" + eclass + level;
     };
 
 INSTANTIATE_TEST_SUITE_P (t8_gtest_element_is_leaf, element_is_leaf,
-                          testing::Combine (AllSchemeCollections, testing::Range (0, T8_IS_LEAF_MAX_LVL),
-                                            AllCmeshsParam),
-                          pretty_print_level_and_cmesh_params);
+                          testing::Combine (AllSchemes, testing::Range (0, T8_IS_LEAF_MAX_LVL)),
+                          pretty_print_eclass_scheme_and_level);

--- a/test/t8_gtest_schemes.hxx
+++ b/test/t8_gtest_schemes.hxx
@@ -48,6 +48,9 @@ auto print_all_schemes = [] (const testing::TestParamInfo<std::tuple<int, t8_ecl
          + t8_eclass_to_string[std::get<1> (info.param)];
 };
 
+auto print_scheme
+  = [] (const testing::TestParamInfo<int> &info) { return std::string (t8_scheme_to_string[info.param]); };
+
 #define AllSchemeCollections ::testing::Range (0, 2)
 #define AllSchemes ::testing::Combine (AllSchemeCollections, ::testing::Range (T8_ECLASS_ZERO, T8_ECLASS_COUNT))
 


### PR DESCRIPTION
**_Describe your changes here:_**
Closes #1646 

Adapts the original test to only be parametrized over all schemes, eclasses and a level. The functionality is tree specific and therefore does not need to run over all cmeshes in our testsuite. 

Adds a test for a all scheme collections to test if the right function is called in a hybrid forest. 

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).