### PR TITLE
Improvement: Remove depricated lines from benchmark

### DIFF
--- a/benchmarks/t8_time_forest_partition.cxx
+++ b/benchmarks/t8_time_forest_partition.cxx
@@ -54,33 +54,6 @@ typedef struct
   int max_level;       /* A max level that is not refined further, see -L argument */
 } adapt_data_t;
 
-#if 0
-/* TODO: deprecated. was replaced by t8_common_midpoint. */
-static void
-t8_anchor_element (t8_forest_t forest, t8_locidx_t which_tree,
-                   const t8_scheme *scheme, t8_element_t *element,
-                   double elem_anchor_f[3])
-{
-  double             *tree_vertices;
-
-  tree_vertices = t8_cmesh_get_tree_vertices (t8_forest_get_cmesh (forest),
-                                              t8_forest_ltreeid_to_cmesh_ltreeid
-                                              (forest, which_tree));
-
-  t8_forest_element_coordinate (forest, which_tree, element, tree_vertices,
-                                0, elem_anchor_f);
-#if 0
-  /* get the element anchor node */
-  scheme->t8_element_anchor (element, elem_anchor);
-  maxlevel = scheme->t8_element_maxlevel ();
-  for (i = 0; i < 3; i++) {
-    /* Calculate the anchor coordinate in [0,1]^3 */
-    elem_anchor_f[i] = elem_anchor[i] / (1 << maxlevel);
-  }
-#endif
-}
-#endif
-
 /* refine the forest in a band, given by a plane E and two constants
  * c_min, c_max. We refine the cells in the band c_min*E, c_max*E */
 static int


### PR DESCRIPTION
Closes #1709

**_Describe your changes here:_**

In the benchmark `t8_time_forest_partition.cxx` a block of code was depreciated and not used by ´#if 0` eight years ago, so I would just remove it. 

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).