### PR TITLE
Fix: Remove unnecessary cmake paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,13 +22,13 @@ cmake_minimum_required( VERSION 3.16 )
 
 include( cmake/GitProjectVersion.cmake )
 
-project( 
+project(
     T8CODE
     DESCRIPTION "Parallel algorithms and data structures for tree-based AMR with arbitrary element shapes."
     LANGUAGES C CXX
-    VERSION "${T8CODE_VERSION_MAJOR}.${T8CODE_VERSION_MINOR}.${T8CODE_VERSION_PATCH}" 
+    VERSION "${T8CODE_VERSION_MAJOR}.${T8CODE_VERSION_MINOR}.${T8CODE_VERSION_PATCH}"
     )
-    
+
 include( GNUInstallDirs)
 include( CTest )
 include( CMakeDependentOption )
@@ -135,17 +135,17 @@ set(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT FALSE)
 set(libPath ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}) # Library directory)
 cmake_path(RELATIVE_PATH libPath
     BASE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR} # Binary directory
-    OUTPUT_VARIABLE relativeRpath 
+    OUTPUT_VARIABLE relativeRpath
 )
 set(CMAKE_INSTALL_RPATH $ORIGIN $ORIGIN/${relativeRpath})
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
 
 if ( T8CODE_USE_SYSTEM_SC )
-    find_package( SC REQUIRED PATHS /path/to/system/sc )
+    find_package( SC REQUIRED )
 else()
     set( SC_BUILD_EXAMPLES ${T8CODE_BUILD_TPL_EXAMPLES} )
     set( SC_BUILD_TESTING ${T8CODE_BUILD_TPL_TESTS} )
-    
+
     # Capture the list of variables before adding the subdirectory to mark the added ones as advanced.
     get_cmake_property(_vars_before_sc VARIABLES )
     add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/sc )
@@ -158,17 +158,17 @@ else()
             list( APPEND _new_sc_vars ${_var} )
         endif()
     endforeach()
-    
+
     # Mark the new variables as advanced
     mark_as_advanced( FORCE ${_new_sc_vars} )
 endif()
 
 if ( T8CODE_USE_SYSTEM_P4EST )
-    find_package( P4EST REQUIRED PATHS /path/to/system/p4est )
+    find_package( P4EST REQUIRED )
 else()
     set( P4EST_BUILD_EXAMPLES ${T8CODE_BUILD_TPL_EXAMPLES} )
     set( P4EST_BUILD_TESTING ${T8CODE_BUILD_TPL_TESTS} )
-    
+
     # Capture the list of variables before adding the subdirectory to mark the added ones as advanced.
     get_cmake_property( _vars_before_p4est VARIABLES )
     add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/p4est )
@@ -181,7 +181,7 @@ else()
             list( APPEND _new_p4est_vars ${_var} )
         endif()
     endforeach()
-    
+
     # Mark the new variables as advanced
     mark_as_advanced( FORCE ${_new_p4est_vars} )
 endif()


### PR DESCRIPTION
Closes #1728

**_Describe your changes here:_**
I was young and did not know how cmake works.
The removed paths are completely unnecessary and I thought that this would be the "default" argument shown during `ccmake`.
Instead, `PATHS` is a keyword for giving hints where cmake should search for the module. And these paths are obviously not correct on any system.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).