### PR TITLE
Bugfix: local search

### DIFF
--- a/src/t8_forest/t8_forest_search/t8_forest_search.cxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.cxx
@@ -99,8 +99,8 @@ t8_search_base::search_recursion (const t8_locidx_t ltreeid, t8_element_t *eleme
        * we construct an array of these leaves */
       t8_element_array_init_view (&child_leaves, leaf_elements, indexa, indexb - indexa);
       /* Enter the recursion */
-      search_recursion (ltreeid, children[ichild], ts, &child_leaves, indexa + tree_lindex_of_first_leaf);
       update_queries (new_active_queries);
+      search_recursion (ltreeid, children[ichild], ts, &child_leaves, indexa + tree_lindex_of_first_leaf);
     }
   }
 

--- a/src/t8_forest/t8_forest_search/t8_forest_search.cxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.cxx
@@ -138,6 +138,7 @@ t8_search_base::do_search ()
   T8_ASSERT (t8_forest_is_committed (forest));
   const t8_locidx_t num_local_trees = t8_forest_get_num_local_trees (this->forest);
   for (t8_locidx_t itree = 0; itree < num_local_trees; itree++) {
+    this->init_queries ();
     this->search_tree (itree);
   }
 }

--- a/src/t8_forest/t8_forest_search/t8_forest_search.hxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.hxx
@@ -425,14 +425,11 @@ class t8_search_with_queries: public t8_search<Udata> {
   {
     T8_ASSERT (new_active_queries.empty ());
     if (!this->active_queries.empty ()) {
-      auto positive_queries = this->active_queries | std::ranges::views::filter ([&] (size_t &query_index) {
-                                return this->queries_callback (this->forest, ltreeid, element, is_leaf, leaf_elements,
-                                                               tree_leaf_index, queries[query_index], this->user_data);
-                              });
-      if (!is_leaf) {
-        new_active_queries.assign (positive_queries.begin (), positive_queries.end ());
-        std::swap (this->active_queries, new_active_queries);
-      }
+      std::copy_if (this->active_queries.begin (), this->active_queries.end (), std::back_inserter (new_active_queries),
+                    [&] (size_t &query_index) {
+                      return this->queries_callback (this->forest, ltreeid, element, is_leaf, leaf_elements,
+                                                     tree_leaf_index, queries[query_index], this->user_data);
+                    });
     }
   }
 
@@ -499,14 +496,9 @@ class t8_search_with_batched_queries: public t8_search<Udata> {
       std::vector<bool> query_matches (this->queries.size ());
       this->queries_callback (this->forest, ltreeid, element, is_leaf, leaf_elements, tree_leaf_index, this->queries,
                               this->active_queries, query_matches, this->user_data);
-      if (!is_leaf) {
-        auto positive_queries = this->active_queries | std::ranges::views::filter ([&] (size_t &query_index) {
-                                  return query_matches[query_index];
-                                });
-        new_active_queries.assign (positive_queries.begin (), positive_queries.end ());
-      }
+      std::copy_if (this->active_queries.begin (), this->active_queries.end (), std::back_inserter (new_active_queries),
+                    [&] (size_t &query_index) { return query_matches[query_index]; });
     }
-    std::swap (new_active_queries, this->active_queries);
   }
 
   void

--- a/src/t8_forest/t8_forest_search/t8_forest_search.hxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.hxx
@@ -308,6 +308,10 @@ class t8_search_base {
   virtual void
   update_queries (std::vector<size_t> &old_query_indices)
     = 0;
+
+  virtual void
+  init_queries ()
+    = 0;
 };
 
 template <typename Udata = void>
@@ -370,6 +374,12 @@ class t8_search: public t8_search_base {
     return;
   }
 
+  void
+  init_queries () override
+  {
+    return;
+  }
+
   t8_search_element_callback<Udata> element_callback;
 };
 
@@ -389,8 +399,6 @@ class t8_search_with_queries: public t8_search<Udata> {
                           const t8_forest_t forest = nullptr, Udata *user_data = nullptr)
     : t8_search<Udata> (element_callback, forest, user_data), queries_callback (queries_callback), queries (queries)
   {
-    this->active_queries.resize (queries.size ());
-    std::iota (this->active_queries.begin (), this->active_queries.end (), 0);
   }
 
   void
@@ -434,6 +442,13 @@ class t8_search_with_queries: public t8_search<Udata> {
     this->active_queries = old_query_indices;
   }
 
+  void
+  init_queries () override
+  {
+    this->active_queries.resize (this->queries.size ());
+    std::iota (this->active_queries.begin (), this->active_queries.end (), 0);
+  }
+
   t8_search_query_callback<Query_T, Udata> queries_callback;
   std::vector<Query_T> &queries;
   std::vector<size_t> active_queries;
