### PR TITLE
Fix: Use testsuite alloc

### DIFF
--- a/test/t8_cmesh/t8_gtest_cmesh_vertex_conn_tree_to_vertex.cxx
+++ b/test/t8_cmesh/t8_gtest_cmesh_vertex_conn_tree_to_vertex.cxx
@@ -91,7 +91,7 @@ class cmesh_vertex_conn_ttv_with_core_classes: public testing::TestWithParam<cme
       const t8_eclass_t tree_class = t8_cmesh_get_tree_class (committed_cmesh, itree);
       /* Allocate space for entries. */
       const int num_tree_vertices = t8_eclass_num_vertices[tree_class];
-      t8_gloidx_t *global_indices = T8_ALLOC (t8_gloidx_t, num_tree_vertices);
+      t8_gloidx_t *global_indices = T8_TESTSUITE_ALLOC (t8_gloidx_t, num_tree_vertices);
       /* Fill with 0, 1, 2, 3, 4 ... */
       const t8_gloidx_t start_index = itree * T8_ECLASS_MAX_CORNERS;
       for (t8_locidx_t ientry = start_index; ientry < num_tree_vertices; ++ientry) {
@@ -99,7 +99,7 @@ class cmesh_vertex_conn_ttv_with_core_classes: public testing::TestWithParam<cme
       }
       ttv.set_global_vertex_ids_of_tree_vertices (cmesh, itree, global_indices, num_tree_vertices);
       /* It is save to free the entries after commit, since the value got copied. */
-      T8_FREE (global_indices);
+      T8_TESTSUITE_FREE (global_indices);
     }
 
     /* Commit the cmesh */
@@ -163,7 +163,7 @@ class cmesh_vertex_conn_ttv_with_core_classes_temp:
       t8_cmesh_set_tree_class (cmesh, itree, tree_class);
       /* Allocate space for entries. */
       const int num_tree_vertices = t8_eclass_num_vertices[tree_class];
-      t8_gloidx_t *global_indices = T8_ALLOC (t8_gloidx_t, num_tree_vertices);
+      t8_gloidx_t *global_indices = T8_TESTSUITE_ALLOC (t8_gloidx_t, num_tree_vertices);
       /* Fill with i, i+1, i+2, i+3, ... */
       const t8_gloidx_t start_index = itree * T8_ECLASS_MAX_CORNERS;
       for (t8_locidx_t ientry = 0; ientry < num_tree_vertices; ++ientry) {
@@ -171,7 +171,7 @@ class cmesh_vertex_conn_ttv_with_core_classes_temp:
       }
       ttv.set_global_vertex_ids_of_tree_vertices (cmesh, itree, global_indices, num_tree_vertices);
       /* It is save to free the entries after commit, since the value got copied. */
-      T8_FREE (global_indices);
+      T8_TESTSUITE_FREE (global_indices);
     }
 
     /* Commit the cmesh */
@@ -279,7 +279,7 @@ class cmesh_vertex_conn_ttv_with_cmesh_functions: public testing::TestWithParam<
       const t8_eclass_t tree_class = t8_cmesh_get_tree_class (committed_cmesh, itree);
       /* Allocate space for entries. */
       const int num_tree_vertices = t8_eclass_num_vertices[tree_class];
-      t8_gloidx_t *global_indices = T8_ALLOC (t8_gloidx_t, num_tree_vertices);
+      t8_gloidx_t *global_indices = T8_TESTSUITE_ALLOC (t8_gloidx_t, num_tree_vertices);
       /* Fill with 0, 1, 2, 3, 4 ... */
       const t8_gloidx_t start_index = itree * T8_ECLASS_MAX_CORNERS;
       for (t8_locidx_t ientry = start_index; ientry < num_tree_vertices; ++ientry) {
@@ -288,7 +288,7 @@ class cmesh_vertex_conn_ttv_with_cmesh_functions: public testing::TestWithParam<
       const t8_gloidx_t global_tree_id = t8_cmesh_get_global_id (cmesh, itree);
       t8_cmesh_set_global_vertices_of_tree (cmesh, global_tree_id, global_indices, num_tree_vertices);
       /* It is save to free the entries after commit, since the value got copied. */
-      T8_FREE (global_indices);
+      T8_TESTSUITE_FREE (global_indices);
     }
 
     /* Commit the cmesh */
@@ -350,7 +350,7 @@ class cmesh_vertex_conn_ttv_with_cmesh_functions_temp:
       t8_cmesh_set_tree_class (cmesh, itree, tree_class);
       /* Allocate space for entries. */
       const int num_tree_vertices = t8_eclass_num_vertices[tree_class];
-      t8_gloidx_t *global_indices = T8_ALLOC (t8_gloidx_t, num_tree_vertices);
+      t8_gloidx_t *global_indices = T8_TESTSUITE_ALLOC (t8_gloidx_t, num_tree_vertices);
       /* Fill with i, i+1, i+2, i+3, ... */
       const t8_gloidx_t start_index = itree * T8_ECLASS_MAX_CORNERS;
       for (t8_locidx_t ientry = 0; ientry < num_tree_vertices; ++ientry) {
@@ -358,7 +358,7 @@ class cmesh_vertex_conn_ttv_with_cmesh_functions_temp:
       }
       t8_cmesh_set_global_vertices_of_tree (cmesh, itree, global_indices, num_tree_vertices);
       /* It is save to free the entries after commit, since the value got copied. */
-      T8_FREE (global_indices);
+      T8_TESTSUITE_FREE (global_indices);
     }
 
     /* Commit the cmesh */


### PR DESCRIPTION
Closes #1718

**_Describe your changes here:_**
I missed `T8_ALLOC`s in a new test during a merge.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).