### PR TITLE
Fix: OpenMPI linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,26 +191,19 @@ else()
 
     if(MPI_HEADER_FOUND)
         # Create a temporary C++ source file to check for OpenMPI-specific macros
-        file(WRITE ${CMAKE_BINARY_DIR}/test_mpi.cpp "
+        include(CheckCXXSourceCompiles)
+        check_cxx_source_compiles("
         #include <mpi.h>
         #ifndef OPEN_MPI
         #error 'Not OpenMPI'
         #endif
-        int main() { return 0; }")
+        int main() { return 0; }" HAS_OPENMPI)
 
-        # Try compiling the test
-        try_compile(HAS_OPENMPI
-                    ${CMAKE_BINARY_DIR}
-                    ${CMAKE_BINARY_DIR}/test_mpi.cpp
-                    OUTPUT_VARIABLE _OUTPUT)
         if(HAS_OPENMPI)
             message(STATUS "OpenMPI detected via mpi.h")
             # Suppress warning
             target_compile_options(SC::SC INTERFACE -Wno-error=cast-function-type)
         endif()
-
-        # Clean up temporary test file
-        file(REMOVE ${CMAKE_BINARY_DIR}/test_mpi.cpp)
     else()
         message(WARNING "mpi.h not found!")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ elseif(T8CODE_TEST_LEVEL STREQUAL "T8_TEST_LEVEL_MEDIUM" )
     set(T8_TEST_LEVEL_INT 1)
 elseif(T8CODE_TEST_LEVEL STREQUAL "T8_TEST_LEVEL_FULL" )
     set(T8_TEST_LEVEL_INT 0)
-else() 
+else()
     message( FATAL_ERROR "Invalid string for T8CODE_TEST_LEVEL: ${T8CODE_TEST_LEVEL}. Valid options are T8_TEST_LEVEL_FULL, T8_TEST_LEVEL_MEDIUM, or T8_TEST_LEVEL_BASIC.")
 endif()
 
@@ -163,6 +163,7 @@ else()
     # Capture the list of variables before adding the subdirectory to mark the added ones as advanced.
     get_cmake_property(_vars_before_sc VARIABLES )
     add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/sc )
+    add_library(SC INTERFACE)
     # Capture the list of variables after adding the subdirectory
     get_cmake_property(_vars_after_sc VARIABLES )
     # Compute the difference (new variables added by the subdirectory)
@@ -175,6 +176,44 @@ else()
 
     # Mark the new variables as advanced
     mark_as_advanced( FORCE ${_new_sc_vars} )
+
+    ########################## Fix for OpenMPI ############################################
+    # OpenMPI sometimes has a mismatch between their C and CXX interface which produces a warning in SC.
+    # The warning makes t8codes build fail when Werror is activated. This fix checks if t8code
+    # is linked against OpenMPI and then suppresses this warning.
+    # We compile a test program mich checks if a OpenMPI specific macro is defined and then apply the fix.
+
+    include(CheckIncludeFile)
+
+    # Check if mpi.h is available
+    check_include_file("mpi.h" MPI_HEADER_FOUND)
+
+    if(MPI_HEADER_FOUND)
+        # Create a temporary C++ source file to check for OpenMPI-specific macros
+        file(WRITE ${CMAKE_BINARY_DIR}/test_mpi.cpp "
+        #include <mpi.h>
+        #ifndef OPEN_MPI
+        #error 'Not OpenMPI'
+        #endif
+        int main() { return 0; }")
+
+        # Try compiling the test
+        try_compile(HAS_OPENMPI
+                    ${CMAKE_BINARY_DIR}
+                    ${CMAKE_BINARY_DIR}/test_mpi.cpp
+                    OUTPUT_VARIABLE _OUTPUT)
+        if(HAS_OPENMPI)
+            message(STATUS "OpenMPI detected via mpi.h")
+            # Suppress warning
+            target_compile_options(SC::SC INTERFACE -Wno-error=cast-function-type)
+        endif()
+
+        # Clean up temporary test file
+        file(REMOVE ${CMAKE_BINARY_DIR}/test_mpi.cpp)
+    else()
+        message(WARNING "mpi.h not found!")
+    endif()
+    ########################## End of fix for OpenMPI ############################################
 endif()
 
 if ( T8CODE_USE_SYSTEM_P4EST )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,8 @@ else()
     ########################## Fix for OpenMPI ############################################
     # OpenMPI sometimes has a mismatch between their C and CXX interface which produces a warning in SC.
     # The warning makes t8codes build fail when Werror is activated. This fix checks if t8code
-    # is linked against OpenMPI and then suppresses this warning.
+    # is linked against OpenMPI and then suppresses that Werror treats this warning as error.
+    # The warning is still displayed while compiling.
     # We compile a test program mich checks if a OpenMPI specific macro is defined and then apply the fix.
 
     include(CheckIncludeFile)


### PR DESCRIPTION
Closes #1795

**_Describe your changes here:_**
I have the problem, that I have to build t8code with OpenMPI .
This works as long as I link to a self-build SC, because the arising warnings are within SC and Werror of t8code does not trigger.
But when I try to build t8code with the shipped SC, the warnings are part of t8code and Werror will kick in.
Therefore, i implemented a check which determines if OpenMPI was used and then suppresses that the warning for SC (not for t8code) is treated as an error.
The code builds an example program which checks if [this macro](https://github.com/open-mpi/ompi/blob/6a2c60aa00ef084a86955eb88e716635353500e5/ompi/include/mpi.h.in#L254-L257) was defined.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).