@@ -458,8 +473,6 @@ class t8_search_with_batched_queries: public t8_search<Udata> {
                                   Udata *user_data = nullptr)
     : t8_search<Udata> (element_callback, forest, user_data), queries_callback (queries_callback), queries (queries)
   {
-    this->active_queries.resize (queries.size ());
-    std::iota (this->active_queries.begin (), this->active_queries.end (), 0);
   }
 
   void
@@ -500,6 +513,13 @@ class t8_search_with_batched_queries: public t8_search<Udata> {
   update_queries (std::vector<size_t> &old_query_indices) override
   {
     this->active_queries = old_query_indices;
+  }
+
+  void
+  init_queries () override
+  {
+    this->active_queries.resize (this->queries.size ());
+    std::iota (this->active_queries.begin (), this->active_queries.end (), 0);
   }
 
   t8_search_batched_queries_callback<Query_T, Udata> queries_callback;

--- a/src/t8_forest/t8_forest_search/t8_forest_search.hxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.hxx
@@ -310,7 +310,7 @@ class t8_search_base {
     = 0;
 
   /**
-   * @brief Function gives the user the opportunity to set the queries to the initial
+   * Function gives the user the opportunity to set the queries to the initial
    *        full set before searching each tree.
    *
    */

--- a/src/t8_forest/t8_forest_search/t8_forest_search.hxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.hxx
@@ -309,6 +309,11 @@ class t8_search_base {
   update_queries (std::vector<size_t> &old_query_indices)
     = 0;
 
+  /**
+   * @brief Function gives the user the opportunity to set the queries to the initial
+   *        full set before searching each tree.
+   *
+   */
   virtual void
   init_queries ()
     = 0;

--- a/src/t8_forest/t8_forest_search/t8_forest_search.hxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.hxx
@@ -483,7 +483,7 @@ class t8_search_with_batched_queries: public t8_search<Udata> {
   {
     T8_ASSERT (new_active_queries.empty ());
     if (!this->active_queries.empty ()) {
-      std::vector<bool> query_matches (this->active_queries.size ());
+      std::vector<bool> query_matches (this->queries.size ());
       this->queries_callback (this->forest, ltreeid, element, is_leaf, leaf_elements, tree_leaf_index, this->queries,
                               this->active_queries, query_matches, this->user_data);
       if (!is_leaf) {

--- a/src/t8_forest/t8_forest_search/t8_forest_search.hxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.hxx
@@ -145,7 +145,7 @@ using t8_partition_search_element_callback
  */
 template <typename Query_T, typename Udata = void>
 using t8_partition_search_query_callback
-  = std::function<void (const t8_forest_t forest, const t8_locidx_t ltreeid, const t8_element_t *element,
+  = std::function<bool (const t8_forest_t forest, const t8_locidx_t ltreeid, const t8_element_t *element,
                         const int pfirst, const int plast, const Query_T &query, Udata *user_data)>;
 
 /**

--- a/src/t8_forest/t8_forest_search/t8_forest_search.hxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.hxx
@@ -431,7 +431,7 @@ class t8_search_with_queries: public t8_search<Udata> {
   void
   update_queries (std::vector<size_t> &old_query_indices) override
   {
-    std::swap (this->active_queries, old_query_indices);
+    this->active_queries = old_query_indices;
   }
 
   t8_search_query_callback<Query_T, Udata> queries_callback;
@@ -499,7 +499,7 @@ class t8_search_with_batched_queries: public t8_search<Udata> {
   void
   update_queries (std::vector<size_t> &old_query_indices) override
   {
-    std::swap (this->active_queries, old_query_indices);
+    this->active_queries = old_query_indices;
   }
 
   t8_search_batched_queries_callback<Query_T, Udata> queries_callback;


### PR DESCRIPTION
This PR addresses some issues that I encountered while using the local search.
- In `check_queries` the query callback is called inside a `std::ranges::views::filter` used later to define the array `new_active_queries` based on the return value of the callback. On leaf level `new_active_queries` is not computed and due to lazy evaluation, the query callback is not executed on leaf level either. Furthermore, the assignment
`new_active_queries.assign (positive_queries.begin (), positive_queries.end ());`
leads to the same callback being evaluated twice for some indices. This PR replaces the evaluation by a copy_if, which seems to work fine, evaluating every callback exactly once.
- In `update_queries` and `check_queries` the active_queries array is swapped with the new_active_queries array. Since update queries is called after every recursion, this leads to the recursion being entered with the actual new_active_queries array and the old active_queries array in alternating order for the children. This PR replaces the swap with an assignment and moves update_queries before the first recursion.
- This PR proposes a `init_queries` function, that can be called once before every tree recursion to reset the queries to their original state.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).