### PR TITLE
Feature: element_face_get_ancestor_face function

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.hxx
@@ -339,6 +339,24 @@ class t8_default_scheme_hex: public t8_default_scheme_common<t8_default_scheme_h
   int
   element_face_get_parent_face (const t8_element_t *elem, int face) const;
 
+  /** Given an element and a face of an element as well as an ancestor of the element
+   * that has a face that is an ancestor of the given face, compute the corresponding face number of the ancestor element.
+   * 
+   * \param [in] tree_class    The eclass of the current tree.
+   * \param [in]  elem    An element.
+   * \param [in]  face    Then number of a face of \a element.
+   * \param [in]  ancestor An ancestor of \a element that has a common face with \a face. (Could be \a element itself).
+   * \return              The face number \a f_a corresponding to the face of with \a face is a asubface.
+   *                      <0 on failure.
+   */
+  inline int
+  element_face_get_ancestor_face (const t8_element_t *elem, const int face, const t8_element_t *ancestor) const
+  {
+    // For Hex elements the face number does not change when refining.
+    T8_ASSERT (is_ancestor (ancestor, elem));
+    return face;
+  }
+
   /** Given an element and a face of this element. If the face lies on the
    *  tree boundary, return the face number of the tree face.
    *  If not the return value is arbitrary.

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.hxx
@@ -352,6 +352,27 @@ class t8_default_scheme_line: public t8_default_scheme_common<t8_default_scheme_
   int
   element_face_get_parent_face (const t8_element_t *elem, int face) const;
 
+  /** Given an element and a face of an element as well as an ancestor of the element
+   * that has a face that is an ancestor of the given face, compute the corresponding face number of the ancestor element.
+   * 
+   * \param [in] tree_class    The eclass of the current tree.
+   * \param [in]  elem    An element.
+   * \param [in]  face    Then number of a face of \a element.
+   * \param [in]  ancestor An ancestor of \a element that has a common face with \a face. (Could be \a element itself).
+   * \return              The face number \a f_a corresponding to the face of with \a face is a asubface.
+   *                      <0 on failure.
+   */
+  inline int
+  element_face_get_ancestor_face (const t8_element_t *elem, const int face, const t8_element_t *ancestor) const
+  {
+    // For Line elements the face number does not change when refining.
+    T8_ASSERT (element_is_valid (elem));
+    T8_ASSERT (element_is_valid (ancestor));
+    T8_ASSERT (0 <= face && face < element_get_num_face (elem));
+    T8_ASSERT (is_ancestor (ancestor, elem));
+    return face;
+  }
+
   /** Given an element and a face of this element. If the face lies on the
    *  tree boundary, return the face number of the tree face.
    *  If not the return value is arbitrary.

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.hxx
@@ -331,6 +331,27 @@ class t8_default_scheme_prism: public t8_default_scheme_common<t8_default_scheme
   int
   element_face_get_parent_face (const t8_element_t *elem, int face) const;
 
+  /** Given an element and a face of an element as well as an ancestor of the element
+   * that has a face that is an ancestor of the given face, compute the corresponding face number of the ancestor element.
+   * 
+   * \param [in] tree_class    The eclass of the current tree.
+   * \param [in]  elem    An element.
+   * \param [in]  face    Then number of a face of \a element.
+   * \param [in]  ancestor An ancestor of \a element that has a common face with \a face. (Could be \a element itself).
+   * \return              The face number \a f_a corresponding to the face of with \a face is a asubface.
+   *                      <0 on failure.
+   */
+  inline int
+  element_face_get_ancestor_face (const t8_element_t *elem, const int face, const t8_element_t *ancestor) const
+  {
+    // For Prism elements the face number does not change when refining.
+    T8_ASSERT (element_is_valid (elem));
+    T8_ASSERT (element_is_valid (ancestor));
+    T8_ASSERT (0 <= face && face < element_get_num_face (elem));
+    T8_ASSERT (is_ancestor (ancestor, elem));
+    return face;
+  }
+
   /** Given an element and a face of this element. If the face lies on the
    *  tree boundary, return the face number of the tree face.
    *  If not the return value is arbitrary.

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
@@ -375,6 +375,27 @@ class t8_default_scheme_quad: public t8_default_scheme_common<t8_default_scheme_
   int
   element_face_get_parent_face (const t8_element_t *elem, int face) const;
 
+  /** Given an element and a face of an element as well as an ancestor of the element
+   * that has a face that is an ancestor of the given face, compute the corresponding face number of the ancestor element.
+   * 
+   * \param [in] tree_class    The eclass of the current tree.
+   * \param [in]  elem    An element.
+   * \param [in]  face    Then number of a face of \a element.
+   * \param [in]  ancestor An ancestor of \a element that has a common face with \a face. (Could be \a element itself).
+   * \return              The face number \a f_a corresponding to the face of with \a face is a asubface.
+   *                      <0 on failure.
+   */
+  inline int
+  element_face_get_ancestor_face (const t8_element_t *elem, const int face, const t8_element_t *ancestor) const
+  {
+    // For Quad elements the face number does not change when refining.
+    T8_ASSERT (element_is_valid (elem));
+    T8_ASSERT (element_is_valid (ancestor));
+    T8_ASSERT (0 <= face && face < element_get_num_face (elem));
+    T8_ASSERT (is_ancestor (ancestor, elem));
+    return face;
+  }
+
   /** Given an element and a face of this element. If the face lies on the
    *  tree boundary, return the face number of the tree face.
    *  If not the return value is arbitrary.

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.hxx
@@ -312,6 +312,27 @@ class t8_default_scheme_tri: public t8_default_scheme_common<t8_default_scheme_t
   int
   element_face_get_parent_face (const t8_element_t *elem, int face) const;
 
+  /** Given an element and a face of an element as well as an ancestor of the element
+   * that has a face that is an ancestor of the given face, compute the corresponding face number of the ancestor element.
+   * 
+   * \param [in] tree_class    The eclass of the current tree.
+   * \param [in]  elem    An element.
+   * \param [in]  face    Then number of a face of \a element.
+   * \param [in]  ancestor An ancestor of \a element that has a common face with \a face. (Could be \a element itself).
+   * \return              The face number \a f_a corresponding to the face of with \a face is a asubface.
+   *                      <0 on failure.
+   */
+  inline int
+  element_face_get_ancestor_face (const t8_element_t *elem, const int face, const t8_element_t *ancestor) const
+  {
+    // For Triangle elements the face number does not change when refining.
+    T8_ASSERT (element_is_valid (elem));
+    T8_ASSERT (element_is_valid (ancestor));
+    T8_ASSERT (0 <= face && face < element_get_num_face (elem));
+    T8_ASSERT (is_ancestor (ancestor, elem));
+    return face;
+  }
+
   /** Given an element and a face of this element. If the face lies on the tree boundary, return the face number of 
    * the tree face. If not the return value is arbitrary.
    * \param [in] elem     The element.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.hxx
@@ -357,6 +357,27 @@ class t8_default_scheme_vertex: public t8_default_scheme_common<t8_default_schem
     return 0; /* prevents compiler warning */
   }
 
