### PR TITLE
Other: Add date of creation to entries in issue board

### DIFF
--- a/.github/workflows/add_date_created.yml
+++ b/.github/workflows/add_date_created.yml
@@ -1,0 +1,115 @@
+name: Add the date the issue was created to the project board entry, triggered by certain Issue events
+
+#  This file is part of t8code.
+#  t8code is a C library to manage a collection (a forest) of multiple
+#  connected adaptive space-trees of general element types in parallel.
+#
+#  Copyright (C) 2025 the developers
+#
+#  t8code is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  t8code is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with t8code; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+on:
+  workflow_call:
+    inputs:
+      ISSUE_NODE_ID:
+        required: true
+        type: string
+        description: 'The node id of the issue that triggered the workflow'
+      CREATION_DATE:
+        required: true
+        type: string
+        description: 'The date of the issue'
+    secrets:
+        PAT:
+          required: true
+
+jobs:
+  Add_creation_date_to_card:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Add creation date to card in projects"
+      id: add_creation_date
+      run: |
+        ISSUE_NODE_ID="${{ inputs.ISSUE_NODE_ID }}"
+        CREATION_DATE="${{ inputs.CREATION_DATE }}"
+        echo "CREATION_DATE=$CREATION_DATE"
+        # Get the projects associated with the organization
+        projects=$(curl --request POST \
+            --url https://api.github.com/graphql \
+            --header "Authorization: Bearer ${{ secrets.PAT }}" \
+            --data '{"query":"{organization(login: \"DLR-AMR\") {projectsV2(first: 20) {nodes {id title}}}}"}')
+        echo "projects=$projects"
+        # Get the project IDs
+        project_ids=$(echo $projects | jq -r '.data.organization.projectsV2.nodes[].id')
+        for project_id in $project_ids; do
+          echo "project_id is $project_id"
+          # set hasNextPage initially to true
+          hasNextPage=true
+          # set the startCursor to null initially
+          startCursor=""
+          max_iter=100
+          # set the iteration counter to 0
+          iter=0
+          # start a while loop to get all the issues in the project, until hasNextPage is false
+          while [ "$hasNextPage" == "true" ] && [ "$iter" -lt "$max_iter" ]; do
+            echo "retrieve page $iter"
+            # Increment the iteration counter
+            iter=$((iter + 1))
+            # Get the issues within the project
+            project_fields_and_issues=$(curl --request POST \
+              --url https://api.github.com/graphql \
+              --header "Authorization: Bearer ${{ secrets.PAT }}" \
+              --data "{\"query\":\"{ node(id: \\\"$project_id\\\") { ... on ProjectV2 { items(first: 100, after: \\\"$startCursor\\\") { pageInfo { startCursor endCursor hasNextPage } nodes { id fieldValues(first: 8) { nodes { ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } }  } } content { ... on Issue { id } } } } fields(first: 20) { nodes { ... on ProjectV2Field { id name }      } } } } }\"}")    
+            echo "issues=$project_fields_and_issues"
+            # Update hasNextPage
+            hasNextPage=$(echo $project_fields_and_issues | jq -r '.data.node.items.pageInfo.hasNextPage')
+            # Update startCursor
+            startCursor=$(echo $project_fields_and_issues | jq -r '.data.node.items.pageInfo.endCursor')
+            echo "hasNextPage=$hasNextPage"
+            echo "startCursor=$startCursor"
+            # Extract the issue ids and PVII ids. The issue_id is the global_id, the PVII id is the project specific id
+            issue_ids=$(echo $project_fields_and_issues | jq -r '.data.node.items.nodes[].content.id')
+            PVII_ids=$(echo $project_fields_and_issues | jq -r '.data.node.items.nodes[].id')
+            # In the following loop we need both values, so we combine them into a single string
+            combined_ids=$(paste -d, <(echo "$issue_ids") <(echo "$PVII_ids"))
+            for combined_id in $combined_ids; do
+              issue_id=$(echo $combined_id | cut -d, -f1)
+              PVII_id=$(echo $combined_id | cut -d, -f2)
+              if [ "$issue_id" == "$ISSUE_NODE_ID" ]; then
+                echo "Found issue $issue_id in project $project_id"
+            
+                date_field_id=$(echo $project_fields_and_issues | jq -r '.data.node.fields.nodes[] | select(.name == "Date_Created") | .id')
+                echo "date_field_id is $date_field_id"
+                date_message="updateProjectV2ItemFieldValue3: updateProjectV2ItemFieldValue(input: {projectId: \"'$project_id'\", itemId: \"'$PVII_id'\", fieldId: \"'$date_field_id'\", value: {date: \"'$CREATION_DATE'\"}}) {projectV2Item {id}}"
+          
+                # Construct the query to move the issue to the specified column.
+                # The query is a mutation that updates the status, priority, and workload fields of the issue.
+                # If priority or workload are not set, the corresponding message is empty.
+                # The query is constructed using jq and sed to remove null values and extra whitespace.
+                query=$(jq -n --arg dm "$date_message" \
+                        '{"query": "mutation { \($dm) }"}' | \
+                      jq '.query |= gsub("null"; "") | .query |= gsub("\\s+"; " ") | .query |= sub("\\{\\s*\\}"; "{}")' | \
+                      sed 's/\\\\"/"/g' | \
+                      sed "s/'//g")
+                echo "query=$query"
+                response=$(curl --request POST \
+                  --url https://api.github.com/graphql \
+                  --header "Authorization: Bearer ${{ secrets.PAT }}" \
+                  --data "$query")
+                echo "response=$response"
+              fi
+            done
+          done
+        done

