### PR TITLE
Improvement: Reduce vertex maxlevel and document it

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
@@ -313,9 +313,9 @@ int
 t8_default_scheme_vertex::element_is_valid ([[maybe_unused]] const t8_element_t *elem)
 
 {
-  /* A vertex is always valid, since it only saves the level as uint8, 
-     which therefore automatically is >= 0 and <= 255 (=MAXLEVEL)*/
-  return 1;
+  /* Check maxlevel, nothing else is saved in a vertex. */
+  const t8_dvertex_t *vertex = (t8_dvertex_t *) elem;
+  return vertex->level <= T8_DVERTEX_MAXLEVEL;
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex.h
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex.h
@@ -41,8 +41,13 @@
 /** The length of a vertex root tree */
 #define T8_DVERTEX_ROOT_LEN 0
 
-/** The maximum refinement level allowed for a vertex. */
-#define T8_DVERTEX_MAXLEVEL 255
+/** The maximum refinement level allowed for a vertex.
+ * The max level is lower than 255 so that we can use \ref t8_element_level (uint8_t)
+ * to iterate to maxlevel:
+ * for (t8_element_level level = 0; level <= T8_DVERTEX_MAXLEVEL; ++level)
+ * Otherwise, t8_element_level would overflow after 255 and we would have an infinite loop.
+*/
+#define T8_DVERTEX_MAXLEVEL 254
 
 typedef struct t8_dvertex
 {

--- a/src/t8_schemes/t8_standalone/t8_standalone_elements.hxx
+++ b/src/t8_schemes/t8_standalone/t8_standalone_elements.hxx
@@ -29,12 +29,30 @@
 
 #define t8_standalone_element t8_standalone
 
+/** Dimension of the standalone element types */
 constexpr uint8_t T8_ELEMENT_DIM[T8_ECLASS_COUNT] = { 0, 1, 2, 2, 3, 3, 3, 3 };
-constexpr uint8_t T8_ELEMENT_MAXLEVEL[T8_ECLASS_COUNT] = { 255, 30, 30, 29, 21, 21, 21, 18 };
+
+/** Maximum level of the standalone element types
+ * \note The maxlevel is lower than 255 so that we can use \ref t8_element_level (uint8_t)
+ * to iterate to maxlevel:
+ * for (t8_element_level level = 0; level <= T8_ELEMENT_MAXLEVEL[T8_ECLASS_VERTEX]; ++level)
+ * Otherwise, t8_element_level would overflow after 255 and we would have an infinite loop.
+*/
+constexpr uint8_t T8_ELEMENT_MAXLEVEL[T8_ECLASS_COUNT] = { 254, 30, 30, 29, 21, 21, 21, 18 };
+
+/** Maximum number of faces of the standalone element types */
 constexpr uint8_t T8_ELEMENT_MAX_NUM_FACES[T8_ECLASS_COUNT] = { 1, 2, 4, 3, 6, 4, 5, 5 };
+
+/** Number of children of the standalone element types */
 constexpr uint8_t T8_ELEMENT_NUM_CHILDREN[T8_ECLASS_COUNT] = { 1, 2, 4, 4, 8, 8, 8, 10 };
+
+/** Number of corners (vertices) of the standalone element types */
 constexpr uint8_t T8_ELEMENT_NUM_CORNERS[T8_ECLASS_COUNT] = { 1, 2, 4, 3, 8, 4, 6, 5 };
+
+/** Actual number of faces of the standalone element types */
 constexpr uint8_t T8_ELEMENT_NUM_FACES[T8_ECLASS_COUNT] = { 0, 2, 4, 3, 6, 4, 5, 5 };
+
+/** Number of facechildren of the standalone element types */
 constexpr uint8_t T8_ELEMENT_MAX_NUM_FACECHILDREN[T8_ECLASS_COUNT] = { 0, 1, 2, 2, 4, 4, 4, 4 };
 
 constexpr uint8_t T8_ELEMENT_NUM_EQUATIONS[T8_ECLASS_COUNT] = { 0, 0, 0, 1, 0, 3, 1, 2 };


### PR DESCRIPTION
**_Describe your changes here:_**
I had the problem that I wanted to iterate to maxlevel using `t8_element_level` and got stuck because of an overflowing uint8_t.
When doing
```cxx
for (t8_element_level level = 0; level <= T8_DVERTEX_MAXLEVEL; ++level)
{
  do_something();
}
```
you get an infinite loop and your program won't respond and you need one day to find out why. Also, nobody needs a level 255 vertex anyway.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).