### PR TITLE
Fix a typo whihc makes spell check fail

### DIFF
--- a/test/t8_forest/t8_gtest_partition_data.cxx
+++ b/test/t8_forest/t8_gtest_partition_data.cxx
@@ -129,13 +129,13 @@ gTestCompareEQ (const T& value1, const T& value2) -> std::enable_if_t<std::is_sa
 }
 
 /**
- * \brief This function generates example data of the type \tparam T corresponding to the global 
- * element id of each element. It constructs one value per element. The data is defined according 
+ * \brief This function generates example data of the type \tparam T corresponding to the global
+ * element id of each element. It constructs one value per element. The data is defined according
  * to the partition of \a initial_forest. Afterwards a call to \see t8_forest_partition_data() is made
  * which redistributes the example data array accordingly to the partition of \a partitioned_forest.
  * Once the partitioning of the example data array is finished, we check whether each process obtained
  * the correct data entries in the proper ordering.
- * 
+ *
  * \tparam T The datatype of which example data will be generated.
  * \param initial_forest The forest before a partitioning step.
  * \param partitioned_forest The 'same' forest after a partitioning step.
@@ -234,7 +234,7 @@ class t8_test_partition_data_test: public testing::TestWithParam<std::tuple<int,
  * to a pre-set refinement level stated within the adaptation function \see t8_test_partition_data_adapt.
  * The adapted forest is partitioned thereafter.
  * Afterwards example data of different data types is generated according to the partition of the adapted
- * forest. The data is then re-partitioned by calling \see t8_forest_partition_data according to the 
+ * forest. The data is then re-partitioned by calling \see t8_forest_partition_data according to the
  * partition given by the partitioned forest.
  * At last the data is checked for compliance with the partition of the partitioned forest.
  */
@@ -268,4 +268,4 @@ TEST_P (t8_test_partition_data_test, test_partition_data)
   t8_forest_unref (&partitioned_forest);
 }
 
-INSTANTIATE_TEST_SUITE_P (t8_gtest_partititon_data, t8_test_partition_data_test, AllSchemes, print_all_schemes);
+INSTANTIATE_TEST_SUITE_P (t8_gtest_partition_data, t8_test_partition_data_test, AllSchemes, print_all_schemes);


### PR DESCRIPTION
**_Describe your changes here:_**
This typo causes problems with the CI in many different branches.
Probably nothing can be merged before this.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).