--- a/.github/workflows/move_card.yml
+++ b/.github/workflows/move_card.yml
@@ -22,7 +22,7 @@ name: "Move the Issue after workload and urgency is evaluated"
 
 on:
   issues:
-    types: [labeled, assigned, unassigned, unlabeled]
+    types: [labeled, assigned, unassigned, unlabeled, opened]
   pull_request:
     types: [opened, reopened, ready_for_review, review_requested, review_request_removed, closed]
 
@@ -35,7 +35,17 @@ jobs:
       PRIORITY_SET: ${{ steps.check_urgency.outputs.PRIORITY_SET || 'false' }}
       WORKLOAD: ${{ steps.check_workload.outputs.WORKLOAD || 'false' }}
       PRIORITY: ${{ steps.check_urgency.outputs.PRIORITY || 'false' }}
+      CREATION_DATE: ${{ steps.get_creation_date.outputs.CREATION_DATE || 'unset' }}
     steps:
+      - name: "Extract the issues date of creation"
+        id: get_creation_date
+        run: |
+            echo "Extract the date of creation:"
+            github_date_string="${{ github.event.issue.created_at }}"
+            CREATION_DATE="${github_date_string:0:10}"
+            echo "$CREATION_DATE"
+            echo "CREATION_DATE=$CREATION_DATE" >> $GITHUB_OUTPUT
+
       - name: "Check if workload is set"
         id: check_workload
         # Check if the issue has a workload label
@@ -133,6 +143,18 @@ jobs:
             # Debug output!
             echo "NUMBER_IS_SET=$NUMBER_IS_SET"
             echo "${{ github.event.action }}"
+
+  # Add the issue's date of creation to the project board card.
+  # Triggered only if the issue was newly opened or the label 'manual_trigger_date_event' has been added.
+  add_creation_date:
+    needs: [evaluate_issues]
+    if: ${{ github.event.action == 'opened' || ( github.event.action == 'labeled' && contains(join(github.event.issue.labels.*.name, ','), 'manual_trigger_date_event') ) }}
+    uses: ./.github/workflows/add_date_created.yml
+    with:
+        ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+        CREATION_DATE: ${{ needs.evaluate_issues.outputs.CREATION_DATE }}
+    secrets:
+        PAT: ${{ secrets.T8DDY_PROJECTS }}
 
   # Move the issue card to ToDo if the workload and priority are set
   move_card_to_ToDo:


### PR DESCRIPTION
**_Describe your changes here:_**

Closes #1706.

As already discussed, it would be useful to sort the entries in the issue board based on the dates they were created. This PR extends the project board Github actions such that the date is added if either:

a. A new issue is opened.
b. An existing issue gets the label `manually_trigger_date_event` (required only to get the date for existing issues.)

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).