### PR TITLE
Bugfix: Overflowing datatype in test

### DIFF
--- a/test/t8_schemes/t8_gtest_get_linear_id.cxx
+++ b/test/t8_schemes/t8_gtest_get_linear_id.cxx
@@ -96,13 +96,14 @@ TEST_P (get_linear_id, uniform_forest)
       /*Get the number of elements in the tree*/
       const t8_locidx_t num_elements_in_tree = t8_forest_get_tree_num_leaf_elements (forest, tree_id);
       /*Manually compute the id of the first element*/
-      const t8_locidx_t shift = tc_scheme->count_leaves_from_root (eclass, level) - num_elements_in_tree;
+      const t8_linearidx_t shift = tc_scheme->count_leaves_from_root (eclass, level) - num_elements_in_tree;
       /*Iterate over elements */
-      for (t8_locidx_t id_iter = 0; id_iter < num_elements_in_tree; id_iter++) {
+      for (t8_linearidx_t id_iter = 0; id_iter < (t8_linearidx_t) num_elements_in_tree; id_iter++) {
         /*Get the current element*/
         const t8_element_t *element = t8_forest_get_leaf_element_in_tree (forest, tree_id, id_iter);
         /*Get the ID of the element at current level */
-        const t8_locidx_t id = tc_scheme->element_get_linear_id (eclass, element, level);
+        const t8_element_level elem_level = tc_scheme->element_get_level (eclass, element);
+        const t8_linearidx_t id = tc_scheme->element_get_linear_id (eclass, element, elem_level);
         /* Check the computed id*/
         EXPECT_EQ (id, id_iter + shift);
       }
@@ -118,7 +119,7 @@ TEST_P (get_linear_id, uniform_forest)
   t8_forest_unref (&forest_adapt);
 }
 
-/* Test, if the linear_id of descendants of an element is the same as the id of element 
+/* Test, if the linear_id of descendants of an element is the same as the id of element
  * (on the level defined by the element) */
 TEST_P (get_linear_id, id_at_other_level)
 {
@@ -141,7 +142,7 @@ TEST_P (get_linear_id, id_at_other_level)
       const t8_linearidx_t child_desc = scheme->element_count_leaves (eclass, child, level + add_lvl);
       /* Iterate over all descendants */
       for (t8_linearidx_t leaf_id = 0; leaf_id < child_desc; leaf_id++) {
-        /* Set the descendant (test) at level of the descendants and shift the 
+        /* Set the descendant (test) at level of the descendants and shift the
          * leaf_id into the region of the descendants of child*/
         scheme->element_set_linear_id (eclass, test, level + add_lvl, id_at_lvl + leaf_id);
         /* Compute the id of the descendant (test) at the current level */

--- a/test/t8_schemes/t8_gtest_get_linear_id.cxx
+++ b/test/t8_schemes/t8_gtest_get_linear_id.cxx
@@ -98,14 +98,14 @@ TEST_P (get_linear_id, uniform_forest)
       /*Manually compute the id of the first element*/
       const t8_linearidx_t shift = tc_scheme->count_leaves_from_root (eclass, level) - num_elements_in_tree;
       /*Iterate over elements */
-      for (t8_linearidx_t id_iter = 0; id_iter < (t8_linearidx_t) num_elements_in_tree; id_iter++) {
+      for (t8_locidx_t id_iter = 0; id_iter < num_elements_in_tree; id_iter++) {
         /*Get the current element*/
         const t8_element_t *element = t8_forest_get_leaf_element_in_tree (forest, tree_id, id_iter);
         /*Get the ID of the element at current level */
         const t8_element_level elem_level = tc_scheme->element_get_level (eclass, element);
         const t8_linearidx_t id = tc_scheme->element_get_linear_id (eclass, element, elem_level);
         /* Check the computed id*/
-        EXPECT_EQ (id, id_iter + shift);
+        EXPECT_EQ (id, static_cast<t8_linearidx_t> (id_iter) + shift);
       }
     }
     /* Construct the uniformly refined forest of the next level */


### PR DESCRIPTION
Closes #1770

**_Describe your changes here:_**
The linear id test used a `t8_locidx_t` to store linear ids and this of course overflows under specific circumstances.
Furthermore, the test now uses the actual element level for retrieving ids. Normally, this makes no difference, but in the multilevel scheme it does.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).