+  /** Given an element and a face of an element as well as an ancestor of the element
+   * that has a face that is an ancestor of the given face, compute the corresponding face number of the ancestor element.
+   * 
+   * \param [in] tree_class    The eclass of the current tree.
+   * \param [in]  elem    An element.
+   * \param [in]  face    Then number of a face of \a element.
+   * \param [in]  ancestor An ancestor of \a element that has a common face with \a face. (Could be \a element itself).
+   * \return              The face number \a f_a corresponding to the face of with \a face is a asubface.
+   *                      <0 on failure.
+   */
+  inline int
+  element_face_get_ancestor_face (const t8_element_t *elem, const int face, const t8_element_t *ancestor) const
+  {
+    // For vertex elements the face number does not change when refining.
+    T8_ASSERT (element_is_valid (elem));
+    T8_ASSERT (element_is_valid (ancestor));
+    T8_ASSERT (0 <= face && face < element_get_num_face (elem));
+    T8_ASSERT (is_ancestor (ancestor, elem));
+    return face;
+  }
+
   /** Given an element and a face of this element. If the face lies on the
    *  tree boundary, return the face number of the tree face.
    *  If not the return value is arbitrary.

--- a/src/t8_schemes/t8_scheme.hxx
+++ b/src/t8_schemes/t8_scheme.hxx
@@ -613,6 +613,24 @@ class t8_scheme {
                        eclass_schemes[tree_class]);
   };
 
+  /** Given an element and a face of an element as well as an ancestor of the element
+   * that has a face that is an ancestor of the given face, compute the corresponding face number of the ancestor element.
+   * 
+   * \param [in] tree_class    The eclass of the current tree.
+   * \param [in]  elem    An element.
+   * \param [in]  face    Then number of a face of \a element.
+   * \param [in]  ancestor An ancestor of \a element that has a common face with \a face. (Could be \a element itself).
+   * \return              The face number \a f_a corresponding to the face of with \a face is a asubface.
+   *                      <0 on failure.
+   */
+  inline int
+  element_face_get_ancestor_face (const t8_eclass_t tree_class, const t8_element_t *elem, const int face,
+                                  const t8_element_t *ancestor) const
+  {
+    return std::visit ([&] (auto &&scheme) { return scheme.element_face_get_ancestor_face (elem, face, ancestor); },
+                       eclass_schemes[tree_class]);
+  };
+
   /** Given an element and a face of this element. If the face lies on the
    * tree boundary, return the face number of the tree face.
    * If not the return value is arbitrary.


### PR DESCRIPTION
Closes #1738 currently stil WIP but i already started working on it.

**_Describe your changes here:_**
Started a new element_face_get_ancestor_face scheme function.

Given an element and a face of an element as well as an ancestor of the element
that has a face that is an ancestor of the given face, compute the corresponding face number of the ancestor element.

Added first implementations.
For vertex, quad, tri, hex, prism the face numbers do not change across the refinement history.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).