### PR TITLE
Improvement: Remove forest argument from adapt callback

### DIFF
--- a/benchmarks/t8_time_forest_partition.cxx
+++ b/benchmarks/t8_time_forest_partition.cxx
@@ -57,7 +57,7 @@ typedef struct
 /* refine the forest in a band, given by a plane E and two constants
  * c_min, c_max. We refine the cells in the band c_min*E, c_max*E */
 static int
-t8_band_adapt (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree, t8_eclass_t tree_class,
+t8_band_adapt (t8_forest_t forest_from, t8_locidx_t which_tree, t8_eclass_t tree_class,
                [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme, const int is_family,
                [[maybe_unused]] const int num_elements, t8_element_t *elements[])
 {
@@ -68,7 +68,7 @@ t8_band_adapt (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tr
   T8_ASSERT (!is_family || num_elements == scheme->element_get_num_children (tree_class, elements[0]));
   level = scheme->element_get_level (tree_class, elements[0]);
   /* Get the minimum and maximum x-coordinate from the user data pointer of forest */
-  adapt_data = (adapt_data_t *) t8_forest_get_user_data (forest);
+  adapt_data = (adapt_data_t *) t8_forest_get_user_data (forest_from);
   t8_3D_vec normal = adapt_data->normal;
   base_level = adapt_data->base_level;
   max_level = adapt_data->max_level;

--- a/benchmarks/t8_time_fractal.cxx
+++ b/benchmarks/t8_time_fractal.cxx
@@ -45,13 +45,12 @@
  *
  */
 static int
-t8_adapt_menger_quad (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                      [[maybe_unused]] t8_locidx_t which_tree, t8_eclass_t tree_class,
-                      [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_adapt_menger_quad ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                      t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                       [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                       t8_element_t *elements[])
 {
-  const int *adapt_data = (const int *) t8_forest_get_user_data (forest);
+  const int *adapt_data = (const int *) t8_forest_get_user_data (forest_from);
   const int level_max = adapt_data[0];
   const int ret = adapt_data[1]; /* -2 if elements get removed, 0 else */
 
@@ -79,13 +78,12 @@ t8_adapt_menger_quad (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_fr
  * of the mesh or leave it untouched. Refine the remaining elements.
  */
 static int
-t8_adapt_sierpinski_tri (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                         [[maybe_unused]] t8_locidx_t which_tree, t8_eclass_t tree_class,
-                         [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_adapt_sierpinski_tri ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                         t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                          [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                          t8_element_t *elements[])
 {
-  const int *adapt_data = (const int *) t8_forest_get_user_data (forest);
+  const int *adapt_data = (const int *) t8_forest_get_user_data (forest_from);
   const int level_max = adapt_data[0];
   const int ret = adapt_data[1]; /* -2 if elements shall be removed, 0 else */
 
@@ -106,13 +104,12 @@ t8_adapt_sierpinski_tri (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest
  * of the mesh or leave them untouched. Refine the remaining elements.
  */
 static int
-t8_adapt_menger_hex (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                     [[maybe_unused]] t8_locidx_t which_tree, t8_eclass_t tree_class,
-                     [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_adapt_menger_hex ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                     t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                      [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                      t8_element_t *elements[])
 {
-  const int *adapt_data = (const int *) t8_forest_get_user_data (forest);
+  const int *adapt_data = (const int *) t8_forest_get_user_data (forest_from);
   const int level_max = adapt_data[0];
   const int ret = adapt_data[1]; /* -2 if elements shall be removed, 0 else */
 
@@ -157,13 +154,12 @@ t8_adapt_menger_hex (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_fro
  * of the mesh or leave it untouched. Refine the remaining elements.
  */
 static int
-t8_adapt_sierpinski_tet (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                         [[maybe_unused]] t8_locidx_t which_tree, t8_eclass_t tree_class,
-                         [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_adapt_sierpinski_tet ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                         t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                          [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                          t8_element_t *elements[])
 {
-  const int *adapt_data = (const int *) t8_forest_get_user_data (forest);
+  const int *adapt_data = (const int *) t8_forest_get_user_data (forest_from);
   const int level_max = adapt_data[0];
   const int ret = adapt_data[1]; /* -2 if elements shall be removed, 0 else */
 
@@ -184,13 +180,12 @@ t8_adapt_sierpinski_tet (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest
  * of the mesh or leave it untouched. Refine the remaining elements.
  */
 static int
-t8_adapt_sierpinski_prism (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                           [[maybe_unused]] t8_locidx_t which_tree, t8_eclass_t tree_class,
-                           [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_adapt_sierpinski_prism ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                           t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                            [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                            t8_element_t *elements[])
 {
-  const int *adapt_data = (const int *) t8_forest_get_user_data (forest);
+  const int *adapt_data = (const int *) t8_forest_get_user_data (forest_from);
   const int level_max = adapt_data[0];
   const int ret = adapt_data[1]; /* -2 if elements shall be removed, 0 else */
 
@@ -211,13 +206,12 @@ t8_adapt_sierpinski_prism (t8_forest_t forest, [[maybe_unused]] t8_forest_t fore
  * of the mesh or leave it untouched. Refine the remaining elements.
  */
 static int
-t8_adapt_sierpinski_pyramid (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                             [[maybe_unused]] t8_locidx_t which_tree, t8_eclass_t tree_class,
-                             [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_adapt_sierpinski_pyramid ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                             t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                              [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                              t8_element_t *elements[])
 {
-  const int *adapt_data = (const int *) t8_forest_get_user_data (forest);
+  const int *adapt_data = (const int *) t8_forest_get_user_data (forest_from);
   const int level_max = adapt_data[0];
   const int ret = adapt_data[1]; /* -2 if elements shall be removed, 0 else */
 
@@ -235,10 +229,9 @@ t8_adapt_sierpinski_pyramid (t8_forest_t forest, [[maybe_unused]] t8_forest_t fo
 
 /* Coarse every family in the mesh. */
 static int
-t8_adapt_coarse ([[maybe_unused]] t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                 [[maybe_unused]] t8_locidx_t which_tree, [[maybe_unused]] t8_eclass_t tree_class,
-                 [[maybe_unused]] t8_locidx_t lelement_id, [[maybe_unused]] const t8_scheme *scheme,
-                 const int is_family, [[maybe_unused]] const int num_elements,
+t8_adapt_coarse ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                 [[maybe_unused]] t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
+                 [[maybe_unused]] const t8_scheme *scheme, const int is_family, [[maybe_unused]] const int num_elements,
                  [[maybe_unused]] t8_element_t *elements[])
 {
   if (is_family) {

--- a/benchmarks/t8_time_new_refine.c
+++ b/benchmarks/t8_time_new_refine.c
@@ -35,7 +35,7 @@
 #include <t8_forest/t8_forest_types.h> /* TODO: This file should not be included from an application */
 /* This function refines every element */
 static int
-t8_basic_adapt_refine (__attribute__ ((unused)) t8_forest_t forest, __attribute__ ((unused)) t8_forest_t forest_from,
+t8_basic_adapt_refine (__attribute__ ((unused)) t8_forest_t forest_from,
                        __attribute__ ((unused)) t8_locidx_t which_tree, t8_eclass_t tree_class,
                        __attribute__ ((unused)) t8_locidx_t lelement_id, const t8_scheme_c *scheme,
                        __attribute__ ((unused)) const int is_family, const int num_elements, t8_element_t *elements[])
@@ -52,7 +52,7 @@ t8_basic_adapt_refine (__attribute__ ((unused)) t8_forest_t forest, __attribute_
 
 /* This function coarsens each element */
 static int
-t8_basic_adapt_coarsen (__attribute__ ((unused)) t8_forest_t forest, __attribute__ ((unused)) t8_forest_t forest_from,
+t8_basic_adapt_coarsen (__attribute__ ((unused)) t8_forest_t forest_from,
                         __attribute__ ((unused)) t8_locidx_t which_tree,
                         __attribute__ ((unused)) t8_eclass_t tree_class,
                         __attribute__ ((unused)) t8_locidx_t lelement_id,

--- a/benchmarks/t8_time_prism_adapt.cxx
+++ b/benchmarks/t8_time_prism_adapt.cxx
@@ -35,9 +35,8 @@
 #include <t8_cmesh/t8_cmesh_examples.h>
 
 static int
-t8_basic_adapt_refine_type (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                            [[maybe_unused]] t8_locidx_t which_tree, t8_eclass_t tree_class,
-                            [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_basic_adapt_refine_type ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                            t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                             [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                             t8_element_t *elements[])
 {
@@ -47,7 +46,7 @@ t8_basic_adapt_refine_type (t8_forest_t forest, [[maybe_unused]] t8_forest_t for
   T8_ASSERT (!is_family || num_elements == scheme->element_get_num_children (tree_class, elements[0]));
 
   level = scheme->element_get_level (tree_class, elements[0]);
-  if (level >= *(int *) t8_forest_get_user_data (forest)) {
+  if (level >= *(int *) t8_forest_get_user_data (forest_from)) {
     return 0;
   }
   /* get the type of the current element */
@@ -60,9 +59,8 @@ t8_basic_adapt_refine_type (t8_forest_t forest, [[maybe_unused]] t8_forest_t for
 }
 
 static int
-t8_basic_adapt_refine_tet (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                           [[maybe_unused]] t8_locidx_t which_tree, t8_eclass_t tree_class,
-                           [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_basic_adapt_refine_tet ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                           t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                            [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                            t8_element_t *elements[])
 {
@@ -72,7 +70,7 @@ t8_basic_adapt_refine_tet (t8_forest_t forest, [[maybe_unused]] t8_forest_t fore
   T8_ASSERT (!is_family || num_elements == scheme->element_get_num_children (tree_class, elements[0]));
 
   level = scheme->element_get_level (tree_class, elements[0]);
-  if (level >= *(int *) t8_forest_get_user_data (forest)) {
+  if (level >= *(int *) t8_forest_get_user_data (forest_from)) {
     return 0;
   }
   /* get the type of the current element */

--- a/example/IO/cmesh/gmsh/t8_load_and_refine_square_w_hole.cxx
+++ b/example/IO/cmesh/gmsh/t8_load_and_refine_square_w_hole.cxx
@@ -98,8 +98,8 @@ t8_midpoint (t8_forest_t forest, t8_locidx_t which_tree, t8_element_t *element, 
 }
 
 static int
-t8_load_refine_adapt ([[maybe_unused]] t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                      t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_load_refine_adapt (t8_forest_t forest_from, t8_locidx_t which_tree, t8_eclass_t tree_class,
+                      [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                       [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                       t8_element_t *elements[])
 {

--- a/example/IO/forest/netcdf/t8_write_forest_netcdf.cxx
+++ b/example/IO/forest/netcdf/t8_write_forest_netcdf.cxx
@@ -64,7 +64,7 @@ struct t8_example_netcdf_adapt_data
 * \note A detailed description of the adaption process is found in step 3 of the tutorial located in 't8code/example/tutorials'.
 */
 int
-t8_example_netcdf_adapt_fn (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
+t8_example_netcdf_adapt_fn (t8_forest_t forest_from, t8_locidx_t which_tree,
                             [[maybe_unused]] const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
                             [[maybe_unused]] const t8_scheme *scheme, const int is_family,
                             [[maybe_unused]] const int num_elements, t8_element_t *elements[])

--- a/example/advect/t8_advection.cxx
+++ b/example/advect/t8_advection.cxx
@@ -179,9 +179,9 @@ t8_advect_element_set_phi_adapt (const t8_advect_problem_t *problem, t8_locidx_t
 /* Adapt the forest. We refine if the level-set function is close to zero
  * and coarsen if it is larger than a given threshold. */
 static int
-t8_advect_adapt (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t ltree_id, const t8_eclass_t tree_class,
-                 t8_locidx_t lelement_id, const t8_scheme *scheme, const int is_family,
-                 [[maybe_unused]] const int num_elements, t8_element_t *elements[])
+t8_advect_adapt (t8_forest_t forest_from, t8_locidx_t ltree_id, const t8_eclass_t tree_class, t8_locidx_t lelement_id,
+                 const t8_scheme *scheme, const int is_family, [[maybe_unused]] const int num_elements,
+                 t8_element_t *elements[])
 {
   t8_advect_problem_t *problem;
   t8_advect_element_data_t *elem_data;
@@ -194,7 +194,7 @@ t8_advect_adapt (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t ltree_
 
   srand (seed++);
   /* Get a pointer to the problem from the user data pointer of forest */
-  problem = (t8_advect_problem_t *) t8_forest_get_user_data (forest);
+  problem = (t8_advect_problem_t *) t8_forest_get_user_data (forest_from);
   /* Get the element's level */
   level = scheme->element_get_level (tree_class, elements[0]);
   if (level == problem->maxlevel && !is_family) {

--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -36,10 +36,10 @@
  * The user data of forest must an integer set to the maximum refinement level.
  */
 int
-t8_common_adapt_balance (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                         const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
-                         const t8_scheme *scheme, [[maybe_unused]] const int is_family,
-                         [[maybe_unused]] const int num_elements, t8_element_t *elements[])
+t8_common_adapt_balance (t8_forest_t forest_from, t8_locidx_t which_tree, const t8_eclass_t tree_class,
+                         [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+                         [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
+                         t8_element_t *elements[])
 {
   int level;
   int maxlevel, child_id;
@@ -47,7 +47,7 @@ t8_common_adapt_balance (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_
   level = scheme->element_get_level (tree_class, elements[0]);
 
   /* we set a maximum refinement level as forest user data */
-  maxlevel = *(int *) t8_forest_get_user_data (forest);
+  maxlevel = *(int *) t8_forest_get_user_data (forest_from);
   if (level >= maxlevel) {
     /* Do not refine after the maxlevel */
     return 0;
@@ -118,10 +118,9 @@ t8_common_within_levelset (t8_forest_t forest, const t8_locidx_t ltreeid, const 
  */
 /* TODO: Currently the band_width control is not working yet. */
 int
-t8_common_adapt_level_set (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                           const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
-                           const t8_scheme *scheme, const int is_family, [[maybe_unused]] const int num_elements,
-                           t8_element_t *elements[])
+t8_common_adapt_level_set (t8_forest_t forest_from, t8_locidx_t which_tree, const t8_eclass_t tree_class,
+                           [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme, const int is_family,
+                           [[maybe_unused]] const int num_elements, t8_element_t *elements[])
 {
   t8_example_level_set_struct_t *data;
   int within_band;
@@ -129,11 +128,11 @@ t8_common_adapt_level_set (t8_forest_t forest, t8_forest_t forest_from, t8_locid
 
   T8_ASSERT (!is_family || num_elements == scheme->element_get_num_children (tree_class, elements[0]));
 
-  data = (t8_example_level_set_struct_t *) t8_forest_get_user_data (forest);
+  data = (t8_example_level_set_struct_t *) t8_forest_get_user_data (forest_from);
   level = scheme->element_get_level (tree_class, elements[0]);
 
   /* Get the minimum and maximum x-coordinate from the user data pointer of forest */
-  data = (t8_example_level_set_struct_t *) t8_forest_get_user_data (forest);
+  data = (t8_example_level_set_struct_t *) t8_forest_get_user_data (forest_from);
 
   /* If maxlevel is exceeded then coarsen */
   if (level > data->max_level && is_family) {

--- a/example/common/t8_example_common.hxx
+++ b/example/common/t8_example_common.hxx
@@ -83,9 +83,9 @@ t8_common_within_levelset (t8_forest_t forest, const t8_locidx_t ltreeid, const 
  * imbalanced forest.
  */
 int
-t8_common_adapt_balance (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                         const t8_eclass_t tree_class, t8_locidx_t lelement_id, const t8_scheme_c *scheme,
-                         const int is_family, const int num_elements, t8_element_t *elements[]);
+t8_common_adapt_balance (t8_forest_t forest_from, t8_locidx_t which_tree, const t8_eclass_t tree_class,
+                         t8_locidx_t lelement_id, const t8_scheme_c *scheme, const int is_family,
+                         const int num_elements, t8_element_t *elements[]);
 
 /** Adapt a forest along a given level-set function.
  * The user data of forest must be a pointer to a \a t8_example_level_set_struct_t.
@@ -95,9 +95,9 @@ t8_common_adapt_balance (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_
 /* TODO: Currently the band_width control is not working yet.
  *        if band_with = 0, then all elements that are touched by the zero LS are refined. */
 int
-t8_common_adapt_level_set (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                           const t8_eclass_t tree_class, t8_locidx_t lelement_id, const t8_scheme_c *scheme,
-                           const int is_family, const int num_elements, t8_element_t *elements[]);
+t8_common_adapt_level_set (t8_forest_t forest_from, t8_locidx_t which_tree, const t8_eclass_t tree_class,
+                           t8_locidx_t lelement_id, const t8_scheme_c *scheme, const int is_family,
+                           const int num_elements, t8_element_t *elements[]);
 
 /** Real valued functions defined in t8_example_common_functions.h */
 

--- a/example/forest/t8_test_face_iterate.cxx
+++ b/example/forest/t8_test_face_iterate.cxx
@@ -58,9 +58,9 @@ t8_test_fiterate_callback (t8_forest_t forest, t8_locidx_t ltreeid, const t8_ele
 
 /* Only refine the first tree on a process. */
 static int
-t8_basic_adapt ([[maybe_unused]] t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from, t8_locidx_t which_tree,
-                const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
-                [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements, t8_element_t *elements[])
+t8_basic_adapt ([[maybe_unused]] t8_forest_t forest_from, t8_locidx_t which_tree, const t8_eclass_t tree_class,
+                [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme, [[maybe_unused]] const int is_family,
+                [[maybe_unused]] const int num_elements, t8_element_t *elements[])
 {
   int mpirank, mpiret;
   T8_ASSERT (!is_family || num_elements == scheme->element_get_num_children (tree_class, elements[0]));

--- a/example/forest/t8_test_ghost.cxx
+++ b/example/forest/t8_test_ghost.cxx
@@ -43,9 +43,8 @@ typedef enum {
  * This function comes from the timings2.c example of p4est.
  */
 int
-t8_refine_p8est ([[maybe_unused]] t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                 [[maybe_unused]] t8_locidx_t which_tree, const t8_eclass_t tree_class,
-                 [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_refine_p8est ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                 const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                  [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                  t8_element_t *elements[])
 {
@@ -58,11 +57,10 @@ t8_refine_p8est ([[maybe_unused]] t8_forest_t forest, [[maybe_unused]] t8_forest
 
 /* Refine every third element. */
 static int
-t8_adapt_every_third_element ([[maybe_unused]] t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                              [[maybe_unused]] t8_locidx_t which_tree, const t8_eclass_t tree_class,
-                              [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
-                              [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
-                              t8_element_t *elements[])
+t8_adapt_every_third_element ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                              const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
+                              const t8_scheme *scheme, [[maybe_unused]] const int is_family,
+                              [[maybe_unused]] const int num_elements, t8_element_t *elements[])
 {
   T8_ASSERT (!is_family || num_elements == scheme->element_get_num_children (tree_class, elements[0]));
   const int level = scheme->element_get_level (tree_class, elements[0]);

--- a/example/forest/t8_test_ghost_large_level_diff.cxx
+++ b/example/forest/t8_test_ghost_large_level_diff.cxx
@@ -67,9 +67,8 @@
  *           scheme (see t8_scheme_new_default in t8_default/t8_default.hxx).
  */
 static int
-t8_ghost_fractal_adapt (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                        [[maybe_unused]] t8_locidx_t which_tree, const t8_eclass_t tree_class,
-                        [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_ghost_fractal_adapt ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                        const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                         [[maybe_unused]] int is_family, [[maybe_unused]] int num_elements, t8_element_t *elements[])
 {
   int level;
@@ -78,7 +77,7 @@ t8_ghost_fractal_adapt (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_
   T8_ASSERT (t8_eclass_scheme_is_default (scheme, tree_class));
 
   level = scheme->element_get_level (tree_class, elements[0]);
-  if (level >= *(int *) t8_forest_get_user_data (forest)) {
+  if (level >= *(int *) t8_forest_get_user_data (forest_from)) {
     return 0;
   }
   if (tree_class == T8_ECLASS_PRISM) {

--- a/example/geometry/t8_example_geometries.cxx
+++ b/example/geometry/t8_example_geometries.cxx
@@ -590,7 +590,7 @@ struct t8_geometry_cube_zdistorted: public t8_geometry
 /* This adapt callback function will refine all elements at the
  * domain boundary up to a given maximum refinement level. */
 static int
-t8_geom_adapt_boundary (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t ltree_id, const t8_eclass_t tree_class,
+t8_geom_adapt_boundary (t8_forest_t forest_from, t8_locidx_t ltree_id, const t8_eclass_t tree_class,
                         [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                         [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                         t8_element_t *elements[])
@@ -601,7 +601,7 @@ t8_geom_adapt_boundary (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t
   int iface;
   /* Get the maximum level from the forest's user data 
    * (must be set before using the callback). */
-  int maxlevel = *(int *) t8_forest_get_user_data (forest);
+  int maxlevel = *(int *) t8_forest_get_user_data (forest_from);
 
   /* We do not refine more then the given maximum level. */
   if (scheme->element_get_level (tree_class, elements[0]) >= maxlevel) {

--- a/example/remove/t8_example_empty_trees.cxx
+++ b/example/remove/t8_example_empty_trees.cxx
@@ -34,12 +34,12 @@ T8_EXTERN_C_BEGIN ();
 /** Removes all elements of a local tree if they belong to the corresponding
  *  global trees which is given by the user_data. */
 static int
-t8_adapt_remove (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                 [[maybe_unused]] const t8_eclass_t tree_class, [[maybe_unused]] const t8_locidx_t lelement_id,
-                 [[maybe_unused]] const t8_scheme *scheme, [[maybe_unused]] const int is_family,
-                 [[maybe_unused]] const int num_elements, [[maybe_unused]] t8_element_t *elements[])
+t8_adapt_remove (t8_forest_t forest_from, t8_locidx_t which_tree, [[maybe_unused]] const t8_eclass_t tree_class,
+                 [[maybe_unused]] const t8_locidx_t lelement_id, [[maybe_unused]] const t8_scheme *scheme,
+                 [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
+                 [[maybe_unused]] t8_element_t *elements[])
 {
-  const t8_gloidx_t *tree_id = (const t8_gloidx_t *) t8_forest_get_user_data (forest);
+  const t8_gloidx_t *tree_id = (const t8_gloidx_t *) t8_forest_get_user_data (forest_from);
   const t8_gloidx_t global_tree_id = t8_forest_global_tree_id (forest_from, which_tree);
   if (global_tree_id == *tree_id) {
     return -2;

--- a/example/remove/t8_example_gauss_blob.cxx
+++ b/example/remove/t8_example_gauss_blob.cxx
@@ -96,12 +96,12 @@ t8_output_data_to_vtu (t8_forest_t forest, double *data, const char *prefix)
 
 /* Refine, if element is within a given radius. */
 static int
-t8_adapt_refine (t8_forest_t forest, t8_forest_t forest_from, const t8_locidx_t which_tree,
-                 [[maybe_unused]] const t8_eclass_t tree_class, [[maybe_unused]] const t8_locidx_t lelement_id,
-                 [[maybe_unused]] const t8_scheme *scheme, [[maybe_unused]] const int is_family,
-                 [[maybe_unused]] const int num_elements, t8_element_t *elements[])
+t8_adapt_refine (t8_forest_t forest_from, const t8_locidx_t which_tree, [[maybe_unused]] const t8_eclass_t tree_class,
+                 [[maybe_unused]] const t8_locidx_t lelement_id, [[maybe_unused]] const t8_scheme *scheme,
+                 [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
+                 t8_element_t *elements[])
 {
-  const struct t8_adapt_data *adapt_data = (const struct t8_adapt_data *) t8_forest_get_user_data (forest);
+  const struct t8_adapt_data *adapt_data = (const struct t8_adapt_data *) t8_forest_get_user_data (forest_from);
   T8_ASSERT (adapt_data != NULL);
 
   t8_3D_point centroid;
@@ -116,12 +116,12 @@ t8_adapt_refine (t8_forest_t forest, t8_forest_t forest_from, const t8_locidx_t 
 
 /* Remove, element if it is within our outside a given radius. */
 static int
-t8_adapt_remove (t8_forest_t forest, t8_forest_t forest_from, const t8_locidx_t which_tree,
-                 [[maybe_unused]] const t8_eclass_t tree_class, [[maybe_unused]] const t8_locidx_t lelement_id,
-                 [[maybe_unused]] const t8_scheme *scheme, [[maybe_unused]] const int is_family,
-                 [[maybe_unused]] const int num_elements, t8_element_t *elements[])
+t8_adapt_remove (t8_forest_t forest_from, const t8_locidx_t which_tree, [[maybe_unused]] const t8_eclass_t tree_class,
+                 [[maybe_unused]] const t8_locidx_t lelement_id, [[maybe_unused]] const t8_scheme *scheme,
+                 [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
+                 t8_element_t *elements[])
 {
-  const struct t8_adapt_data *adapt_data = (const struct t8_adapt_data *) t8_forest_get_user_data (forest);
+  const struct t8_adapt_data *adapt_data = (const struct t8_adapt_data *) t8_forest_get_user_data (forest_from);
   T8_ASSERT (adapt_data != NULL);
 
   t8_3D_point centroid;

--- a/example/remove/t8_example_spheres.cxx
+++ b/example/remove/t8_example_spheres.cxx
@@ -39,12 +39,12 @@ struct t8_adapt_data
 
 /* Refine, if element is within a given radius. */
 static int
-t8_adapt_callback_refine (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
+t8_adapt_callback_refine (t8_forest_t forest_from, t8_locidx_t which_tree,
                           [[maybe_unused]] const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
                           [[maybe_unused]] const t8_scheme *scheme, [[maybe_unused]] const int is_family,
                           [[maybe_unused]] const int num_elements, t8_element_t *elements[])
 {
-  const struct t8_adapt_data *adapt_data = (const struct t8_adapt_data *) t8_forest_get_user_data (forest);
+  const struct t8_adapt_data *adapt_data = (const struct t8_adapt_data *) t8_forest_get_user_data (forest_from);
   T8_ASSERT (adapt_data != NULL);
 
   t8_3D_point centroid;
@@ -61,12 +61,12 @@ t8_adapt_callback_refine (t8_forest_t forest, t8_forest_t forest_from, t8_locidx
 
 /* Remove, element if it is within a given radius. */
 static int
-t8_adapt_callback_remove (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
+t8_adapt_callback_remove (t8_forest_t forest_from, t8_locidx_t which_tree,
                           [[maybe_unused]] const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
                           [[maybe_unused]] const t8_scheme *scheme, [[maybe_unused]] const int is_family,
                           [[maybe_unused]] const int num_elements, t8_element_t *elements[])
 {
-  const struct t8_adapt_data *adapt_data = (const struct t8_adapt_data *) t8_forest_get_user_data (forest);
+  const struct t8_adapt_data *adapt_data = (const struct t8_adapt_data *) t8_forest_get_user_data (forest_from);
   T8_ASSERT (adapt_data != NULL);
 
   t8_3D_point centroid;

--- a/src/t8_forest/t8_forest.cxx
+++ b/src/t8_forest/t8_forest.cxx
@@ -2977,11 +2977,10 @@ t8_forest_comm_global_num_leaf_elements (t8_forest_t forest)
  * \return                  Always return 1, to refine every element
  */
 static int
-t8_forest_refine_everything ([[maybe_unused]] t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                             [[maybe_unused]] t8_locidx_t which_tree, [[maybe_unused]] t8_eclass_t tree_class,
-                             [[maybe_unused]] t8_locidx_t lelement_id, [[maybe_unused]] const t8_scheme *scheme,
-                             [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
-                             [[maybe_unused]] t8_element_t *elements[])
+t8_forest_refine_everything ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                             [[maybe_unused]] t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
+                             [[maybe_unused]] const t8_scheme *scheme, [[maybe_unused]] const int is_family,
+                             [[maybe_unused]] const int num_elements, [[maybe_unused]] t8_element_t *elements[])
 {
 
   return 1;

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -281,7 +281,7 @@ t8_forest_adapt_coarsen_recursive (t8_forest_t forest, t8_locidx_t ltreeid, t8_e
     }
 #endif
     if (is_family
-        && forest->set_adapt_fn (forest, forest->set_from, ltreeid, tree_class, lelement_id, scheme, is_family,
+        && forest->set_adapt_fn (forest->set_from, ltreeid, tree_class, lelement_id, scheme, is_family,
                                  num_elements_to_adapt_callback, fam)
              == -1) {
       /* Coarsen the element */
@@ -340,8 +340,8 @@ t8_forest_adapt_refine_recursive (t8_forest_t forest, t8_locidx_t ltreeid, t8_ec
     const int num_children = scheme->element_get_num_children (tree_class, el_buffer[0]);
     const int is_family = 0;
     const int num_elements_to_adapt_callback = 1;
-    const int refine = forest->set_adapt_fn (forest, forest->set_from, ltreeid, tree_class, lelement_id, scheme,
-                                             is_family, num_elements_to_adapt_callback, el_buffer);
+    const int refine = forest->set_adapt_fn (forest->set_from, ltreeid, tree_class, lelement_id, scheme, is_family,
+                                             num_elements_to_adapt_callback, el_buffer);
     T8_ASSERT (refine != -1);
     if (refine == 1) {
       /* The element should be refined */
@@ -533,8 +533,8 @@ t8_forest_adapt (t8_forest_t forest)
          *                    -1 if we passed a family and it should get coarsened
          *                    -2 if the element should be removed.
          */
-        refine = forest->set_adapt_fn (forest, forest->set_from, ltree_id, tree->eclass, el_considered, scheme,
-                                       is_family, num_elements_to_adapt_callback, elements_from);
+        refine = forest->set_adapt_fn (forest->set_from, ltree_id, tree->eclass, el_considered, scheme, is_family,
+                                       num_elements_to_adapt_callback, elements_from);
 
         T8_ASSERT (is_family || refine != -1);
         if (refine > 0

--- a/src/t8_forest/t8_forest_balance.cxx
+++ b/src/t8_forest/t8_forest_balance.cxx
@@ -41,10 +41,10 @@ T8_EXTERN_C_BEGIN ();
  * we pass forest_from as a parameter. But doing so is not valid anymore
  * if we refine recursively. */
 static int
-t8_forest_balance_adapt (t8_forest_t forest, t8_forest_t forest_from, const t8_locidx_t ltree_id,
-                         const t8_eclass_t tree_class, [[maybe_unused]] const t8_locidx_t lelement_id,
-                         const t8_scheme *scheme, [[maybe_unused]] const int is_family,
-                         [[maybe_unused]] const int num_elements, t8_element_t *elements[])
+t8_forest_balance_adapt (t8_forest_t forest_from, const t8_locidx_t ltree_id, const t8_eclass_t tree_class,
+                         [[maybe_unused]] const t8_locidx_t lelement_id, const t8_scheme *scheme,
+                         [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
+                         t8_element_t *elements[])
 {
   int *pdone, iface, num_faces, num_half_neighbors, ineigh;
   t8_gloidx_t neighbor_tree;
@@ -62,7 +62,7 @@ t8_forest_balance_adapt (t8_forest_t forest, t8_forest_t forest_from, const t8_l
   if (forest_from->maxlevel_existing <= 0
       || scheme->element_get_level (tree_class, element) <= forest_from->maxlevel_existing - 2) {
 
-    pdone = (int *) forest->t8code_data;
+    pdone = (int *) forest_from->t8code_data;
 
     num_faces = scheme->element_get_num_faces (tree_class, element);
     for (iface = 0; iface < num_faces; iface++) {
@@ -342,8 +342,7 @@ t8_forest_is_balanced (t8_forest_t forest)
       const t8_element_t *element = t8_forest_get_leaf_element_in_tree (forest, itree, ielem);
       /* Test if this element would need to be refined in the balance step.
        * If so, the forest is not balanced locally. */
-      if (t8_forest_balance_adapt (forest, forest, itree, tree_class, ielem, scheme, 0, 1,
-                                   (t8_element_t **) (&element))) {
+      if (t8_forest_balance_adapt (forest, itree, tree_class, ielem, scheme, 0, 1, (t8_element_t **) (&element))) {
         forest->set_from = forest_from;
         forest->t8code_data = data_temp;
         return 0;

--- a/src/t8_forest/t8_forest_general.h
+++ b/src/t8_forest/t8_forest_general.h
@@ -113,9 +113,9 @@ typedef void (*t8_forest_replace_t) (t8_forest_t forest_old, t8_forest_t forest_
  */
 /* TODO: Do we really need the forest argument? Since the forest is not committed yet it
  *       seems dangerous to expose to the user. */
-typedef int (*t8_forest_adapt_t) (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                                  const t8_eclass_t tree_class, t8_locidx_t lelement_id, const t8_scheme_c *scheme,
-                                  const int is_family, const int num_elements, t8_element_t *elements[]);
+typedef int (*t8_forest_adapt_t) (t8_forest_t forest_from, t8_locidx_t which_tree, const t8_eclass_t tree_class,
+                                  t8_locidx_t lelement_id, const t8_scheme_c *scheme, const int is_family,
+                                  const int num_elements, t8_element_t *elements[]);
 
 /** Create a new forest with reference count one.
  * This forest needs to be specialized with the t8_forest_set_* calls.

--- a/test/t8_forest/t8_gtest_balance.cxx
+++ b/test/t8_forest/t8_gtest_balance.cxx
@@ -85,12 +85,13 @@ struct gtest_balance_adapt_data
 };
 
 static int
-t8_gtest_balance_refine_certain_trees (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                                       const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
-                                       const t8_scheme *scheme, [[maybe_unused]] const int is_family,
-                                       [[maybe_unused]] const int num_elements, t8_element_t *elements[])
+t8_gtest_balance_refine_certain_trees (t8_forest_t forest_from, t8_locidx_t which_tree, const t8_eclass_t tree_class,
+                                       [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+                                       [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
+                                       t8_element_t *elements[])
 {
-  gtest_balance_adapt_data *adapt_data = static_cast<gtest_balance_adapt_data *> (t8_forest_get_user_data (forest));
+  gtest_balance_adapt_data *adapt_data
+    = static_cast<gtest_balance_adapt_data *> (t8_forest_get_user_data (forest_from));
 
   const t8_gloidx_t gtree_id = t8_forest_global_tree_id (forest_from, which_tree);
 

--- a/test/t8_forest/t8_gtest_element_is_leaf.cxx
+++ b/test/t8_forest/t8_gtest_element_is_leaf.cxx
@@ -46,18 +46,17 @@
  * family is refined and no other elements. This results in a highly
  * imbalanced forest. */
 static int
-t8_test_adapt_first_child (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                           [[maybe_unused]] t8_locidx_t which_tree, const t8_eclass_t tree_class,
-                           [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
-                           [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
-                           t8_element_t *elements[])
+t8_test_adapt_first_child ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                           const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
+                           const t8_scheme *scheme, [[maybe_unused]] const int is_family,
+                           [[maybe_unused]] const int num_elements, t8_element_t *elements[])
 {
   T8_ASSERT (!is_family || (is_family && num_elements == scheme->element_get_num_children (tree_class, elements[0])));
 
   const int level = scheme->element_get_level (tree_class, elements[0]);
 
   /* we set a maximum refinement level as forest user data */
-  int maxlevel = *(int *) t8_forest_get_user_data (forest);
+  int maxlevel = *(int *) t8_forest_get_user_data (forest_from);
   if (level >= maxlevel) {
     /* Do not refine after the maxlevel */
     return 0;

--- a/test/t8_forest/t8_gtest_forest_commit.cxx
+++ b/test/t8_forest/t8_gtest_forest_commit.cxx
@@ -67,9 +67,8 @@ class forest_commit: public testing::TestWithParam<std::tuple<int, cmesh_example
  * tree is refined and no other elements. This results in a highly
  * imbalanced forest. */
 static int
-t8_test_adapt_balance (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                       [[maybe_unused]] t8_locidx_t which_tree, t8_eclass_t tree_class,
-                       [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_test_adapt_balance ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                       t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                        [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                        t8_element_t *elements[])
 {
@@ -78,7 +77,7 @@ t8_test_adapt_balance (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_f
   const int level = scheme->element_get_level (tree_class, elements[0]);
 
   /* we set a maximum refinement level as forest user data */
-  int maxlevel = *(int *) t8_forest_get_user_data (forest);
+  int maxlevel = *(int *) t8_forest_get_user_data (forest_from);
   if (level >= maxlevel) {
     /* Do not refine after the maxlevel */
     return 0;

--- a/test/t8_forest/t8_gtest_ghost_and_owner.cxx
+++ b/test/t8_forest/t8_gtest_ghost_and_owner.cxx
@@ -62,16 +62,15 @@ class forest_ghost_owner: public testing::TestWithParam<std::tuple<int, cmesh_ex
 };
 
 static int
-t8_test_gao_adapt (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                   [[maybe_unused]] t8_locidx_t which_tree, t8_eclass_t tree_class,
-                   [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_test_gao_adapt ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                   t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                    [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                    t8_element_t *elements[])
 {
   /* refine every second element up to the maximum level */
   const int level = scheme->element_get_level (tree_class, elements[0]);
   const t8_linearidx_t eid = scheme->element_get_linear_id (tree_class, elements[0], level);
-  const int maxlevel = *(int *) t8_forest_get_user_data (forest);
+  const int maxlevel = *(int *) t8_forest_get_user_data (forest_from);
 
   if (eid % 2 && level < maxlevel) {
     return 1;

--- a/test/t8_forest/t8_gtest_ghost_delete.cxx
+++ b/test/t8_forest/t8_gtest_ghost_delete.cxx
@@ -42,10 +42,10 @@
  * delete elements, whose lower left y coordniate is 0.25, so that the second row is deleted
  */
 static int
-test_adapt_holes ([[maybe_unused]] t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                  [[maybe_unused]] const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
-                  [[maybe_unused]] const t8_scheme *scheme, [[maybe_unused]] const int is_family,
-                  [[maybe_unused]] const int num_elements, t8_element_t *elements[])
+test_adapt_holes (t8_forest_t forest_from, t8_locidx_t which_tree, [[maybe_unused]] const t8_eclass_t tree_class,
+                  [[maybe_unused]] t8_locidx_t lelement_id, [[maybe_unused]] const t8_scheme *scheme,
+                  [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
+                  t8_element_t *elements[])
 {
   double coordinates[3];
   t8_forest_element_coordinate (forest_from, which_tree, elements[0], 0, coordinates);

--- a/test/t8_forest/t8_gtest_ghost_exchange.cxx
+++ b/test/t8_forest/t8_gtest_ghost_exchange.cxx
@@ -67,16 +67,15 @@ class forest_ghost_exchange: public testing::TestWithParam<std::tuple<int, cmesh
 };
 
 static int
-t8_test_exchange_adapt (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                        [[maybe_unused]] t8_locidx_t which_tree, const t8_eclass_t tree_class,
-                        [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_test_exchange_adapt ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                        const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                         [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                         t8_element_t *elements[])
 {
   /* refine every second element up to the maximum level */
   const int level = scheme->element_get_level (tree_class, elements[0]);
   const t8_linearidx_t eid = scheme->element_get_linear_id (tree_class, elements[0], level);
-  const int maxlevel = *(int *) t8_forest_get_user_data (forest);
+  const int maxlevel = *(int *) t8_forest_get_user_data (forest_from);
 
   if (eid % 2 && level < maxlevel) {
     return 1;

--- a/test/t8_forest/t8_gtest_partition_data.cxx
+++ b/test/t8_forest/t8_gtest_partition_data.cxx
@@ -200,10 +200,10 @@ TestPartitionData (const t8_forest_t initial_forest, const t8_forest_t partition
  * to a pre-set refinement level.
  */
 static int
-t8_test_partition_data_adapt ([[maybe_unused]] t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                              const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
-                              const t8_scheme* scheme, [[maybe_unused]] const int is_family,
-                              [[maybe_unused]] const int num_elements, t8_element_t* elements[])
+t8_test_partition_data_adapt (t8_forest_t forest_from, t8_locidx_t which_tree, const t8_eclass_t tree_class,
+                              [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme* scheme,
+                              [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
+                              t8_element_t* elements[])
 {
   const int level = scheme->element_get_level (tree_class, elements[0]);
   const t8_gloidx_t gtree_id = t8_forest_global_tree_id (forest_from, which_tree);

--- a/test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
@@ -61,12 +61,12 @@ class DISABLED_global_tree: public testing::TestWithParam<std::tuple<t8_eclass, 
 /** Removes all elements of local trees if they belong to the corresponding
  *  global trees which are defined by the current testcase of test. */
 static int
-t8_adapt_remove (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                 [[maybe_unused]] const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
-                 [[maybe_unused]] const t8_scheme *scheme, [[maybe_unused]] const int is_family,
-                 [[maybe_unused]] const int num_elements, [[maybe_unused]] t8_element_t *elements[])
+t8_adapt_remove (t8_forest_t forest_from, t8_locidx_t which_tree, [[maybe_unused]] const t8_eclass_t tree_class,
+                 [[maybe_unused]] t8_locidx_t lelement_id, [[maybe_unused]] const t8_scheme *scheme,
+                 [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
+                 [[maybe_unused]] t8_element_t *elements[])
 {
-  const int *testcase = (const int *) t8_forest_get_user_data (forest);
+  const int *testcase = (const int *) t8_forest_get_user_data (forest_from);
   const t8_gloidx_t global_tree_id = t8_forest_global_tree_id (forest_from, which_tree);
   switch (*testcase) {
   case 0:

--- a/test/t8_forest_incomplete/t8_gtest_empty_local_tree.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_empty_local_tree.cxx
@@ -93,12 +93,12 @@ struct t8_trees_to_remove
 /** Remove every element of rank i if the i`th bit in 
  * the current instance \a remove is 0. */
 static int
-t8_adapt_remove (t8_forest_t forest, t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+t8_adapt_remove (t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
                  [[maybe_unused]] const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
                  [[maybe_unused]] const t8_scheme *scheme, [[maybe_unused]] const int is_family,
                  [[maybe_unused]] const int num_elements, [[maybe_unused]] t8_element_t *elements[])
 {
-  struct t8_trees_to_remove *trees_to_remove = (struct t8_trees_to_remove *) t8_forest_get_user_data (forest);
+  struct t8_trees_to_remove *trees_to_remove = (struct t8_trees_to_remove *) t8_forest_get_user_data (forest_from);
   if (trees_to_remove->remove[forest_from->mpirank] == 0) {
     return -2;
   }

--- a/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_iterate_replace.cxx
@@ -150,12 +150,11 @@ t8_forest_replace (t8_forest_t forest_old, t8_forest_t forest_new, t8_locidx_t w
  * else if \a lelement_id mod 12 < 12 -> refine element
 */
 int
-t8_adapt_callback (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                   [[maybe_unused]] const t8_eclass_t tree_class, t8_locidx_t lelement_id,
-                   [[maybe_unused]] const t8_scheme *scheme, const int is_family,
+t8_adapt_callback (t8_forest_t forest_from, t8_locidx_t which_tree, [[maybe_unused]] const t8_eclass_t tree_class,
+                   t8_locidx_t lelement_id, [[maybe_unused]] const t8_scheme *scheme, const int is_family,
                    [[maybe_unused]] const int num_elements, [[maybe_unused]] t8_element_t *elements[])
 {
-  struct t8_return_data *return_data = (struct t8_return_data *) t8_forest_get_user_data (forest);
+  struct t8_return_data *return_data = (struct t8_return_data *) t8_forest_get_user_data (forest_from);
   T8_ASSERT (return_data != NULL);
 
   const int id_mod_12 = lelement_id % 12;

--- a/test/t8_forest_incomplete/t8_gtest_permute_hole.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_permute_hole.cxx
@@ -101,12 +101,12 @@ struct t8_elements
 /** Remove every element with local_id i if the i`th bit in 
  * the current permutation \a remove is 0. */
 static int
-t8_adapt_remove (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+t8_adapt_remove ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
                  [[maybe_unused]] const t8_eclass_t tree_class, t8_locidx_t lelement_id,
                  [[maybe_unused]] const t8_scheme *scheme, [[maybe_unused]] const int is_family,
                  [[maybe_unused]] const int num_elements, [[maybe_unused]] t8_element_t *elements[])
 {
-  struct t8_elements *data = (struct t8_elements *) t8_forest_get_user_data (forest);
+  struct t8_elements *data = (struct t8_elements *) t8_forest_get_user_data (forest_from);
   if (data->remove[lelement_id] == 0) {
     return -2;
   }
@@ -115,10 +115,9 @@ t8_adapt_remove (t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from, [
 
 /** Coarse every (incomplete) family */
 static int
-t8_adapt_coarse ([[maybe_unused]] t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                 [[maybe_unused]] t8_locidx_t which_tree, [[maybe_unused]] const t8_eclass_t tree_class,
-                 [[maybe_unused]] t8_locidx_t lelement_id, [[maybe_unused]] const t8_scheme *scheme,
-                 const int is_family, [[maybe_unused]] const int num_elements,
+t8_adapt_coarse ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                 [[maybe_unused]] const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
+                 [[maybe_unused]] const t8_scheme *scheme, const int is_family, [[maybe_unused]] const int num_elements,
                  [[maybe_unused]] t8_element_t *elements[])
 {
   if (is_family) {

--- a/test/t8_forest_incomplete/t8_gtest_recursive.cxx
+++ b/test/t8_forest_incomplete/t8_gtest_recursive.cxx
@@ -83,11 +83,10 @@ class recursive_tree: public testing::TestWithParam<std::tuple<int, t8_eclass_t>
 
 /** Remove every element except last and first of a family. */
 static int
-t8_adapt_remove_but_last_first ([[maybe_unused]] t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                                [[maybe_unused]] t8_locidx_t which_tree, const t8_eclass_t tree_class,
-                                [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
-                                [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
-                                t8_element_t *elements[])
+t8_adapt_remove_but_last_first ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                                const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
+                                const t8_scheme *scheme, [[maybe_unused]] const int is_family,
+                                [[maybe_unused]] const int num_elements, t8_element_t *elements[])
 {
   const int num_children = scheme->element_get_num_children (tree_class, elements[0]);
   const int child_id = scheme->element_get_child_id (tree_class, elements[0]);
@@ -99,9 +98,8 @@ t8_adapt_remove_but_last_first ([[maybe_unused]] t8_forest_t forest, [[maybe_unu
 
 /** Refine the first element of a family. */
 static int
-t8_adapt_refine_first ([[maybe_unused]] t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                       [[maybe_unused]] t8_locidx_t which_tree, const t8_eclass_t tree_class,
-                       [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+t8_adapt_refine_first ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                       const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
                        [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                        t8_element_t *elements[])
 {
@@ -116,22 +114,20 @@ t8_adapt_refine_first ([[maybe_unused]] t8_forest_t forest, [[maybe_unused]] t8_
 
 /** Refine every element. */
 static int
-t8_adapt_refine_all ([[maybe_unused]] t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                     [[maybe_unused]] t8_locidx_t which_tree, [[maybe_unused]] const t8_eclass_t tree_class,
-                     [[maybe_unused]] t8_locidx_t lelement_id, [[maybe_unused]] const t8_scheme *scheme,
-                     [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
-                     [[maybe_unused]] t8_element_t *elements[])
+t8_adapt_refine_all ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                     [[maybe_unused]] const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
+                     [[maybe_unused]] const t8_scheme *scheme, [[maybe_unused]] const int is_family,
+                     [[maybe_unused]] const int num_elements, [[maybe_unused]] t8_element_t *elements[])
 {
   return 1;
 }
 
 /** Coarse every family. */
 static int
-t8_adapt_coarse_all ([[maybe_unused]] t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
-                     [[maybe_unused]] t8_locidx_t which_tree, [[maybe_unused]] const t8_eclass_t tree_class,
-                     [[maybe_unused]] t8_locidx_t lelement_id, [[maybe_unused]] const t8_scheme *scheme,
-                     const int is_family, [[maybe_unused]] const int num_elements,
-                     [[maybe_unused]] t8_element_t *elements[])
+t8_adapt_coarse_all ([[maybe_unused]] t8_forest_t forest_from, [[maybe_unused]] t8_locidx_t which_tree,
+                     [[maybe_unused]] const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
+                     [[maybe_unused]] const t8_scheme *scheme, const int is_family,
+                     [[maybe_unused]] const int num_elements, [[maybe_unused]] t8_element_t *elements[])
 {
   if (is_family) {
     return -1;

--- a/test/t8_schemes/t8_gtest_get_linear_id.cxx
+++ b/test/t8_schemes/t8_gtest_get_linear_id.cxx
@@ -59,7 +59,7 @@ class get_linear_id: public testing::TestWithParam<std::tuple<int, t8_eclass_t>>
 };
 
 static int
-t8_test_init_linear_id_refine_everything ([[maybe_unused]] t8_forest_t forest, [[maybe_unused]] t8_forest_t forest_from,
+t8_test_init_linear_id_refine_everything ([[maybe_unused]] t8_forest_t forest_from,
                                           [[maybe_unused]] t8_locidx_t which_tree,
                                           [[maybe_unused]] const t8_eclass_t tree_class,
                                           [[maybe_unused]] t8_locidx_t lelement_id,

--- a/tutorials/features/t8_features_curved_meshes.cxx
+++ b/tutorials/features/t8_features_curved_meshes.cxx
@@ -87,14 +87,14 @@ struct t8_naca_geometry_adapt_data
  * \param [in] elements     The element or family of elements to consider for refinement/coarsening.
  */
 int
-t8_naca_geometry_adapt_callback (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                                 t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
-                                 const t8_scheme *scheme, [[maybe_unused]] const int is_family,
-                                 [[maybe_unused]] const int num_elements, t8_element_t *elements[])
+t8_naca_geometry_adapt_callback (t8_forest_t forest_from, t8_locidx_t which_tree, t8_eclass_t tree_class,
+                                 [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
+                                 [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
+                                 t8_element_t *elements[])
 {
   /* We retrieve the adapt data */
   const struct t8_naca_geometry_adapt_data *adapt_data
-    = (const struct t8_naca_geometry_adapt_data *) t8_forest_get_user_data (forest);
+    = (const struct t8_naca_geometry_adapt_data *) t8_forest_get_user_data (forest_from);
   /* And check if it was retrieved successfully. */
   T8_ASSERT (adapt_data != NULL);
   /* Refine element to the uniform refinement level */
@@ -115,7 +115,7 @@ t8_naca_geometry_adapt_callback (t8_forest_t forest, t8_forest_t forest_from, t8
        * In the 3D case, we look for linked surfaces, but in 2D, we look for linked edges. */
       const int attribute_key = element_dim == 3 ? T8_CMESH_CAD_FACE_ATTRIBUTE_KEY : T8_CMESH_CAD_EDGE_ATTRIBUTE_KEY;
       const int *linked_geometries = (const int *) t8_cmesh_get_attribute (
-        t8_forest_get_cmesh (forest), t8_get_package_id (), attribute_key, cmesh_ltreeid);
+        t8_forest_get_cmesh (forest_from), t8_get_package_id (), attribute_key, cmesh_ltreeid);
       /* If the tree face has a linked surface and it is in the list we refine it */
       for (int igeom = 0; igeom < adapt_data->n_geometries; ++igeom) {
         if (linked_geometries[tree_face] == adapt_data->geometries[igeom]
@@ -231,9 +231,9 @@ struct t8_naca_plane_adapt_data
  * \param [in] elements     The element or family of elements to consider for refinement/coarsening.
  */
 int
-t8_naca_plane_adapt_callback (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                              t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme,
-                              const int is_family, const int num_elements, t8_element_t *elements[])
+t8_naca_plane_adapt_callback (t8_forest_t forest_from, t8_locidx_t which_tree, t8_eclass_t tree_class,
+                              [[maybe_unused]] t8_locidx_t lelement_id, const t8_scheme *scheme, const int is_family,
+                              const int num_elements, t8_element_t *elements[])
 {
   double elem_midpoint[3];
   int elem_level;
@@ -242,7 +242,7 @@ t8_naca_plane_adapt_callback (t8_forest_t forest, t8_forest_t forest_from, t8_lo
   elem_level = scheme->element_get_level (tree_class, elements[0]);
   /* We retrieve the adapt data */
   const struct t8_naca_plane_adapt_data *adapt_data
-    = (const struct t8_naca_plane_adapt_data *) t8_forest_get_user_data (forest);
+    = (const struct t8_naca_plane_adapt_data *) t8_forest_get_user_data (forest_from);
   /* And check if it was retrieved successfully. */
   T8_ASSERT (adapt_data != NULL);
 

--- a/tutorials/general/t8_step3.h
+++ b/tutorials/general/t8_step3.h
@@ -73,7 +73,7 @@ t8_step3_adapt_forest (t8_forest_t forest);
  * See t8_step3.cxx for more details.
  */
 int
-t8_step3_adapt_callback (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree, t8_eclass_t tree_class,
+t8_step3_adapt_callback (t8_forest_t forest_from, t8_locidx_t which_tree, t8_eclass_t tree_class,
                          t8_locidx_t lelement_id, const t8_scheme_c *scheme, const int is_family,
                          const int num_elements, t8_element_t *elements[]);
 

--- a/tutorials/general/t8_step3_adapt_forest.cxx
+++ b/tutorials/general/t8_step3_adapt_forest.cxx
@@ -83,10 +83,9 @@ T8_EXTERN_C_BEGIN ();
  * \param [in] elements     The element or family of elements to consider for refinement/coarsening.
  */
 int
-t8_step3_adapt_callback (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                         [[maybe_unused]] t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
-                         [[maybe_unused]] const t8_scheme *scheme, const int is_family,
-                         [[maybe_unused]] const int num_elements, t8_element_t *elements[])
+t8_step3_adapt_callback (t8_forest_t forest_from, t8_locidx_t which_tree, [[maybe_unused]] t8_eclass_t tree_class,
+                         [[maybe_unused]] t8_locidx_t lelement_id, [[maybe_unused]] const t8_scheme *scheme,
+                         const int is_family, [[maybe_unused]] const int num_elements, t8_element_t *elements[])
 {
   /* Our adaptation criterion is to look at the midpoint coordinates of the current element and if
    * they are inside a sphere around a given midpoint we refine, if they are outside, we coarsen. */
@@ -94,7 +93,8 @@ t8_step3_adapt_callback (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_
   /* In t8_step3_adapt_forest we pass a t8_step3_adapt_data pointer as user data to the
    * t8_forest_new_adapt function. This pointer is stored as the used data of the new forest
    * and we can now access it with t8_forest_get_user_data (forest). */
-  const struct t8_step3_adapt_data *adapt_data = (const struct t8_step3_adapt_data *) t8_forest_get_user_data (forest);
+  const struct t8_step3_adapt_data *adapt_data
+    = (const struct t8_step3_adapt_data *) t8_forest_get_user_data (forest_from);
   double dist; /* Will store the distance of the element's midpoint and the sphere midpoint. */
 
   /* You can use T8_ASSERT for assertions that are active in debug mode (when configured with --enable-debug).

--- a/tutorials/general/t8_step7_interpolation.cxx
+++ b/tutorials/general/t8_step7_interpolation.cxx
@@ -108,10 +108,9 @@ t8_element_get_value (const t8_step7_adapt_data *adapt_data, t8_locidx_t ielemen
  * \param [in] elements     The element or family of elements to consider for refinement/coarsening.
  */
 int
-t8_step7_adapt_callback (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_t which_tree,
-                         [[maybe_unused]] const t8_eclass_t tree_class, [[maybe_unused]] t8_locidx_t lelement_id,
-                         [[maybe_unused]] const t8_scheme *scheme, const int is_family,
-                         [[maybe_unused]] const int num_elements, t8_element_t *elements[])
+t8_step7_adapt_callback (t8_forest_t forest_from, t8_locidx_t which_tree, [[maybe_unused]] const t8_eclass_t tree_class,
+                         [[maybe_unused]] t8_locidx_t lelement_id, [[maybe_unused]] const t8_scheme *scheme,
+                         const int is_family, [[maybe_unused]] const int num_elements, t8_element_t *elements[])
 {
   /* Our adaptation criterion is to look at the midpoint coordinates of the current element and if
    * they are inside a sphere around a given midpoint we refine, if they are outside, we coarsen. */
@@ -119,7 +118,8 @@ t8_step7_adapt_callback (t8_forest_t forest, t8_forest_t forest_from, t8_locidx_
   /* In t8_step3_adapt_forest we pass a t8_step3_adapt_data pointer as user data to the
    * t8_forest_new_adapt function. This pointer is stored as the used data of the new forest
    * and we can now access it with t8_forest_get_user_data (forest). */
-  const struct t8_step7_adapt_data *adapt_data = (const struct t8_step7_adapt_data *) t8_forest_get_user_data (forest);
+  const struct t8_step7_adapt_data *adapt_data
+    = (const struct t8_step7_adapt_data *) t8_forest_get_user_data (forest_from);
   double dist; /* Will store the distance of the element's midpoint and the sphere midpoint. */
 
   /* You can use T8_ASSERT for assertions that are active in debug mode (when configured with --enable-debug).


### PR DESCRIPTION
Closes #1279

**_Describe your changes here:_**

In line with #1279, this PR removes the `forest` argument, i.e., the uncommitted new forest, from the adapt callback arguments.

So far, this is just a draft: While the removal of the argument is already completed, #1279 additionally discussed the option of moderating this breaking change by using C++'s `[[ deprecated ]]` keyword. This is still to be done.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).