### PR TITLE
Fix some weird compiler errors

### DIFF
--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -175,6 +175,73 @@ struct t8_msh_file_node
   {
   }
 
+  /**
+   * Copy constructor
+   * \param [in] other The node to copy.
+   */
+  t8_msh_file_node (const t8_msh_file_node &other)
+    : parameters (other.parameters), coordinates (other.coordinates), index (other.index),
+      parametric (other.parametric), entity_dim (other.entity_dim), entity_tag (other.entity_tag)
+  {
+  }
+
+  /**
+   * Move constructor.
+   * \param [in] other The node to move.
+   */
+  t8_msh_file_node (t8_msh_file_node &&other) noexcept
+    : parameters (std::move (other.parameters)), coordinates (std::move (other.coordinates)), index (other.index),
+      parametric (other.parametric), entity_dim (other.entity_dim), entity_tag (other.entity_tag)
+  {
+    other.index = -1;
+    other.parametric = false;
+    other.entity_dim = -1;
+    other.entity_tag = -1;
+  }
+
+  /**
+   * Copy assignment operator.
+   * \param [in] other The node to copy.
+   * \return           Reference to this node.
+   */
+  t8_msh_file_node &
+  operator= (const t8_msh_file_node &other)
+  {
+    if (this != &other) {
+      parameters = other.parameters;
+      coordinates = other.coordinates;
+      index = other.index;
+      parametric = other.parametric;
+      entity_dim = other.entity_dim;
+      entity_tag = other.entity_tag;
+    }
+    return *this;
+  }
+
+  /**
+   * Move assignment operator.
+   * \param [in] other The node to move.
+   * \return           Reference to this node.
+   */
+  t8_msh_file_node &
+  operator= (t8_msh_file_node &&other) noexcept
+  {
+    if (this != &other) {
+      parameters = std::move (other.parameters);
+      coordinates = std::move (other.coordinates);
+      index = other.index;
+      parametric = other.parametric;
+      entity_dim = other.entity_dim;
+      entity_tag = other.entity_tag;
+
+      other.index = -1;
+      other.parametric = false;
+      other.entity_dim = -1;
+      other.entity_tag = -1;
+    }
+    return *this;
+  }
+
   std::array<double, 2> parameters;  /**< Parameters of the node in the parametric space, if applicable.
                                            * For example, for a point on a curve, this would be the parameter on the curve. */
   std::array<double, 3> coordinates; /**< Coordinates of the node in physical space. */
@@ -899,7 +966,8 @@ t8_cmesh_msh_file_4_read_eles (t8_cmesh_t cmesh, FILE *fp, const t8_msh_node_tab
   t8_eclass_t eclass;
   t8_msh_file_node Node;
 #if T8_ENABLE_OCC
-  t8_msh_file_node face_nodes[T8_ECLASS_MAX_CORNERS_2D], edge_nodes[2];
+  std::array<t8_msh_file_node, T8_ECLASS_MAX_CORNERS_2D> face_nodes;
+  std::array<t8_msh_file_node, 2> edge_nodes;
 #endif /* T8_ENABLE_OCC */
   long lnum_trees, lnum_blocks, entity_tag;
   int retval;

--- a/src/t8_vtk/t8_vtk_write_ASCII.cxx
+++ b/src/t8_vtk/t8_vtk_write_ASCII.cxx
@@ -768,7 +768,7 @@ t8_forest_vtk_write_points (t8_forest_t forest, FILE *vtufile, const int write_g
 
         if (sreturn >= BUFSIZ) {
           /* The output was truncated */
-          /* Note: gcc >= 7.1 prints a warning if we 
+          /* Note: gcc >= 7.1 prints a warning if we
            * do not check the return value of snprintf. */
           t8_debugf ("Warning: Truncated vtk point data description to '%s'\n", description);
         }
@@ -943,7 +943,7 @@ t8_cmesh_vtk_write_file_ext (const t8_cmesh_t cmesh, const char *fileprefix, con
   T8_ASSERT (t8_cmesh_is_committed (cmesh));
   T8_ASSERT (fileprefix != NULL);
 
-  /* Constants used as return values in order 
+  /* Constants used as return values in order
    * to have more readable code. */
   constexpr int write_successful = 1;
   constexpr int write_failure = 0;
@@ -983,7 +983,6 @@ t8_cmesh_vtk_write_file_ext (const t8_cmesh_t cmesh, const char *fileprefix, con
     vtufile = fopen (vtufilename, "wb");
     if (vtufile == NULL) {
       t8_global_errorf ("Could not open file %s for output.\n", vtufilename);
-      fclose (vtufile);
       return write_failure;
     }
     fprintf (vtufile, "<?xml version=\"1.0\"?>\n");


### PR DESCRIPTION
Closes #1790

**_Describe your changes here:_**
From one day to the other I had some weird compiler errors which prevented me from building t8code.
For one I had to implement copy and move constructors/assignment operators and I do not know why.
The other error complained, that we want to close a file which is NULL, which made sense. But I do not know why this never came up before.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).