### PR TITLE
Improvement: Outsource cad utility function

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,7 +120,6 @@ if( T8CODE_ENABLE_OCC )
       t8_geometry/t8_geometry_implementations/t8_geometry_cad.hxx
       t8_geometry/t8_geometry_implementations/t8_geometry_cad.h
       t8_data/t8_cad.hxx
-      t8_data/t8_cad.h
       DESTINATION include
     )
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,7 @@ if( T8CODE_ENABLE_OCC )
     target_link_libraries( T8 PUBLIC ${OpenCASCADE_LIBRARIES} )
     target_sources(T8 PRIVATE 
       t8_geometry/t8_geometry_implementations/t8_geometry_cad.cxx
+      t8_data/t8_cad.cxx
     )
     install( FILES 
       t8_geometry/t8_geometry_implementations/t8_geometry_cad.hxx
@@ -173,8 +174,7 @@ target_sources( T8 PRIVATE
     t8_cmesh/t8_cmesh_vertex_connectivity/t8_cmesh_vertex_conn_tree_to_vertex.cxx 
     t8_cmesh/t8_cmesh_vertex_connectivity/t8_cmesh_vertex_conn_vertex_to_tree.cxx 
     t8_cmesh/t8_cmesh_vertex_connectivity/t8_cmesh_vertex_connectivity.cxx 
-    t8_cmesh/t8_cmesh_readmshfile.cxx 
-    t8_data/t8_cad.cxx
+    t8_cmesh/t8_cmesh_readmshfile.cxx
     t8_data/t8_shmem.c 
     t8_data/t8_containers.cxx 
     t8_forest/t8_forest_adapt.cxx 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -172,6 +172,7 @@ target_sources( T8 PRIVATE
     t8_cmesh/t8_cmesh_vertex_connectivity/t8_cmesh_vertex_conn_vertex_to_tree.cxx 
     t8_cmesh/t8_cmesh_vertex_connectivity/t8_cmesh_vertex_connectivity.cxx 
     t8_cmesh/t8_cmesh_readmshfile.cxx 
+    t8_data/t8_cad.cxx
     t8_data/t8_shmem.c 
     t8_data/t8_containers.cxx 
     t8_forest/t8_forest_adapt.cxx 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,6 +118,8 @@ if( T8CODE_ENABLE_OCC )
     install( FILES 
       t8_geometry/t8_geometry_implementations/t8_geometry_cad.hxx
       t8_geometry/t8_geometry_implementations/t8_geometry_cad.h
+      t8_data/t8_cad.hxx
+      t8_data/t8_cad.h
       DESTINATION include
     )
 endif()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,6 +44,7 @@ libt8_installed_headers_cmesh = \
   src/t8_cmesh/t8_cmesh_types.h \
   src/t8_cmesh/t8_cmesh_stash.h
 libt8_installed_headers_data = \
+  src/t8_data/t8_cad.hxx
   src/t8_data/t8_shmem.h src/t8_data/t8_containers.h \
   src/t8_data/t8_data_handler.hxx \
   src/t8_data/t8_element_array_iterator.hxx

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -48,14 +48,14 @@
 const t8_eclass_t t8_msh_tree_type_to_eclass[T8_NUM_GMSH_ELEM_CLASSES + 1] = {
   T8_ECLASS_COUNT,     /* 0 is not valid */
   T8_ECLASS_LINE,      /* 1 */
-  T8_ECLASS_TRIANGLE, 
-  T8_ECLASS_QUAD, 
-  T8_ECLASS_TET, 
+  T8_ECLASS_TRIANGLE,
+  T8_ECLASS_QUAD,
+  T8_ECLASS_TET,
   T8_ECLASS_HEX,        /* 5 */
-  T8_ECLASS_PRISM, 
+  T8_ECLASS_PRISM,
   T8_ECLASS_PYRAMID,    /* 7 This is the last first order tree type, except the Point, which is type 15 */
   /* We do not support type 8 to 14 */
-  T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, 
+  T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT,
   T8_ECLASS_COUNT, T8_ECLASS_COUNT, T8_ECLASS_COUNT,
   T8_ECLASS_VERTEX      /* 15 */
 };
@@ -625,12 +625,12 @@ t8_msh_file_4_read_nodes (FILE *fp)
 
 /**
  * Adds the elements of \a fp and dimension \a dim into the \a cmesh.
- * Returns a list of all vertex indices of each tree. 
+ * Returns a list of all vertex indices of each tree.
  * \param [in, out] cmesh     The cmesh.
  * \param [in, out] fp        The msh file.
  * \param [in, out] vertices  A hashtable filled with the nodes of the msh file.
  * \param [in, out] dim       The dimension of nodes to read in.
- * \return 
+ * \return
  */
 static std::optional<t8_msh_tree_vertex_indices>
 t8_cmesh_msh_file_2_read_eles (t8_cmesh_t cmesh, FILE *fp, const t8_msh_node_table vertices, const int dim)
@@ -854,20 +854,20 @@ t8_cmesh_msh_file_2_read_eles (t8_cmesh_t cmesh, FILE *fp, const t8_msh_node_tab
  */
 static void
 t8_cmesh_correct_parameters_on_closed_geometry (const int geometry_dim, const int geometry_index,
-                                                const int num_face_nodes, const t8_geometry_cad_c *geometry_cad,
+                                                const int num_face_nodes, const t8_geometry_cad *geometry_cad,
                                                 double *parameters)
 {
   switch (geometry_dim) {
     /* Check for closed U parameter in case of an edge. */
   case 1:
     /* Only correct the U parameter if the edge is closed. */
-    if (geometry_cad->t8_geom_is_edge_closed (geometry_index)) {
-      /* Get the parametric bounds of the closed geometry 
+    if (geometry_cad->get_cad_manager ()->t8_geom_is_edge_closed (geometry_index)) {
+      /* Get the parametric bounds of the closed geometry
        * edge    -> [Umin, Umax]
        */
       double parametric_bounds[2];
       /* Get the parametric edge bounds. */
-      geometry_cad->t8_geom_get_edge_parametric_bounds (geometry_index, parametric_bounds);
+      geometry_cad->get_cad_manager ()->t8_geom_get_edge_parametric_bounds (geometry_index, parametric_bounds);
       /* Check the upper an the lower parametric bound. */
       for (int bound = 0; bound < 2; ++bound) {
         /* Iterate over both nodes of the edge. */
@@ -899,12 +899,12 @@ t8_cmesh_correct_parameters_on_closed_geometry (const int geometry_dim, const in
     /* Iterate over both parameters. 0 stands for the U parameter an 1 for the V parameter. */
     for (int param_dim = 0; param_dim < 2; ++param_dim) {
       /* Only correct the surface parameters if they are closed */
-      if (geometry_cad->t8_geom_is_surface_closed (geometry_index, param_dim)) {
+      if (geometry_cad->get_cad_manager ()->t8_geom_is_surface_closed (geometry_index, param_dim)) {
         /* Get the parametric bounds of the closed geometry
          * surface -> [Umin, Umax, Vmin, Vmax]
          */
         double parametric_bounds[4];
-        geometry_cad->t8_geom_get_face_parametric_bounds (geometry_index, parametric_bounds);
+        geometry_cad->get_cad_manager ()->t8_geom_get_face_parametric_bounds (geometry_index, parametric_bounds);
         /* Check the upper an the lower parametric bound. */
         for (int bound = 0; bound < 2; ++bound) {
           /* Iterate over every corner node of the tree. */
@@ -947,12 +947,12 @@ t8_cmesh_correct_parameters_on_closed_geometry (const int geometry_dim, const in
 #endif /* T8_ENABLE_OCC */
 
 /**
- * This function stores the entity dimensions, tags, and parameters of each node in a given 
+ * This function stores the entity dimensions, tags, and parameters of each node in a given
  * tree in arrays. These arrays are then passed to the tree as attributes in cmesh.
  * \param [in, out] cmesh        The cmesh.
  * \param [in] tree_count   The index of the tree.
  * \param [in] tree_nodes   The array of the nodes of the tree.
- * \param [in] num_nodes    The number of nodes. 
+ * \param [in] num_nodes    The number of nodes.
  */
 static void
 t8_store_element_node_data (t8_cmesh_t cmesh, t8_gloidx_t tree_count,
@@ -974,7 +974,7 @@ t8_store_element_node_data (t8_cmesh_t cmesh, t8_gloidx_t tree_count,
     parameter_array[2 * node_i + 1] = current_node.parameters[1];
   }
 
-  /* Give the tree information about the dimension, tag and the parameters of the vertices. 
+  /* Give the tree information about the dimension, tag and the parameters of the vertices.
           * Each parameter set is given to the tree via its attribute key*/
   t8_cmesh_set_attribute (cmesh, tree_count, t8_get_package_id (), T8_CMESH_NODE_GEOMETRY_ATTRIBUTE_KEY,
                           entity_dim_array, T8_ECLASS_MAX_CORNERS * 2 * sizeof (int), 0);
@@ -1013,7 +1013,7 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
 {
   /* Calculate the parametric geometries of the tree */
   T8_ASSERT (cad_geometry_base->t8_geom_get_type () == T8_GEOMETRY_TYPE_CAD);
-  const t8_geometry_cad_c *cad_geometry = dynamic_cast<const t8_geometry_cad_c *> (cad_geometry_base);
+  const t8_geometry_cad *cad_geometry = dynamic_cast<const t8_geometry_cad *> (cad_geometry_base);
   /* Check for right element class */
   if (eclass != T8_ECLASS_TRIANGLE && eclass != T8_ECLASS_QUAD && eclass != T8_ECLASS_HEX && eclass != T8_ECLASS_TET
       && eclass != T8_ECLASS_PRISM) {
@@ -1060,7 +1060,7 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
       }
     }
 
-    /* A face can only be linked to an cad surface if all nodes of the face are parametric or on a vertex 
+    /* A face can only be linked to an cad surface if all nodes of the face are parametric or on a vertex
              * (gmsh labels nodes on vertices as not parametric) */
     int all_parametric = 1;
     for (int i_face_nodes = 0; i_face_nodes < num_face_nodes; ++i_face_nodes) {
@@ -1084,7 +1084,7 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
     }
     /* If not we can take two curves and look if they share a surface and then use this surface */
     if (!surface_index) {
-      /* To do this we can look if there are two curves, otherwise we have to check which vertices 
+      /* To do this we can look if there are two curves, otherwise we have to check which vertices
                * share the same curve. */
       int edge1_index = 0;
       int edge2_index = 0;
@@ -1100,7 +1100,7 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
           }
         }
       }
-      /* If there are less than 2 curves we can look at the vertices and check, 
+      /* If there are less than 2 curves we can look at the vertices and check,
                * if two of them are on the same curve */
       if (edge2_index == 0) {
         /* For each edge of face */
@@ -1113,7 +1113,8 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
 
           /* If both nodes are on a vertex we look if both vertices share an edge */
           if (node1.entity_dim == 0 && node2.entity_dim == 0) {
-            int common_edge = cad_geometry->t8_geom_get_common_edge (node1.entity_tag, node2.entity_tag);
+            int common_edge
+              = cad_geometry->get_cad_manager ()->t8_geom_get_common_edge (node1.entity_tag, node2.entity_tag);
             if (common_edge > 0) {
               if (edge1_index == 0) {
                 edge1_index = common_edge;
@@ -1127,7 +1128,7 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
         }
       }
       if (edge2_index > 0) {
-        surface_index = cad_geometry->t8_geom_get_common_face (edge1_index, edge2_index);
+        surface_index = cad_geometry->get_cad_manager ()->t8_geom_get_common_face (edge1_index, edge2_index);
       }
       else {
         continue;
@@ -1148,8 +1149,9 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
         else {
           /* If it is on another geometry we retrieve its parameters */
           if (face_nodes[i_face_nodes].entity_dim == 0) {
-            if (cad_geometry->t8_geom_is_vertex_on_face (face_nodes[i_face_nodes].entity_tag, surface_index)) {
-              cad_geometry->t8_geom_get_parameters_of_vertex_on_face (
+            if (cad_geometry->get_cad_manager ()->t8_geom_is_vertex_on_face (face_nodes[i_face_nodes].entity_tag,
+                                                                             surface_index)) {
+              cad_geometry->get_cad_manager ()->t8_geom_get_parameters_of_vertex_on_face (
                 face_nodes[i_face_nodes].entity_tag, surface_index, face_nodes[i_face_nodes].parameters.data ());
               face_nodes[i_face_nodes].entity_dim = 2;
             }
@@ -1159,8 +1161,9 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
             }
           }
           if (face_nodes[i_face_nodes].entity_dim == 1) {
-            if (cad_geometry->t8_geom_is_edge_on_face (face_nodes[i_face_nodes].entity_tag, surface_index)) {
-              cad_geometry->t8_geom_edge_parameter_to_face_parameters (
+            if (cad_geometry->get_cad_manager ()->t8_geom_is_edge_on_face (face_nodes[i_face_nodes].entity_tag,
+                                                                           surface_index)) {
+              cad_geometry->get_cad_manager ()->t8_geom_edge_parameter_to_face_parameters (
                 face_nodes[i_face_nodes].entity_tag, surface_index, num_face_nodes,
                 face_nodes[i_face_nodes].parameters[0], NULL, face_nodes[i_face_nodes].parameters.data ());
               face_nodes[i_face_nodes].entity_dim = 2;
@@ -1173,14 +1176,14 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
         }
       }
       /* Abort if not all nodes are on the surface or if the surface is a plane */
-      if (!all_nodes_on_surface || cad_geometry->t8_geom_is_plane (surface_index)) {
+      if (!all_nodes_on_surface || cad_geometry->get_cad_manager ()->t8_geom_is_plane (surface_index)) {
         continue;
       }
       /* If we have found a surface we link it to the face */
       face_geometries[i_tree_faces] = surface_index;
       tree_is_linked = 1;
       for (int i_face_edges = 0; i_face_edges < num_face_edges; ++i_face_edges) {
-        /* We lock the edges of the face for surfaces, so that we do not link the same surface again 
+        /* We lock the edges of the face for surfaces, so that we do not link the same surface again
                  * to the edges of the face */
         if (dim == 2) /* 2D */
         {
@@ -1199,7 +1202,7 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
       }
       /* Corrects the parameters on the surface if it is closed to prevent disorted elements. */
       for (int param_dim = 0; param_dim < 2; ++param_dim) {
-        if (cad_geometry->t8_geom_is_surface_closed (surface_index, param_dim)) {
+        if (cad_geometry->get_cad_manager ()->t8_geom_is_surface_closed (surface_index, param_dim)) {
           t8_cmesh_correct_parameters_on_closed_geometry (2, surface_index, num_face_nodes, cad_geometry, parameters);
         }
       }
@@ -1225,7 +1228,7 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
         || (!edge_nodes[1].parametric && edge_nodes[1].entity_dim != 0)) {
       continue;
     }
-    /* An edge can be linked to a curve as well as a surface. 
+    /* An edge can be linked to a curve as well as a surface.
              * Therefore, we have to save the geometry dim and tag */
     int edge_geometry_dim = 0;
     int edge_geometry_tag = 0;
@@ -1254,19 +1257,22 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
       int is_on_geom = 1;
       for (int i_edge = 0; i_edge < 2; ++i_edge) {
         if (edge_geometry_dim == 2 && edge_nodes[i_edge].entity_dim == 1) {
-          if (!cad_geometry->t8_geom_is_edge_on_face (edge_nodes[i_edge].entity_tag, edge_geometry_tag)) {
+          if (!cad_geometry->get_cad_manager ()->t8_geom_is_edge_on_face (edge_nodes[i_edge].entity_tag,
+                                                                          edge_geometry_tag)) {
             is_on_geom = 0;
             break;
           }
         }
         else if (edge_geometry_dim == 2 && edge_nodes[i_edge].entity_dim == 0) {
-          if (!cad_geometry->t8_geom_is_vertex_on_face (edge_nodes[i_edge].entity_tag, edge_geometry_tag)) {
+          if (!cad_geometry->get_cad_manager ()->t8_geom_is_vertex_on_face (edge_nodes[i_edge].entity_tag,
+                                                                            edge_geometry_tag)) {
             is_on_geom = 0;
             break;
           }
         }
         else if (edge_geometry_dim == 1 && edge_nodes[i_edge].entity_dim == 0) {
-          if (!cad_geometry->t8_geom_is_vertex_on_edge (edge_nodes[i_edge].entity_tag, edge_geometry_tag)) {
+          if (!cad_geometry->get_cad_manager ()->t8_geom_is_vertex_on_edge (edge_nodes[i_edge].entity_tag,
+                                                                            edge_geometry_tag)) {
             is_on_geom = 0;
             break;
           }
@@ -1277,11 +1283,12 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
       }
     }
 
-    /* If both nodes are on a vertex we still got no edge. 
-             * But we can look if both vertices share an edge and use this edge. 
+    /* If both nodes are on a vertex we still got no edge.
+             * But we can look if both vertices share an edge and use this edge.
              * If not we can skip this edge. */
     if (edge_geometry_dim == 0 && edge_geometry_tag == 0) {
-      int common_curve = cad_geometry->t8_geom_get_common_edge (edge_nodes[0].entity_tag, edge_nodes[1].entity_tag);
+      int common_curve = cad_geometry->get_cad_manager ()->t8_geom_get_common_edge (edge_nodes[0].entity_tag,
+                                                                                    edge_nodes[1].entity_tag);
       if (common_curve > 0) {
         edge_geometry_tag = common_curve;
         edge_geometry_dim = 1;
@@ -1290,11 +1297,12 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
         continue;
       }
     }
-    /* If both nodes are on different edges we have to look if both edges share a surface. 
+    /* If both nodes are on different edges we have to look if both edges share a surface.
              * If not we can skip this edge */
     if (edge_nodes[0].entity_dim == 1 && edge_nodes[1].entity_dim == 1
         && edge_nodes[0].entity_tag != edge_nodes[1].entity_tag) {
-      int common_surface = cad_geometry->t8_geom_get_common_face (edge_nodes[0].entity_tag, edge_nodes[1].entity_tag);
+      int common_surface = cad_geometry->get_cad_manager ()->t8_geom_get_common_face (edge_nodes[0].entity_tag,
+                                                                                      edge_nodes[1].entity_tag);
       if (common_surface > 0) {
         edge_geometry_tag = common_surface;
         edge_geometry_dim = 2;
@@ -1308,7 +1316,7 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
       /* Check if adjacent faces carry a surface and if this edge lies on the surface */
       for (int i_adjacent_face = 0; i_adjacent_face < 2; ++i_adjacent_face) {
         if (face_geometries[t8_edge_to_face[eclass][i_tree_edges][i_adjacent_face]] > 0) {
-          if (!cad_geometry->t8_geom_is_edge_on_face (
+          if (!cad_geometry->get_cad_manager ()->t8_geom_is_edge_on_face (
                 edge_geometry_tag, face_geometries[t8_edge_to_face[eclass][i_tree_edges][i_adjacent_face]])) {
             t8_global_errorf ("Error: Adjacent edge and face of a tree carry "
                               "incompatible geometries.\n");
@@ -1331,7 +1339,8 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
           return 0;
         }
         if (edge_nodes[i_edge_node].entity_dim == 0) {
-          if (!cad_geometry->t8_geom_is_vertex_on_edge (edge_nodes[i_edge_node].entity_tag, edge_geometry_tag)) {
+          if (!cad_geometry->get_cad_manager ()->t8_geom_is_vertex_on_edge (edge_nodes[i_edge_node].entity_tag,
+                                                                            edge_geometry_tag)) {
             t8_global_errorf ("Error: Node %li should lie on a vertex which lies on an edge, "
                               "but the vertex does not lie on that edge.\n",
                               edge_nodes[i_edge_node].index);
@@ -1341,14 +1350,14 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
 
         /* If the node lies on a vertex we retrieve its parameter on the curve */
         if (edge_nodes[i_edge_node].entity_dim == 0) {
-          cad_geometry->t8_geom_get_parameter_of_vertex_on_edge (edge_nodes[i_edge_node].entity_tag, edge_geometry_tag,
-                                                                 edge_nodes[i_edge_node].parameters.data ());
+          cad_geometry->get_cad_manager ()->t8_geom_get_parameter_of_vertex_on_edge (
+            edge_nodes[i_edge_node].entity_tag, edge_geometry_tag, edge_nodes[i_edge_node].parameters.data ());
           edge_nodes[i_edge_node].entity_dim = 1;
         }
       }
 
       /* Abort if the edge is a line */
-      if (cad_geometry->t8_geom_is_line (edge_geometry_tag)) {
+      if (cad_geometry->get_cad_manager ()->t8_geom_is_line (edge_geometry_tag)) {
         continue;
       }
 
@@ -1358,7 +1367,7 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
       parameters[1] = edge_nodes[1].parameters[0];
 
       /* Corrects the parameters on the edge if it is closed to prevent disorted elements. */
-      if (cad_geometry->t8_geom_is_edge_closed (edge_geometry_tag)) {
+      if (cad_geometry->get_cad_manager ()->t8_geom_is_edge_closed (edge_geometry_tag)) {
         t8_cmesh_correct_parameters_on_closed_geometry (1, edge_geometry_tag, 2, cad_geometry, parameters);
       }
 
@@ -1366,7 +1375,7 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
                               T8_CMESH_CAD_EDGE_PARAMETERS_ATTRIBUTE_KEY + i_tree_edges, parameters,
                               2 * sizeof (double), 0);
     }
-    /* If we have found a surface we can look for the parameters. 
+    /* If we have found a surface we can look for the parameters.
              * If the edge is locked for edges on surfaces we have to skip this edge */
     else if (edge_geometry_dim == 2 && edge_geometries[i_tree_edges + num_edges] >= 0) {
       /* If the node lies on a geometry with a different dimension we try to retrieve the parameters */
@@ -1378,7 +1387,8 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
           return 0;
         }
         if (edge_nodes[i_edge_node].entity_dim == 0) {
-          if (!cad_geometry->t8_geom_is_vertex_on_face (edge_nodes[i_edge_node].entity_tag, edge_geometry_tag)) {
+          if (!cad_geometry->get_cad_manager ()->t8_geom_is_vertex_on_face (edge_nodes[i_edge_node].entity_tag,
+                                                                            edge_geometry_tag)) {
             t8_global_errorf ("Error: Node %li should lie on a vertex which lies on a face, "
                               "but the vertex does not lie on that face.\n",
                               edge_nodes[i_edge_node].index);
@@ -1386,7 +1396,8 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
           }
         }
         if (edge_nodes[i_edge_node].entity_dim == 1) {
-          if (!cad_geometry->t8_geom_is_edge_on_face (edge_nodes[i_edge_node].entity_tag, edge_geometry_tag)) {
+          if (!cad_geometry->get_cad_manager ()->t8_geom_is_edge_on_face (edge_nodes[i_edge_node].entity_tag,
+                                                                          edge_geometry_tag)) {
             t8_global_errorf ("Error: Node %li should lie on an edge which lies on a face, "
                               "but the edge does not lie on that face.\n",
                               edge_nodes[i_edge_node].index);
@@ -1396,14 +1407,14 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
 
         /* If the node lies on a vertex we retrieve its parameters on the surface */
         if (edge_nodes[i_edge_node].entity_dim == 0) {
-          cad_geometry->t8_geom_get_parameters_of_vertex_on_face (edge_nodes[i_edge_node].entity_tag, edge_geometry_tag,
-                                                                  edge_nodes[i_edge_node].parameters.data ());
+          cad_geometry->get_cad_manager ()->t8_geom_get_parameters_of_vertex_on_face (
+            edge_nodes[i_edge_node].entity_tag, edge_geometry_tag, edge_nodes[i_edge_node].parameters.data ());
           edge_nodes[i_edge_node].entity_dim = 2;
         }
         /* If the node lies on an edge we have to do the same */
         if (edge_nodes[i_edge_node].entity_dim == 1) {
           const int num_face_nodes = t8_eclass_num_vertices[eclass];
-          cad_geometry->t8_geom_edge_parameter_to_face_parameters (
+          cad_geometry->get_cad_manager ()->t8_geom_edge_parameter_to_face_parameters (
             edge_nodes[i_edge_node].entity_tag, edge_geometry_tag, num_face_nodes,
             edge_nodes[i_edge_node].parameters[0], parameters, edge_nodes[i_edge_node].parameters.data ());
           edge_nodes[i_edge_node].entity_dim = 2;
@@ -1411,7 +1422,7 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
       }
 
       /* Abort if the edge is a line */
-      if (cad_geometry->t8_geom_is_line (edge_geometry_tag)) {
+      if (cad_geometry->get_cad_manager ()->t8_geom_is_line (edge_geometry_tag)) {
         continue;
       }
 
@@ -1424,7 +1435,7 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
 
       /* Corrects the parameters on the surface if it is closed to prevent disorted elements. */
       for (int param_dim = 0; param_dim < 2; ++param_dim) {
-        if (cad_geometry->t8_geom_is_surface_closed (edge_geometry_tag, param_dim)) {
+        if (cad_geometry->get_cad_manager ()->t8_geom_is_surface_closed (edge_geometry_tag, param_dim)) {
           t8_cmesh_correct_parameters_on_closed_geometry (2, edge_geometry_tag, 2, cad_geometry, parameters);
         }
       }
@@ -1462,7 +1473,7 @@ t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t
 /* fp should be set after the Nodes section, right before the tree section.
  * If vertex_indices is not NULL, it is allocated and will store
  * for each tree the indices of its vertices.
- * They are stored as arrays of long ints. 
+ * They are stored as arrays of long ints.
  * If cad geometry is used, the geometry is passed as a pointer here.
  * We cannot access this geometry over the cmesh interface since the cmesh
  * is not committed yet. */
@@ -1971,7 +1982,7 @@ t8_cmesh_msh_file_find_neighbors (t8_cmesh_t cmesh, const t8_msh_tree_vertex_ind
 /* This part should be callable from C */
 T8_EXTERN_C_BEGIN ();
 
-/* This is a helper function to properly register the 
+/* This is a helper function to properly register the
  * geometries for the cmesh created in t8_cmesh_from_msh_file.
  * It should be called by all processes of the cmesh.
  * Returns 1 on success, 0 on cad usage error: use_cad_geometry true, but OCC not linked.

--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -1000,9 +1000,8 @@ t8_store_element_node_data (t8_cmesh_t cmesh, t8_gloidx_t tree_count,
  * \param [in] face_nodes An array of nodes representing the faces of the tree.
  * \param [in] edge_nodes An array of nodes representing the edges of the tree.
  *
- * \return std::optional<t8_msh_tree_vertex_indices>
- *         - Returns a valid `t8_msh_tree_vertex_indices` object if the tree geometry is successfully processed.
- *         - Returns 0 if the geometry processing fails.
+ * \return True if the tree geometry was successfully processed; false otherwise.
+ *
  */
 static bool
 t8_cmesh_process_tree_geometry (t8_cmesh_t cmesh, t8_eclass_t eclass, int dim, t8_gloidx_t tree_count,

--- a/src/t8_data/t8_cad.cxx
+++ b/src/t8_data/t8_cad.cxx
@@ -33,13 +33,10 @@
 #include <TopoDS_Face.hxx>
 #include <Standard_Version.hxx>
 
-//#if T8_ENABLE_OCC
-
 t8_cad::t8_cad (std::string fileprefix)
 {
   BRep_Builder builder;
-  std::string current_file (fileprefix);
-  std::ifstream is (current_file + ".brep");
+  std::ifstream is (fileprefix + ".brep");
   if (is.is_open () == false) {
     SC_ABORTF ("Cannot find the file %s.brep.\n", fileprefix.c_str ());
   }
@@ -303,4 +300,3 @@ t8_cad::t8_geom_is_surface_closed (int geometry_index, int parameter) const
     break;
   }
 }
-//#endif /* T8_ENABLE_OCC */

--- a/src/t8_data/t8_cad.cxx
+++ b/src/t8_data/t8_cad.cxx
@@ -1,0 +1,306 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2025 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#include <t8.h>
+#include <t8_data/t8_cad.hxx>
+#include <t8_geometry/t8_geometry_implementations/t8_geometry_cad.hxx>
+#include <TopoDS.hxx>
+#include <BRep_Builder.hxx>
+#include <BRep_Tool.hxx>
+#include <BRepTools.hxx>
+#include <GeomAPI_ProjectPointOnSurf.hxx>
+#include <GeomAPI_ProjectPointOnCurve.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <Standard_Version.hxx>
+
+//#if T8_ENABLE_OCC
+
+t8_cad::t8_cad (std::string fileprefix)
+{
+  BRep_Builder builder;
+  std::string current_file (fileprefix);
+  std::ifstream is (current_file + ".brep");
+  if (is.is_open () == false) {
+    SC_ABORTF ("Cannot find the file %s.brep.\n", fileprefix.c_str ());
+  }
+  BRepTools::Read (cad_shape, is, builder);
+  is.close ();
+  if (cad_shape.IsNull ()) {
+    SC_ABORTF ("Could not read brep file or brep file contains no shape. "
+               "The cad file may be written with a newer cad version. "
+               "Linked cad version: %s",
+               OCC_VERSION_COMPLETE);
+  }
+  TopExp::MapShapes (cad_shape, TopAbs_VERTEX, cad_shape_vertex_map);
+  TopExp::MapShapes (cad_shape, TopAbs_EDGE, cad_shape_edge_map);
+  TopExp::MapShapes (cad_shape, TopAbs_FACE, cad_shape_face_map);
+  TopExp::MapShapesAndUniqueAncestors (cad_shape, TopAbs_VERTEX, TopAbs_EDGE, cad_shape_vertex2edge_map);
+  TopExp::MapShapesAndUniqueAncestors (cad_shape, TopAbs_EDGE, TopAbs_FACE, cad_shape_edge2face_map);
+}
+
+t8_cad::t8_cad (const TopoDS_Shape cad_shape)
+{
+  if (cad_shape.IsNull ()) {
+    SC_ABORTF ("Shape is null. \n");
+  }
+  TopExp::MapShapes (cad_shape, TopAbs_VERTEX, cad_shape_vertex_map);
+  TopExp::MapShapes (cad_shape, TopAbs_EDGE, cad_shape_edge_map);
+  TopExp::MapShapes (cad_shape, TopAbs_FACE, cad_shape_face_map);
+  TopExp::MapShapesAndUniqueAncestors (cad_shape, TopAbs_VERTEX, TopAbs_EDGE, cad_shape_vertex2edge_map);
+  TopExp::MapShapesAndUniqueAncestors (cad_shape, TopAbs_EDGE, TopAbs_FACE, cad_shape_edge2face_map);
+}
+
+t8_cad::t8_cad ()
+{
+  cad_shape.Nullify ();
+}
+
+int
+t8_cad::t8_geom_is_line (const int curve_index) const
+{
+  const Handle_Geom_Curve curve = t8_geom_get_cad_curve (curve_index);
+  const GeomAdaptor_Curve curve_adaptor (curve);
+  return curve_adaptor.GetType () == GeomAbs_Line;
+}
+
+int
+t8_cad::t8_geom_is_plane (const int surface_index) const
+{
+  const Handle_Geom_Surface surface = t8_geom_get_cad_surface (surface_index);
+  const GeomAdaptor_Surface surface_adaptor (surface);
+  return surface_adaptor.GetType () == GeomAbs_Plane;
+}
+
+const gp_Pnt
+t8_cad::t8_geom_get_cad_point (const int index) const
+{
+  T8_ASSERT (index <= cad_shape_vertex_map.Size ());
+  return BRep_Tool::Pnt (TopoDS::Vertex (cad_shape_vertex_map.FindKey (index)));
+}
+
+const Handle_Geom_Curve
+t8_cad::t8_geom_get_cad_curve (const int index) const
+{
+  T8_ASSERT (index <= cad_shape_edge_map.Size ());
+  Standard_Real first, last;
+  return BRep_Tool::Curve (TopoDS::Edge (cad_shape_edge_map.FindKey (index)), first, last);
+}
+
+const Handle_Geom_Surface
+t8_cad::t8_geom_get_cad_surface (const int index) const
+{
+  T8_ASSERT (index <= cad_shape_face_map.Size ());
+  return BRep_Tool::Surface (TopoDS::Face (cad_shape_face_map.FindKey (index)));
+}
+
+const TopTools_IndexedMapOfShape
+t8_cad::t8_geom_get_cad_shape_vertex_map () const
+{
+  return cad_shape_vertex_map;
+}
+
+const TopTools_IndexedMapOfShape
+t8_cad::t8_geom_get_cad_shape_edge_map () const
+{
+  return cad_shape_edge_map;
+}
+
+const TopTools_IndexedMapOfShape
+t8_cad::t8_geom_get_cad_shape_face_map () const
+{
+  return cad_shape_face_map;
+}
+
+int
+t8_cad::t8_geom_get_common_edge (const int vertex1_index, const int vertex2_index) const
+{
+  const TopTools_ListOfShape collection1 = cad_shape_vertex2edge_map.FindFromIndex (vertex1_index);
+  const TopTools_ListOfShape collection2 = cad_shape_vertex2edge_map.FindFromIndex (vertex2_index);
+
+  for (auto edge1 = collection1.begin (); edge1 != collection1.end (); ++edge1) {
+    for (auto edge2 = collection2.begin (); edge2 != collection2.end (); ++edge2) {
+      if (edge1->IsEqual (*edge2)) {
+        return cad_shape_edge2face_map.FindIndex (*edge1);
+      }
+    }
+  }
+  return 0;
+}
+
+int
+t8_cad::t8_geom_get_common_face (const int edge1_index, const int edge2_index) const
+{
+  const TopTools_ListOfShape collection1 = cad_shape_edge2face_map.FindFromIndex (edge1_index);
+  const TopTools_ListOfShape collection2 = cad_shape_edge2face_map.FindFromIndex (edge2_index);
+
+  for (auto face1 = collection1.begin (); face1 != collection1.end (); ++face1) {
+    for (auto face2 = collection2.begin (); face2 != collection2.end (); ++face2) {
+      if (face1->IsEqual (*face2)) {
+        return cad_shape_face_map.FindIndex (*face1);
+      }
+    }
+  }
+  return 0;
+}
+
+int
+t8_cad::t8_geom_is_vertex_on_edge (const int vertex_index, const int edge_index) const
+{
+  const TopTools_ListOfShape collection = cad_shape_vertex2edge_map.FindFromIndex (vertex_index);
+  return collection.Contains (cad_shape_edge_map.FindKey (edge_index));
+}
+
+int
+t8_cad::t8_geom_is_edge_on_face (const int edge_index, const int face_index) const
+{
+  const TopTools_ListOfShape collection = cad_shape_edge2face_map.FindFromIndex (edge_index);
+  return collection.Contains (cad_shape_face_map.FindKey (face_index));
+}
+
+int
+t8_cad::t8_geom_is_vertex_on_face (const int vertex_index, const int face_index) const
+{
+  const TopTools_ListOfShape edge_collection = cad_shape_vertex2edge_map.FindFromIndex (vertex_index);
+  for (auto edge = edge_collection.begin (); edge != edge_collection.end (); ++edge) {
+    const TopTools_ListOfShape face_collection = cad_shape_edge2face_map.FindFromKey (*edge);
+    if (face_collection.Contains (cad_shape_face_map.FindKey (face_index))) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+void
+t8_cad::t8_geom_get_parameter_of_vertex_on_edge (const int vertex_index, const int edge_index, double *edge_param) const
+{
+  T8_ASSERT (t8_cad::t8_geom_is_vertex_on_edge (vertex_index, edge_index));
+  TopoDS_Vertex vertex = TopoDS::Vertex (cad_shape_vertex_map.FindKey (vertex_index));
+  TopoDS_Edge edge = TopoDS::Edge (cad_shape_edge_map.FindKey (edge_index));
+  *edge_param = BRep_Tool::Parameter (vertex, edge);
+}
+
+void
+t8_cad::t8_geom_get_parameters_of_vertex_on_face (const int vertex_index, const int face_index,
+                                                  double *face_params) const
+{
+  T8_ASSERT (t8_cad::t8_geom_is_vertex_on_face (vertex_index, face_index));
+  gp_Pnt2d uv;
+  TopoDS_Vertex vertex = TopoDS::Vertex (cad_shape_vertex_map.FindKey (vertex_index));
+  TopoDS_Face face = TopoDS::Face (cad_shape_face_map.FindKey (face_index));
+  uv = BRep_Tool::Parameters (vertex, face);
+  face_params[0] = uv.X ();
+  face_params[1] = uv.Y ();
+}
+
+void
+t8_cad::t8_geom_edge_parameter_to_face_parameters (const int edge_index, const int face_index, const int num_face_nodes,
+                                                   const double edge_param, const double *surface_params,
+                                                   double *face_params) const
+{
+  T8_ASSERT (t8_cad::t8_geom_is_edge_on_face (edge_index, face_index));
+  Standard_Real first, last;
+  gp_Pnt2d uv;
+  TopoDS_Edge edge = TopoDS::Edge (cad_shape_edge_map.FindKey (edge_index));
+  TopoDS_Face face = TopoDS::Face (cad_shape_face_map.FindKey (face_index));
+  Handle_Geom2d_Curve curve_on_surface = BRep_Tool::CurveOnSurface (edge, face, first, last);
+  Handle_Geom_Surface surface = BRep_Tool::Surface (face);
+  curve_on_surface->D0 (edge_param, uv);
+  face_params[0] = uv.X ();
+  face_params[1] = uv.Y ();
+
+  /* Check for right conversion of edge to surface parameter and correct if needed */
+  /* Checking u parameter */
+  if (surface_params != NULL) {
+    double parametric_bounds[4];
+    surface->Bounds (parametric_bounds[0], parametric_bounds[1], parametric_bounds[2], parametric_bounds[3]);
+    if (surface->IsUClosed ()) {
+      for (int i_face_node = 0; i_face_node < num_face_nodes; ++i_face_node) {
+        if (surface_params[i_face_node * 2] == parametric_bounds[0]) {
+          if (face_params[0] == parametric_bounds[1]) {
+            face_params[0] = parametric_bounds[0];
+          }
+        }
+        else if (surface_params[i_face_node * 2] == parametric_bounds[1]) {
+          if (face_params[0] == parametric_bounds[0]) {
+            face_params[0] = parametric_bounds[1];
+          }
+        }
+      }
+    }
+    /* Checking v parameter */
+    if (surface->IsVClosed ()) {
+      for (int i_face_node = 0; i_face_node < num_face_nodes; ++i_face_node) {
+        if (surface_params[i_face_node * 2 + 1] == parametric_bounds[0]) {
+          if (face_params[1] == parametric_bounds[1]) {
+            face_params[1] = parametric_bounds[0];
+          }
+        }
+        else if (surface_params[i_face_node * 2 + 1] == parametric_bounds[1]) {
+          if (face_params[1] == parametric_bounds[0]) {
+            face_params[1] = parametric_bounds[1];
+          }
+        }
+      }
+    }
+  }
+}
+
+void
+t8_cad::t8_geom_get_face_parametric_bounds (const int surface_index, double *bounds) const
+{
+  const Handle_Geom_Surface cad_surface = t8_geom_get_cad_surface (surface_index);
+  cad_surface->Bounds (bounds[0], bounds[1], bounds[2], bounds[3]);
+}
+
+void
+t8_cad::t8_geom_get_edge_parametric_bounds (const int edge_index, double *bounds) const
+{
+  const Handle_Geom_Curve cad_edge = t8_geom_get_cad_curve (edge_index);
+  bounds[0] = cad_edge->FirstParameter ();
+  bounds[1] = cad_edge->LastParameter ();
+}
+
+int
+t8_cad::t8_geom_is_edge_closed (int edge_index) const
+{
+  const Handle_Geom_Curve cad_edge = t8_geom_get_cad_curve (edge_index);
+  return cad_edge->IsClosed ();
+}
+
+int
+t8_cad::t8_geom_is_surface_closed (int geometry_index, int parameter) const
+{
+  const Handle_Geom_Surface cad_surface = t8_geom_get_cad_surface (geometry_index);
+  switch (parameter) {
+  case 0:
+    return cad_surface->IsUClosed ();
+    break;
+  case 1:
+    return cad_surface->IsVClosed ();
+    break;
+  default:
+    SC_ABORT_NOT_REACHED ();
+    break;
+  }
+}
+//#endif /* T8_ENABLE_OCC */

--- a/src/t8_data/t8_cad.hxx
+++ b/src/t8_data/t8_cad.hxx
@@ -1,0 +1,238 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2025 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_geometry_cad.hxx
+ * This geometry implements OpenCASCADE geometries. It enables the option to link different 
+ * 1 and 2 dimensional cad geometries to the edges and faces of refinement trees. 
+ * The geometry of the refinement tree is extended into the volume accordingly.
+ */
+
+#ifndef T8_CAD_HXX
+#define T8_CAD_HXX
+
+#include <gp_Pnt.hxx>
+#include <TopExp.hxx>
+#include <Geom_Surface.hxx>
+#include <Geom_Curve.hxx>
+
+class t8_cad {
+ public:
+  /**
+    * Constructor of the cad shape.
+    * The shape is initialized based on a .brep file with the given prefix.
+    * The internal structure extracts and stores geometric information such as
+    * vertices, edges, and faces from this file. The number and type of vertices
+    * should match the tree type (quad/hex/tri), and the cad data must be valid.
+    * This constructor is intended for general use, including file-based mesh creation.
+    *
+    * \param [in] fileprefix  Prefix of a .brep file from which to extract cad geometry.
+    */
+  t8_cad (std::string fileprefix);
+
+  /**
+    * Constructor of the cad shape.
+    * The shape is initialized directly from an existing TopoDS_Shape.
+    * This constructor is especially useful for use in scripts, testing,
+    * or integration with mesh generators that already provide geometry in memory.
+    * It avoids file I/O and allows full control over the CAD input.
+    *
+    * \param [in] cad_shape  cad shape geometry object.
+    */
+  t8_cad (const TopoDS_Shape cad_shape);
+
+  /**
+   * Constructor of the cad shape for testing purposes. Sets an invalid cad_shape.
+   */
+  t8_cad ();
+
+  /** Check if a cad_curve is a line.
+   * \param [in] curve_index      The index of the cad_curve.
+   * \return                      1 if curve is a line, 0 if curve is not a line.
+   */
+  int
+  t8_geom_is_line (const int curve_index) const;
+
+  /** Check if a cad_surface is a plane.
+   * \param [in] surface_index      The index of the cad_surface.
+   * \return                        1 if surface is a plane linear, 0 if surface is not a plane.
+   */
+  int
+  t8_geom_is_plane (const int surface_index) const;
+
+  /** Get an cad point from the cad_shape.
+   * \param [in] index      The index of the point in the cad_shape.
+   * \return                The cad point.
+   */
+  const gp_Pnt
+  t8_geom_get_cad_point (const int index) const;
+
+  /** Get an cad curve from the cad_shape.
+   * \param [in] index      The index of the curve in the cad_shape.
+   * \return                The cad curve.
+   */
+  const Handle_Geom_Curve
+  t8_geom_get_cad_curve (const int index) const;
+
+  /** Get an cad surface from the cad_shape.
+   * \param [in] index      The index of the surface in the cad_shape.
+   * \return                The cad surface.
+   */
+  const Handle_Geom_Surface
+  t8_geom_get_cad_surface (const int index) const;
+
+  /** Get the cad_shape_vertex2edge_map.
+   * \return                The cad_shape_vertex_map.
+   */
+  const TopTools_IndexedMapOfShape
+  t8_geom_get_cad_shape_vertex_map () const;
+
+  /** Get the cad_shape_edge2face_map.
+   * \return                The cad_shape_edge_map.
+   */
+  const TopTools_IndexedMapOfShape
+  t8_geom_get_cad_shape_edge_map () const;
+
+  /** Get the cad_shape_face_map.
+   * \return                The cad_shape_face_map.
+   */
+  const TopTools_IndexedMapOfShape
+  t8_geom_get_cad_shape_face_map () const;
+
+  /** Check if two cad points share a common cad edge.
+   * \param [in]  vertex1_index  The index of the first cad point.
+   * \param [in]  vertex2_index  The index of the second cad point.
+   * \return                    Index of the shared edge. 0 if there is no shared edge.
+   */
+  int
+  t8_geom_get_common_edge (const int vertex1_index, const int vertex2_index) const;
+
+  /** Check if two cad edges share a common cad face.
+   * \param [in]  edge1_index    The index of the first cad edge.
+   * \param [in]  edge2_index    The index of the second cad edge.
+   * \return                    Index of the shared face. 0 if there is no shared face.
+   */
+  int
+  t8_geom_get_common_face (const int edge1_index, const int edge2_index) const;
+
+  /** Check if a cad vertex lies on an cad edge.
+   * \param [in]  vertex_index   The index of the cad vertex.
+   * \param [in]  edge_index     The index of the cad edge.
+   * \return                    1 if vertex lies on edge, otherwise 0.
+   */
+  int
+  t8_geom_is_vertex_on_edge (const int vertex_index, const int edge_index) const;
+
+  /** Check if a cad vertex lies on an cad edge.
+   * \param [in]  edge_index     The index of the cad vertex.
+   * \param [in]  face_index     The index of the cad edge.
+   * \return                    1 if vertex lies on edge, otherwise 0.
+   */
+  int
+  t8_geom_is_edge_on_face (const int edge_index, const int face_index) const;
+
+  /** Check if a cad vertex lies on an cad face.
+   * \param [in]  vertex_index   The index of the cad vertex.
+   * \param [in]  face_index     The index of the cad face.
+   * \return                    1 if vertex lies on face, otherwise 0.
+   */
+  int
+  t8_geom_is_vertex_on_face (const int vertex_index, const int face_index) const;
+
+  /** Retrieves the parameter of an cad vertex on an cad edge.
+   *  The vertex has to lie on the edge.
+   * \param [in]  vertex_index   The index of the cad vertex.
+   * \param [in]  edge_index     The index of the cad edge.
+   * \param [out] edge_param     The parameter of the vertex on the edge.
+   */
+  void
+  t8_geom_get_parameter_of_vertex_on_edge (const int vertex_index, const int edge_index, double *edge_param) const;
+
+  /** Retrieves the parameters of an cad vertex on a cad face.
+   *  The vertex has to lie on the face.
+   * \param [in]  vertex_index   The index of the cad vertex.
+   * \param [in]  face_index     The index of the cad face.
+   * \param [out] face_params    The parameters of the vertex on the face.
+   */
+  void
+  t8_geom_get_parameters_of_vertex_on_face (const int vertex_index, const int face_index, double *face_params) const;
+
+  /** Converts the parameters of an cad edge to the corresponding parameters on an cad face.
+   * The edge has to lie on the face.
+   * For the conversion of edge parameters of mesh elements to topological face parameters of a closed surface, it is additionally
+   * checked, whether the conversion was correct, to prevent disorted elements. 
+   * \param [in]  edge_index     The index of the cad edge, which parameters should be converted to face parameters.
+   * \param [in]  face_index     The index of the cad face, on to which the edge parameters should be converted.
+   * \param [in]  num_face_nodes The number of the face nodes of the evaluated element. Only needed for closed surface check, otherwise NULL.
+   * \param [in]  edge_param     The parameter on the edge.
+   * \param [in]  surface_param  The parameters of the surface nodes.
+   *                             When provided, there are additional checks for closed geometries.
+   *                             If there are no surface parameter
+   *                             to pass in to the function, you can pass NULL.
+   * \param [out] face_params    The corresponding parameters on the face.
+   */
+  void
+  t8_geom_edge_parameter_to_face_parameters (const int edge_index, const int face_index, const int num_face_nodes,
+                                             const double edge_param, const double *surface_params,
+                                             double *face_params) const;
+
+  /** Finds the parametric bounds of an cad face.
+   * \param [in]  face_index   The index of the cad face.
+   * \param [out] bounds          The parametric bounds of the cad face.
+   */
+  void
+  t8_geom_get_face_parametric_bounds (const int surface_index, double *bounds) const;
+
+  /** Finds the parametric bounds of an cad edge.
+   * \param [in]  edge_index   The index of the cad edge.
+   * \param [out] bounds       The parametric bounds of the cad edge.
+   */
+  void
+  t8_geom_get_edge_parametric_bounds (const int edge_index, double *bounds) const;
+
+  /** Checks if an edge is closed in its U parameter.
+   * \param [in]  edge_index   The index of the closed edge.
+   * \return                   1 if edge is closed in U. 0 if edge is not closed in U.
+   */
+  int
+  t8_geom_is_edge_closed (int edge_index) const;
+
+  /** Checks if a surface is closed in its U parameter or V parameter.
+   * \param [in]  geometry_index   The index of the closed geometry.
+   * \param [in]  parameter        The parameter, which should be check for closeness.
+   *                               0 stands for the U parameter and 1 for the V parameter. 
+   * \return                       1 if geometry is closed in U. 0 if geometry is not closed in U.
+   */
+  int
+  t8_geom_is_surface_closed (int geometry_index, int parameter) const;
+
+ private:
+  TopoDS_Shape cad_shape;                          /**< cad geometry */
+  TopTools_IndexedMapOfShape cad_shape_vertex_map; /**< Map of all TopoDS_Vertex in shape. */
+  TopTools_IndexedMapOfShape cad_shape_edge_map;   /**< Map of all TopoDS_Edge in shape. */
+  TopTools_IndexedMapOfShape cad_shape_face_map;   /**< Map of all TopoDS_Face in shape. */
+  TopTools_IndexedDataMapOfShapeListOfShape
+    cad_shape_vertex2edge_map; /**< Maps all TopoDS_Vertex of shape to all its connected TopoDS_Edge */
+  TopTools_IndexedDataMapOfShapeListOfShape
+    cad_shape_edge2face_map; /**< Maps all TopoDS_Edge of shape to all its connected TopoDS_Face */
+};
+
+#endif /* !T8_CAD_HXX */

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.cxx
@@ -51,13 +51,13 @@ const int t8_face_ref_coords_tet[4][2] = { { 2, 1 }, { 0, 1 }, { 0, 1 }, { 0, 2 
 
 t8_geometry_cad::t8_geometry_cad (std::string fileprefix, std::string name_in): t8_geometry_with_vertices (name_in)
 {
-  cad_manager = new t8_cad (fileprefix);
+  cad_manager = std::make_shared<t8_cad> (fileprefix);
 }
 
 t8_geometry_cad::t8_geometry_cad (const TopoDS_Shape cad_shape, std::string name_in)
   : t8_geometry_with_vertices (name_in)
 {
-  cad_manager = new t8_cad (cad_shape);
+  cad_manager = std::make_shared<t8_cad> (cad_shape);
 }
 
 t8_geometry_cad::t8_geometry_cad (): t8_geometry_with_vertices ("t8_geom_cad")

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.cxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.cxx
@@ -3,7 +3,7 @@
   t8code is a C library to manage a collection (a forest) of multiple
   connected adaptive space-trees of general element classes in parallel.
 
-  Copyright (C) 2015 the developers
+  Copyright (C) 2025 the developers
 
   t8code is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -25,6 +25,7 @@
 #include <t8_geometry/t8_geometry_implementations/t8_geometry_cad.h>
 #include <t8_eclass.h>
 #include <t8_geometry/t8_geometry_helpers.h>
+#include <t8_schemes/t8_default/t8_default_prism/t8_dprism.h>
 
 #include <BRep_Builder.hxx>
 #include <BRep_Tool.hxx>
@@ -37,8 +38,8 @@
 #include <TopoDS_Vertex.hxx>
 #include <TopoDS_Edge.hxx>
 #include <TopoDS_Face.hxx>
-#include <Standard_Version.hxx>
-#include <t8_schemes/t8_default/t8_default_prism/t8_dprism.h>
+#include <Geom_Surface.hxx>
+#include <Geom_Curve.hxx>
 
 /* The lookup table contains the coordinate of each edge of a tetrahedron,
  * which is used for the interpolation.
@@ -50,43 +51,17 @@ const int t8_face_ref_coords_tet[4][2] = { { 2, 1 }, { 0, 1 }, { 0, 1 }, { 0, 2 
 
 t8_geometry_cad::t8_geometry_cad (std::string fileprefix, std::string name_in): t8_geometry_with_vertices (name_in)
 {
-  BRep_Builder builder;
-  std::string current_file (fileprefix);
-  std::ifstream is (current_file + ".brep");
-  if (is.is_open () == false) {
-    SC_ABORTF ("Cannot find the file %s.brep.\n", fileprefix.c_str ());
-  }
-  BRepTools::Read (cad_shape, is, builder);
-  is.close ();
-  if (cad_shape.IsNull ()) {
-    SC_ABORTF ("Could not read brep file or brep file contains no shape. "
-               "The cad file may be written with a newer cad version. "
-               "Linked cad version: %s",
-               OCC_VERSION_COMPLETE);
-  }
-  TopExp::MapShapes (cad_shape, TopAbs_VERTEX, cad_shape_vertex_map);
-  TopExp::MapShapes (cad_shape, TopAbs_EDGE, cad_shape_edge_map);
-  TopExp::MapShapes (cad_shape, TopAbs_FACE, cad_shape_face_map);
-  TopExp::MapShapesAndUniqueAncestors (cad_shape, TopAbs_VERTEX, TopAbs_EDGE, cad_shape_vertex2edge_map);
-  TopExp::MapShapesAndUniqueAncestors (cad_shape, TopAbs_EDGE, TopAbs_FACE, cad_shape_edge2face_map);
+  cad_manager = new t8_cad (fileprefix);
 }
 
 t8_geometry_cad::t8_geometry_cad (const TopoDS_Shape cad_shape, std::string name_in)
   : t8_geometry_with_vertices (name_in)
 {
-  if (cad_shape.IsNull ()) {
-    SC_ABORTF ("Shape is null. \n");
-  }
-  TopExp::MapShapes (cad_shape, TopAbs_VERTEX, cad_shape_vertex_map);
-  TopExp::MapShapes (cad_shape, TopAbs_EDGE, cad_shape_edge_map);
-  TopExp::MapShapes (cad_shape, TopAbs_FACE, cad_shape_face_map);
-  TopExp::MapShapesAndUniqueAncestors (cad_shape, TopAbs_VERTEX, TopAbs_EDGE, cad_shape_vertex2edge_map);
-  TopExp::MapShapesAndUniqueAncestors (cad_shape, TopAbs_EDGE, TopAbs_FACE, cad_shape_edge2face_map);
+  cad_manager = new t8_cad (cad_shape);
 }
 
 t8_geometry_cad::t8_geometry_cad (): t8_geometry_with_vertices ("t8_geom_cad")
 {
-  cad_shape.Nullify ();
 }
 
 void
@@ -166,9 +141,6 @@ t8_geometry_cad::t8_geom_evaluate_cad_tri (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
 
   const t8_locidx_t ltreeid = t8_cmesh_get_local_id (cmesh, gtreeid);
   const int num_edges = t8_eclass_num_edges[active_tree_class];
-  Handle_Geom_Curve curve;
-  Handle_Geom_Surface surface;
-  Standard_Real first, last;
   gp_Pnt pnt;
   double displacement;
   double scaling_factor;
@@ -196,7 +168,7 @@ t8_geometry_cad::t8_geom_evaluate_cad_tri (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
    *     /        |     |    /                   |   y
    *    /         |     |   /                   /    |
    *   0----E2----1     |  0---------E2--------1     x--x
-   * 
+   *
    */
 
   /* Linear mapping from ref_coords to out_coords for each reference point */
@@ -250,9 +222,9 @@ t8_geometry_cad::t8_geom_evaluate_cad_tri (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
           t8_geom_linear_interpolation (&ref_intersection[(i_edge == 0) + offset_2d], edge_parameters, 1, 1,
                                         &interpolated_curve_parameter);
           /* Convert the interpolated edge parameter of each reference point to surface parameters */
-          t8_geometry_cad::t8_geom_edge_parameter_to_face_parameters (edges[i_edge], *faces, num_face_nodes,
-                                                                      interpolated_curve_parameter, face_parameters,
-                                                                      converted_edge_surface_parameters + offset_2d);
+          cad_manager->t8_geom_edge_parameter_to_face_parameters (edges[i_edge], *faces, num_face_nodes,
+                                                                  interpolated_curve_parameter, face_parameters,
+                                                                  converted_edge_surface_parameters + offset_2d);
         }
 
         double edge_surface_parameters[4];
@@ -280,28 +252,15 @@ t8_geometry_cad::t8_geom_evaluate_cad_tri (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
             scaled_displacement = displacement * scaling_factor;
             interpolated_surface_parameters[dim + offset_2d] += scaled_displacement;
           }
-          /* Retrieve surface */
-          T8_ASSERT (*faces <= cad_shape_face_map.Size ());
-          surface = BRep_Tool::Surface (TopoDS::Face (cad_shape_face_map.FindKey (*faces)));
-          /* Check if surface is valid */
-          T8_ASSERT (!surface.IsNull ());
 
-          /* Evaluate surface and save result */
-          surface->D0 (interpolated_surface_parameters[offset_2d], interpolated_surface_parameters[offset_2d + 1], pnt);
+          pnt = process_surface (i_edge + num_edges, interpolated_surface_parameters, offset_2d);
 
           for (int dim = 0; dim < 3; ++dim) {
             out_coords[dim + offset_3d] = pnt.Coord (dim + 1);
           }
         }
       }
-      /* Retrieve surface */
-      T8_ASSERT (*faces <= cad_shape_face_map.Size ());
-      surface = BRep_Tool::Surface (TopoDS::Face (cad_shape_face_map.FindKey (*faces)));
-      /* Check if surface is valid */
-      T8_ASSERT (!surface.IsNull ());
-
-      /* Evaluate surface and save result */
-      surface->D0 (interpolated_surface_parameters[0], interpolated_surface_parameters[1], pnt);
+      pnt = process_surface (*faces, interpolated_surface_parameters, 0);
 
       for (int dim = 0; dim < 3; ++dim) {
         out_coords[dim] = pnt.Coord (dim + 1);
@@ -336,27 +295,14 @@ t8_geometry_cad::t8_geom_evaluate_cad_tri (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
             /* Interpolate between the curve parameters of the current edge with the ref_intersection of each reference point */
             t8_geom_linear_interpolation (&ref_intersection[(i_edge == 0) + offset_2d], parameters, 1, 1,
                                           &interpolated_curve_parameter);
-            /* Retrieve curve */
-            T8_ASSERT (edges[i_edge] <= cad_shape_edge_map.Size ());
-            curve = BRep_Tool::Curve (TopoDS::Edge (cad_shape_edge_map.FindKey (edges[i_edge])), first, last);
-            /* Check if curve is valid */
-            T8_ASSERT (!curve.IsNull ());
-
-            /* Calculate point on curve with interpolated parameters. */
-            curve->D0 (interpolated_curve_parameter, pnt);
+            pnt = process_curve (i_edge, interpolated_curve_parameter);
           }
           else {
             /* Interpolate between the surface parameters of the current edge with the ref_intersection of each reference point */
             t8_geom_linear_interpolation (&ref_intersection[(i_edge == 0) + offset_2d], parameters, 2, 1,
                                           interpolated_surface_parameters + offset_2d);
-            T8_ASSERT (edges[i_edge + num_edges] <= cad_shape_face_map.Size ());
-            surface = BRep_Tool::Surface (TopoDS::Face (cad_shape_face_map.FindKey (edges[i_edge + num_edges])));
-            /* Check if surface is valid */
-            T8_ASSERT (!surface.IsNull ());
 
-            /* Compute point on surface with interpolated parameters */
-            surface->D0 (interpolated_surface_parameters[offset_2d], interpolated_surface_parameters[offset_2d + 1],
-                         pnt);
+            pnt = process_surface (i_edge + num_edges, interpolated_surface_parameters, offset_2d);
           }
           /* Determine the scaling factor by calculating the distances from the opposite vertex
           * to the glob_intersection and to the reference point */
@@ -390,9 +336,6 @@ t8_geometry_cad::t8_geom_evaluate_cad_quad (t8_cmesh_t cmesh, t8_gloidx_t gtreei
   const t8_locidx_t ltreeid = t8_cmesh_get_local_id (cmesh, gtreeid);
   const int num_edges = t8_eclass_num_edges[active_tree_class];
   gp_Pnt pnt;
-  Handle_Geom_Curve curve;
-  Handle_Geom_Surface surface;
-  Standard_Real first, last;
 
   /* Check if face has a linked geometry */
   if (*faces > 0) {
@@ -430,7 +373,7 @@ t8_geometry_cad::t8_geom_evaluate_cad_quad (t8_cmesh_t cmesh, t8_gloidx_t gtreei
          *     |                  |    y
          *     |                  |    |
          *     0 -------E2------- 1    x-- x
-         *        
+         *
          */
         const int edge_orthogonal_direction = (i_edge >> 1);
         const int edge_direction = 1 - edge_orthogonal_direction;
@@ -441,22 +384,19 @@ t8_geometry_cad::t8_geom_evaluate_cad_quad (t8_cmesh_t cmesh, t8_gloidx_t gtreei
         const double *edge_parameters = (double *) t8_cmesh_get_attribute (
           cmesh, t8_get_package_id (), T8_CMESH_CAD_EDGE_PARAMETERS_ATTRIBUTE_KEY + i_edge, ltreeid);
         T8_ASSERT (edge_parameters != NULL);
-        T8_ASSERT (edges[i_edge] <= cad_shape_edge_map.Size ());
-
-        curve = BRep_Tool::Curve (TopoDS::Edge (cad_shape_edge_map.FindKey (edges[i_edge])), first, last);
-
-        /* Check if curve is valid */
-        T8_ASSERT (!curve.IsNull ());
 
         for (size_t coord = 0; coord < num_coords; ++coord) {
           const int offset_3d = coord * 3;
           const int offset_2d = coord * 2;
+
           /* Interpolate between curve parameters and surface parameters of the same nodes */
           t8_geom_linear_interpolation (&ref_coords[edge_direction + offset_2d], edge_parameters, 1, 1,
                                         temp_edge_parameters);
 
+          pnt = process_curve (i_edge, temp_edge_parameters[0]);
+
           /* Convert curve parameter to surface parameters */
-          t8_geometry_cad::t8_geom_edge_parameter_to_face_parameters (
+          cad_manager->t8_geom_edge_parameter_to_face_parameters (
             edges[i_edge], *faces, num_face_nodes, temp_edge_parameters[0], face_parameters, temp_edge_parameters);
 
           /* Interpolate between the surface parameters of the current edge */
@@ -480,8 +420,7 @@ t8_geometry_cad::t8_geom_evaluate_cad_quad (t8_cmesh_t cmesh, t8_gloidx_t gtreei
     }
 
     /* Retrieve surface */
-    T8_ASSERT (*faces <= cad_shape_face_map.Size ());
-    surface = BRep_Tool::Surface (TopoDS::Face (cad_shape_face_map.FindKey (*faces)));
+    auto surface = cad_manager->t8_geom_get_cad_surface (*faces);
 
     /* Check if surface is valid */
     T8_ASSERT (!surface.IsNull ());
@@ -519,7 +458,7 @@ t8_geometry_cad::t8_geom_evaluate_cad_quad (t8_cmesh_t cmesh, t8_gloidx_t gtreei
          *     |                  |    y
          *     |                  |    |
          *     0 -------E2------- 1    x-- x
-         *        
+         *
          */
         const int edge_orthogonal_direction = (i_edge >> 1);
         const int edge_direction = 1 - edge_orthogonal_direction;
@@ -537,12 +476,13 @@ t8_geometry_cad::t8_geom_evaluate_cad_quad (t8_cmesh_t cmesh, t8_gloidx_t gtreei
         /* Curves have only one parameter u, surfaces have two, u and v.
          * Therefore, we have to distinguish if the edge has a curve or surface linked to it. */
         if (edges[i_edge] > 0) {
-          /* Get curve */
-          T8_ASSERT (edges[i_edge] <= cad_shape_edge_map.Size ());
-          curve = BRep_Tool::Curve (TopoDS::Edge (cad_shape_edge_map.FindKey (edges[i_edge])), first, last);
+
+          /* Retrieve curve */
+          auto curve = cad_manager->t8_geom_get_cad_curve (edges[i_edge]);
 
           /* Check if curve are valid */
           T8_ASSERT (!curve.IsNull ());
+
           for (size_t coord = 0; coord < num_coords; ++coord) {
             const int offset_3d = coord * 3;
             const int offset_2d = coord * 2;
@@ -570,8 +510,7 @@ t8_geometry_cad::t8_geom_evaluate_cad_quad (t8_cmesh_t cmesh, t8_gloidx_t gtreei
         }
         else {
           /* Get surface */
-          T8_ASSERT (edges[i_edge + num_edges] <= cad_shape_face_map.Size ());
-          surface = BRep_Tool::Surface (TopoDS::Face (cad_shape_face_map.FindKey (edges[i_edge + num_edges])));
+          auto surface = cad_manager->t8_geom_get_cad_surface (edges[i_edge + num_edges]);
 
           /* Check if surface is valid */
           T8_ASSERT (!surface.IsNull ());
@@ -622,9 +561,6 @@ t8_geometry_cad::t8_geom_evaluate_cad_tet (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
   double temp_edge_vertices[2 * 3], temp_face_vertices[T8_ECLASS_MAX_CORNERS_2D * 3], interpolated_curve_param,
     interpolated_surface_params[2], cur_delta[3];
   double interpolated_surface_parameters[2], interpolated_coords[3];
-  Handle_Geom_Curve curve;
-  Handle_Geom_Surface surface;
-  Standard_Real first, last;
 
   for (size_t coord = 0; coord < num_coords; ++coord) {
     const int offset_3d = coord * 3;
@@ -632,16 +568,16 @@ t8_geometry_cad::t8_geom_evaluate_cad_tet (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
     /* Check each edge for a geometry. */
     for (int i_edge = 0; i_edge < num_edges; ++i_edge) {
 
-      /* We have to check for curves as well as surfaces. Linked curves are stored 
-      * in the first half of the array, surfaces in the second. 
-      * If a curve is connected to this edge we have to also check, 
+      /* We have to check for curves as well as surfaces. Linked curves are stored
+      * in the first half of the array, surfaces in the second.
+      * If a curve is connected to this edge we have to also check,
       * if a surface is connected to at least one of the two adjacent faces. */
       if (edges[i_edge] > 0 || edges[i_edge + num_edges] > 0) {
 
         /* Check if only a surface or a curve is present. Abort if both is true. */
         T8_ASSERT (!(edges[i_edge] > 0 && edges[i_edge + num_edges] > 0));
 
-        /* 
+        /*
         *             _0
         *          _- / \
         *       E0   /   \
@@ -670,31 +606,21 @@ t8_geometry_cad::t8_geom_evaluate_cad_tet (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
         /* Interpolate between the parameters of the current edge. Same procedure as above.
         * Curves have only one parameter u, surfaces have two, u and v.
         * Therefore, we have to distinguish if the edge has a curve or surface linked to it. */
+
         if (edges[i_edge] > 0) { /* Check for linked curves */
 
           /* Linear interpolation between parameters */
           t8_geom_linear_interpolation (&interpolation_coeff, parameters, 1, 1, &interpolated_curve_param);
-          T8_ASSERT (edges[i_edge] <= cad_shape_edge_map.Size ());
 
-          /* Retrieve the curve and check if curve is valid */
-          curve = BRep_Tool::Curve (TopoDS::Edge (cad_shape_edge_map.FindKey (edges[i_edge])), first, last);
-          T8_ASSERT (!curve.IsNull ());
-
-          /* Calculate point on curve with the interpolated parameter */
-          curve->D0 (interpolated_curve_param, pnt);
+          pnt = process_curve (i_edge, interpolated_curve_param);
         }
         else { /* Check for linked surfaces */
 
           /* Linear interpolation between parameters */
           t8_geom_linear_interpolation (&interpolation_coeff, parameters, 2, 1, interpolated_surface_params);
-          T8_ASSERT (edges[i_edge + num_edges] <= cad_shape_face_map.Size ());
+          T8_ASSERT (edges[i_edge + num_edges] <= cad_manager->t8_geom_get_cad_shape_face_map ().Size ());
 
-          /* Retrieve the surface and check if surface is valid */
-          surface = BRep_Tool::Surface (TopoDS::Face (cad_shape_face_map.FindKey (edges[i_edge + num_edges])));
-          T8_ASSERT (!surface.IsNull ());
-
-          /* Compute point on surface with interpolated parameters */
-          surface->D0 (interpolated_surface_params[0], interpolated_surface_params[1], pnt);
+          pnt = process_surface (i_edge + num_edges, interpolated_surface_params, 0);
         }
 
         /* Compute displacement between vertex interpolation and curve evaluation with interpolated parameters */
@@ -722,10 +648,10 @@ t8_geometry_cad::t8_geom_evaluate_cad_tet (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
 
       /* Check if face has a linked surface */
       if (faces[i_faces] > 0) {
-        /* 
+        /*
         * The faces of a tetrahedron are numerated in such a way,
-        * that face X is the opposing face to the corner node X. 
-        * 
+        * that face X is the opposing face to the corner node X.
+        *
         *             _0
         *          _- / \
         *       _-   /   \
@@ -746,7 +672,7 @@ t8_geometry_cad::t8_geom_evaluate_cad_tet (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
         double face_intersection[3] = { 0 };
         t8_geom_get_tet_face_intersection (i_faces, ref_coords + offset_3d, face_intersection);
 
-        /* Turn 3D face_intersection into 2D coordinates on current face 
+        /* Turn 3D face_intersection into 2D coordinates on current face
         * for parameter interpolation */
         double face_intersection_2d[2];
         face_intersection_2d[0] = face_intersection[t8_face_ref_coords_tet[i_faces][0]];
@@ -783,13 +709,7 @@ t8_geometry_cad::t8_geom_evaluate_cad_tet (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
             t8_geom_linear_interpolation (interpolation_coeff, edge_vertices_on_face, 3, 1,
                                           interpolated_edge_coordinates);
 
-            /* Retrieve the curve of the edge and check if it is valid */
-            T8_ASSERT (edges[i_tree_edge] <= cad_shape_edge_map.Size ());
-            curve = BRep_Tool::Curve (TopoDS::Edge (cad_shape_edge_map.FindKey (edges[i_tree_edge])), first, last);
-            T8_ASSERT (!curve.IsNull ());
-
-            /* Calculate point on curve with interpolated parameter */
-            curve->D0 (interpolated_curve_param, pnt);
+            pnt = process_curve (i_tree_edge, interpolated_curve_param);
 
             /* Calculate the same scaling factors for the neighbouring faces
             * as in the evaluation of the edges of tetrahedral tree */
@@ -815,13 +735,7 @@ t8_geometry_cad::t8_geom_evaluate_cad_tet (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
           interpolated_coords[dim] += face_displacement_from_edges[dim];
         }
 
-        /* Retrieve the surface and check if it is valid */
-        T8_ASSERT (faces[i_faces] <= cad_shape_face_map.Size ());
-        surface = BRep_Tool::Surface (TopoDS::Face (cad_shape_face_map.FindKey (faces[i_faces])));
-        T8_ASSERT (!surface.IsNull ());
-
-        /* Compute point on surface with interpolated surface parameters */
-        surface->D0 (interpolated_surface_parameters[0], interpolated_surface_parameters[1], pnt);
+        pnt = process_surface (i_faces, interpolated_surface_params, 0);
 
         /* Compute the scaling factor. The scaling happens along the straight from
         * the opposite vertex of the face to the face_intersection. */
@@ -868,18 +782,15 @@ t8_geometry_cad::t8_geom_evaluate_cad_hex (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
   double interpolated_curve_param, interpolated_surface_params[2], cur_delta[3];
   gp_Pnt pnt;
   double interpolation_coeffs[2], temp_face_vertices[T8_ECLASS_MAX_CORNERS_2D * 3], temp_edge_vertices[2 * 3];
-  Handle_Geom_Curve curve;
-  Handle_Geom_Surface surface;
-  Standard_Real first, last;
 
   for (size_t coord = 0; coord < num_coords; ++coord) {
     const int offset_3d = coord * 3;
 
     /* Check each edge for a geometry. */
     for (int i_edge = 0; i_edge < num_edges; ++i_edge) {
-      /* We have to check for curves as well as surfaces. Linked curves are stored 
-      * in the first half of the array, surfaces in the second. 
-      * If a curve is connected to this edge we have to also check, 
+      /* We have to check for curves as well as surfaces. Linked curves are stored
+      * in the first half of the array, surfaces in the second.
+      * If a curve is connected to this edge we have to also check,
       * if a surface is connected to at least one of the two adjacent faces. */
       if (edges[i_edge] > 0 || edges[i_edge + num_edges] > 0) {
         /* Check if only a surface or a curve is present. Abort if both is true. */
@@ -900,7 +811,7 @@ t8_geometry_cad::t8_geom_evaluate_cad_hex (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
         *     | /                | /
         *     |/                 |/
         *     0 -------E0------- 1
-        *        
+        *
         */
         const int edge_direction = i_edge / 4;
         /* Save the edge vertices temporarily. */
@@ -920,28 +831,14 @@ t8_geometry_cad::t8_geom_evaluate_cad_hex (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
           t8_geom_linear_interpolation (&ref_coords[edge_direction + offset_3d], parameters, 1, 1,
                                         &interpolated_curve_param);
 
-          T8_ASSERT (edges[i_edge] <= cad_shape_edge_map.Size ());
-          curve = BRep_Tool::Curve (TopoDS::Edge (cad_shape_edge_map.FindKey (edges[i_edge])), first, last);
-
-          /* Check if curve are valid */
-          T8_ASSERT (!curve.IsNull ());
-
-          /* Calculate point on curve with interpolated parameters. */
-          curve->D0 (interpolated_curve_param, pnt);
+          pnt = process_curve (i_edge, interpolated_curve_param);
         }
         else {
           /* Linear interpolation between parameters */
           t8_geom_linear_interpolation (&ref_coords[edge_direction + offset_3d], parameters, 2, 1,
                                         interpolated_surface_params);
 
-          T8_ASSERT (edges[i_edge + num_edges] <= cad_shape_face_map.Size ());
-          surface = BRep_Tool::Surface (TopoDS::Face (cad_shape_face_map.FindKey (edges[i_edge + num_edges])));
-
-          /* Check if surface is valid */
-          T8_ASSERT (!surface.IsNull ());
-
-          /* Compute point on surface with interpolated parameters */
-          surface->D0 (interpolated_surface_params[0], interpolated_surface_params[1], pnt);
+          pnt = process_surface (i_edge + num_edges, interpolated_surface_params, 0);
         }
 
         /* Compute displacement between vertex interpolation and curve evaluation with interpolated parameters */
@@ -950,9 +847,9 @@ t8_geometry_cad::t8_geom_evaluate_cad_hex (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
         cur_delta[2] = pnt.Z () - interpolated_coords[offset_3d + 2];
 
         /* Multiply curve displacement with corresponding ref coords.
-        * The edges are indexed so that all edges which satisfy i_edge % 4 == 0 
-        * have to multiplied with the inversed (1 - ref_coord) 
-        * coordinate. All edges which satisfy i_edge % 4 == 1 have to multiplied with one 
+        * The edges are indexed so that all edges which satisfy i_edge % 4 == 0
+        * have to multiplied with the inversed (1 - ref_coord)
+        * coordinate. All edges which satisfy i_edge % 4 == 1 have to multiplied with one
         * inversed ref_coord and so forth...
         * An exception are edge 5 and 6, which have to be switched because they do not follow that rule.
         * Edges which are located at ref_coord[i] = 0 have to be multiplied with (1 - ref_coord[i]) and if the
@@ -990,7 +887,7 @@ t8_geometry_cad::t8_geom_evaluate_cad_hex (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
     for (int i_faces = 0; i_faces < num_faces; ++i_faces) {
       /* Check if face has a linked surface */
       if (faces[i_faces] > 0) {
-        /* Allocate some variables and save the normal direction of the face and the face vertices 
+        /* Allocate some variables and save the normal direction of the face and the face vertices
         * in a separate array for later usage. */
         const int face_normal_direction = i_faces / 2;
         t8_geom_get_face_vertices (T8_ECLASS_HEX, active_tree_vertices, i_faces, 3, temp_face_vertices);
@@ -1050,16 +947,8 @@ t8_geometry_cad::t8_geom_evaluate_cad_hex (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
             t8_geom_linear_interpolation (&ref_coords[edge_direction + offset_3d], edge_vertices_on_face, 3, 1,
                                           interpolated_edge_coordinates);
 
-            /* Retrieve the curve of the edge */
-            T8_ASSERT (edges[t8_face_edge_to_tree_edge[T8_ECLASS_HEX][i_faces][i_face_edge]]
-                       <= cad_shape_edge_map.Size ());
-            curve = BRep_Tool::Curve (TopoDS::Edge (cad_shape_edge_map.FindKey (
-                                        edges[t8_face_edge_to_tree_edge[T8_ECLASS_HEX][i_faces][i_face_edge]])),
-                                      first, last);
-            /* Check if curve is valid */
-            T8_ASSERT (!curve.IsNull ());
-            /* Calculate point on curve with interpolated parameters */
-            curve->D0 (interpolated_curve_param, pnt);
+            pnt = process_curve (t8_face_edge_to_tree_edge[T8_ECLASS_HEX][i_faces][i_face_edge],
+                                 interpolated_curve_param);
 
             /* Calculate the displacement generated by the presence of the curve */
             if (i_face_edge % 2 == 0) {
@@ -1076,11 +965,11 @@ t8_geometry_cad::t8_geom_evaluate_cad_hex (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
             }
             /* Convert the interpolated parameter of the curve into the corresponding parameters on the surface */
             const int num_face_nodes = t8_eclass_num_vertices[T8_ECLASS_QUAD];
-            t8_geometry_cad::t8_geom_edge_parameter_to_face_parameters (
+            cad_manager->t8_geom_edge_parameter_to_face_parameters (
               edges[t8_face_edge_to_tree_edge[T8_ECLASS_HEX][i_faces][i_face_edge]], faces[i_faces], num_face_nodes,
               interpolated_curve_param, surface_parameters, surface_parameters_from_curve);
 
-            /* Calculate the displacement between the interpolated parameters on the surface 
+            /* Calculate the displacement between the interpolated parameters on the surface
             * and the parameters on the surface converted from the parameter of the curve
             * and scale them with the corresponding ref coord */
             if (i_face_edge % 2 == 0) {
@@ -1105,7 +994,7 @@ t8_geometry_cad::t8_geom_evaluate_cad_hex (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
         interpolation_coeffs[1] = ref_coords[((face_normal_direction + 2) % 3) + offset_3d];
         /* The normal vectors of the faces 0, 1, 4, 5 of a hex point in the same direction
         * as the corresponding axis (normal(f0) = (1, 0, 0)). The faces 2 and 3 are oriented
-        * in the other direction (normal(f2) = (0, -1, 0)). Therefore we have to switch two 
+        * in the other direction (normal(f2) = (0, -1, 0)). Therefore we have to switch two
         * vertices to change the orientation. Here we switch vertex 1 and 2. */
         double temp_surface_parameters[8];
         memcpy (temp_surface_parameters, surface_parameters, sizeof (double) * 8);
@@ -1139,17 +1028,9 @@ t8_geometry_cad::t8_geom_evaluate_cad_hex (t8_cmesh_t cmesh, t8_gloidx_t gtreeid
           interpolated_surface_params[dim] += surface_parameter_displacement_from_edges[dim];
         }
 
-        /* Retrieve the surface of the edge */
-        T8_ASSERT (faces[i_faces] <= cad_shape_face_map.Size ());
-        surface = BRep_Tool::Surface (TopoDS::Face (cad_shape_face_map.FindKey (faces[i_faces])));
+        pnt = process_surface (i_faces, interpolated_surface_params, 0);
 
-        /* Check if surface is valid */
-        T8_ASSERT (!surface.IsNull ());
-
-        /* Compute point on surface with interpolated parameters */
-        surface->D0 (interpolated_surface_params[0], interpolated_surface_params[1], pnt);
-
-        /* Compute the displacement between surface and interpolated coords, scale them with the appropriate ref_coord 
+        /* Compute the displacement between surface and interpolated coords, scale them with the appropriate ref_coord
         * and add them to the out_coords. */
         if (i_faces % 2 == 0) {
           out_coords[offset_3d]
@@ -1178,10 +1059,10 @@ t8_geometry_cad::t8_geom_evaluate_cad_prism (t8_cmesh_t cmesh, t8_gloidx_t gtree
                                              const size_t num_coords, double *out_coords) const
 {
   T8_ASSERT (active_tree_class == T8_ECLASS_PRISM);
-  /* The array contains the coordinate [x,y,z] to interpolate for each edge of a prism. 
+  /* The array contains the coordinate [x,y,z] to interpolate for each edge of a prism.
    * For example: On edge 0 the interpolation coordinate is y. */
   const int t8_interpolation_coefficient_prism_edge[9] = { 1, 0, 0, 1, 0, 0, 2, 2, 2 };
-  /* The array contains the coordinates [x,y,z] to interpolate for each face of a prism. 
+  /* The array contains the coordinates [x,y,z] to interpolate for each face of a prism.
    * For example: On face 0 the interpolation coordinates are y and z. */
   const int t8_interpolation_coefficients_prism_face[5][2] = { { 1, 2 }, { 0, 2 }, { 0, 2 }, { 0, 1 }, { 0, 1 } };
 
@@ -1193,15 +1074,12 @@ t8_geometry_cad::t8_geom_evaluate_cad_prism (t8_cmesh_t cmesh, t8_gloidx_t gtree
   gp_Pnt pnt;
   double interpolated_coords[3], interpolation_coeffs[3], temp_face_vertices[T8_ECLASS_MAX_CORNERS_2D * 3],
     temp_edge_vertices[2 * 3];
-  Handle_Geom_Curve curve;
-  Handle_Geom_Surface surface;
-  Standard_Real first, last;
 
   /* Check each edge for a geometry. */
   for (int i_edge = 0; i_edge < T8_DPRISM_EDGES; ++i_edge) {
-    /* We have to check for curves as well as surfaces. Linked curves are stored 
-     * in the first half of the array, surfaces in the second. 
-     * If a curve is connected to this edge we have to also check, 
+    /* We have to check for curves as well as surfaces. Linked curves are stored
+     * in the first half of the array, surfaces in the second.
+     * If a curve is connected to this edge we have to also check,
      * if a surface is connected to at least one of the two adjacent faces. */
     if (edges[i_edge] > 0 || edges[i_edge + T8_DPRISM_EDGES] > 0) {
       /* Check if only a surface or a curve is present. Abort if both is true. */
@@ -1212,9 +1090,9 @@ t8_geometry_cad::t8_geom_evaluate_cad_prism (t8_cmesh_t cmesh, t8_gloidx_t gtree
        *     |_-                _- / \
        *     0----x           _-  /   \
        *                    _-   /     \
-       *                  E6   E5      E3 
-       *                _-     /         \ 
-       *              _-      /           \ 
+       *                  E6   E5      E3
+       *                _-     /         \
+       *              _-      /           \
        *            _-      _3-----E4----_-5
        *           1      _-           _-
        *          / \   E8           _-
@@ -1248,28 +1126,14 @@ t8_geometry_cad::t8_geom_evaluate_cad_prism (t8_cmesh_t cmesh, t8_gloidx_t gtree
           t8_geom_linear_interpolation (&ref_coords[t8_interpolation_coefficient_prism_edge[i_edge] + offset_3d],
                                         parameters, 1, 1, &interpolated_curve_param);
 
-          T8_ASSERT (edges[i_edge] <= cad_shape_edge_map.Size ());
-          curve = BRep_Tool::Curve (TopoDS::Edge (cad_shape_edge_map.FindKey (edges[i_edge])), first, last);
-
-          /* Check if curve are valid */
-          T8_ASSERT (!curve.IsNull ());
-
-          /* Compute point on curve with interpolated parameters. */
-          curve->D0 (interpolated_curve_param, pnt);
+          pnt = process_curve (i_edge, interpolated_curve_param);
         }
         else {
           /* Linear interpolation between parameters */
           t8_geom_linear_interpolation (&ref_coords[t8_interpolation_coefficient_prism_edge[i_edge] + offset_3d],
                                         parameters, 2, 1, interpolated_surface_params);
 
-          T8_ASSERT (edges[i_edge + T8_DPRISM_EDGES] <= cad_shape_face_map.Size ());
-          surface = BRep_Tool::Surface (TopoDS::Face (cad_shape_face_map.FindKey (edges[i_edge + T8_DPRISM_EDGES])));
-
-          /* Check if surface is valid */
-          T8_ASSERT (!surface.IsNull ());
-
-          /* Compute point on surface with interpolated parameters */
-          surface->D0 (interpolated_surface_params[0], interpolated_surface_params[1], pnt);
+          pnt = process_surface (i_edge + T8_DPRISM_EDGES, interpolated_surface_params, 0);
         }
 
         /* Compute displacement between vertex interpolation and curve evaluation with interpolated parameters */
@@ -1337,13 +1201,7 @@ t8_geometry_cad::t8_geom_evaluate_cad_prism (t8_cmesh_t cmesh, t8_gloidx_t gtree
             t8_geom_linear_interpolation (&ref_coords[interpolation_coeff + offset_3d], edge_vertices_on_face, 3, 1,
                                           interpolated_edge_coordinates);
 
-            /* Retrieve the curve of the edge */
-            T8_ASSERT (edges[i_tree_edge] <= cad_shape_edge_map.Size ());
-            curve = BRep_Tool::Curve (TopoDS::Edge (cad_shape_edge_map.FindKey (edges[i_tree_edge])), first, last);
-            /* Check if curve is valid */
-            T8_ASSERT (!curve.IsNull ());
-            /* Calculate point on curve with interpolated parameters */
-            curve->D0 (interpolated_curve_param, pnt);
+            pnt = process_curve (i_tree_edge, interpolated_curve_param);
 
             /* Compute the scaling_factor of the edge displacement on the current face */
             double scaling_factor = t8_geom_get_scaling_factor_of_edge_on_face_prism (
@@ -1376,17 +1234,9 @@ t8_geometry_cad::t8_geom_evaluate_cad_prism (t8_cmesh_t cmesh, t8_gloidx_t gtree
           interpolated_coords[dim] += face_displacement_from_edges[dim];
         }
 
-        /* Retrieve the surface of the edge */
-        T8_ASSERT (faces[i_faces] <= cad_shape_face_map.Size ());
-        surface = BRep_Tool::Surface (TopoDS::Face (cad_shape_face_map.FindKey (faces[i_faces])));
+        pnt = process_surface (i_faces, interpolated_surface_params, 0);
 
-        /* Check if surface is valid */
-        T8_ASSERT (!surface.IsNull ());
-
-        /* Compute point on surface with interpolated parameters */
-        surface->D0 (interpolated_surface_params[0], interpolated_surface_params[1], pnt);
-
-        /* Compute the displacement between surface and interpolated coords, scale them with the appropriate scaling_factor 
+        /* Compute the displacement between surface and interpolated coords, scale them with the appropriate scaling_factor
          * and add them to the out_coords. */
         double scaling_factor = t8_geom_get_scaling_factor_face_through_volume_prism (i_faces, ref_coords + offset_3d);
 
@@ -1395,236 +1245,6 @@ t8_geometry_cad::t8_geom_evaluate_cad_prism (t8_cmesh_t cmesh, t8_gloidx_t gtree
         out_coords[offset_3d + 2] += (pnt.Z () - interpolated_coords[2]) * scaling_factor;
       }
     }
-  }
-}
-
-int
-t8_geometry_cad::t8_geom_is_line (const int curve_index) const
-{
-  const Handle_Geom_Curve curve = t8_geom_get_cad_curve (curve_index);
-  const GeomAdaptor_Curve curve_adaptor (curve);
-  return curve_adaptor.GetType () == GeomAbs_Line;
-}
-
-int
-t8_geometry_cad::t8_geom_is_plane (const int surface_index) const
-{
-  const Handle_Geom_Surface surface = t8_geom_get_cad_surface (surface_index);
-  const GeomAdaptor_Surface surface_adaptor (surface);
-  return surface_adaptor.GetType () == GeomAbs_Plane;
-}
-
-const gp_Pnt
-t8_geometry_cad::t8_geom_get_cad_point (const int index) const
-{
-  T8_ASSERT (index <= cad_shape_vertex_map.Size ());
-  return BRep_Tool::Pnt (TopoDS::Vertex (cad_shape_vertex_map.FindKey (index)));
-}
-
-const Handle_Geom_Curve
-t8_geometry_cad::t8_geom_get_cad_curve (const int index) const
-{
-  T8_ASSERT (index <= cad_shape_edge_map.Size ());
-  Standard_Real first, last;
-  return BRep_Tool::Curve (TopoDS::Edge (cad_shape_edge_map.FindKey (index)), first, last);
-}
-
-const Handle_Geom_Surface
-t8_geometry_cad::t8_geom_get_cad_surface (const int index) const
-{
-  T8_ASSERT (index <= cad_shape_face_map.Size ());
-  return BRep_Tool::Surface (TopoDS::Face (cad_shape_face_map.FindKey (index)));
-}
-
-const TopTools_IndexedMapOfShape
-t8_geometry_cad::t8_geom_get_cad_shape_vertex_map () const
-{
-  return cad_shape_vertex_map;
-}
-
-const TopTools_IndexedMapOfShape
-t8_geometry_cad::t8_geom_get_cad_shape_edge_map () const
-{
-  return cad_shape_edge_map;
-}
-
-const TopTools_IndexedMapOfShape
-t8_geometry_cad::t8_geom_get_cad_shape_face_map () const
-{
-  return cad_shape_face_map;
-}
-
-int
-t8_geometry_cad::t8_geom_get_common_edge (const int vertex1_index, const int vertex2_index) const
-{
-  const TopTools_ListOfShape collection1 = cad_shape_vertex2edge_map.FindFromIndex (vertex1_index);
-  const TopTools_ListOfShape collection2 = cad_shape_vertex2edge_map.FindFromIndex (vertex2_index);
-
-  for (auto edge1 = collection1.begin (); edge1 != collection1.end (); ++edge1) {
-    for (auto edge2 = collection2.begin (); edge2 != collection2.end (); ++edge2) {
-      if (edge1->IsEqual (*edge2)) {
-        return cad_shape_edge2face_map.FindIndex (*edge1);
-      }
-    }
-  }
-  return 0;
-}
-
-int
-t8_geometry_cad::t8_geom_get_common_face (const int edge1_index, const int edge2_index) const
-{
-  const TopTools_ListOfShape collection1 = cad_shape_edge2face_map.FindFromIndex (edge1_index);
-  const TopTools_ListOfShape collection2 = cad_shape_edge2face_map.FindFromIndex (edge2_index);
-
-  for (auto face1 = collection1.begin (); face1 != collection1.end (); ++face1) {
-    for (auto face2 = collection2.begin (); face2 != collection2.end (); ++face2) {
-      if (face1->IsEqual (*face2)) {
-        return cad_shape_face_map.FindIndex (*face1);
-      }
-    }
-  }
-  return 0;
-}
-
-int
-t8_geometry_cad::t8_geom_is_vertex_on_edge (const int vertex_index, const int edge_index) const
-{
-  const TopTools_ListOfShape collection = cad_shape_vertex2edge_map.FindFromIndex (vertex_index);
-  return collection.Contains (cad_shape_edge_map.FindKey (edge_index));
-}
-
-int
-t8_geometry_cad::t8_geom_is_edge_on_face (const int edge_index, const int face_index) const
-{
-  const TopTools_ListOfShape collection = cad_shape_edge2face_map.FindFromIndex (edge_index);
-  return collection.Contains (cad_shape_face_map.FindKey (face_index));
-}
-
-int
-t8_geometry_cad::t8_geom_is_vertex_on_face (const int vertex_index, const int face_index) const
-{
-  const TopTools_ListOfShape edge_collection = cad_shape_vertex2edge_map.FindFromIndex (vertex_index);
-  for (auto edge = edge_collection.begin (); edge != edge_collection.end (); ++edge) {
-    const TopTools_ListOfShape face_collection = cad_shape_edge2face_map.FindFromKey (*edge);
-    if (face_collection.Contains (cad_shape_face_map.FindKey (face_index))) {
-      return 1;
-    }
-  }
-  return 0;
-}
-
-void
-t8_geometry_cad::t8_geom_get_parameter_of_vertex_on_edge (const int vertex_index, const int edge_index,
-                                                          double *edge_param) const
-{
-  T8_ASSERT (t8_geometry_cad::t8_geom_is_vertex_on_edge (vertex_index, edge_index));
-  TopoDS_Vertex vertex = TopoDS::Vertex (cad_shape_vertex_map.FindKey (vertex_index));
-  TopoDS_Edge edge = TopoDS::Edge (cad_shape_edge_map.FindKey (edge_index));
-  *edge_param = BRep_Tool::Parameter (vertex, edge);
-}
-
-void
-t8_geometry_cad::t8_geom_get_parameters_of_vertex_on_face (const int vertex_index, const int face_index,
-                                                           double *face_params) const
-{
-  T8_ASSERT (t8_geometry_cad::t8_geom_is_vertex_on_face (vertex_index, face_index));
-  gp_Pnt2d uv;
-  TopoDS_Vertex vertex = TopoDS::Vertex (cad_shape_vertex_map.FindKey (vertex_index));
-  TopoDS_Face face = TopoDS::Face (cad_shape_face_map.FindKey (face_index));
-  uv = BRep_Tool::Parameters (vertex, face);
-  face_params[0] = uv.X ();
-  face_params[1] = uv.Y ();
-}
-
-void
-t8_geometry_cad::t8_geom_edge_parameter_to_face_parameters (const int edge_index, const int face_index,
-                                                            const int num_face_nodes, const double edge_param,
-                                                            const double *surface_params, double *face_params) const
-{
-  T8_ASSERT (t8_geometry_cad::t8_geom_is_edge_on_face (edge_index, face_index));
-  Standard_Real first, last;
-  gp_Pnt2d uv;
-  TopoDS_Edge edge = TopoDS::Edge (cad_shape_edge_map.FindKey (edge_index));
-  TopoDS_Face face = TopoDS::Face (cad_shape_face_map.FindKey (face_index));
-  Handle_Geom2d_Curve curve_on_surface = BRep_Tool::CurveOnSurface (edge, face, first, last);
-  Handle_Geom_Surface surface = BRep_Tool::Surface (face);
-  curve_on_surface->D0 (edge_param, uv);
-  face_params[0] = uv.X ();
-  face_params[1] = uv.Y ();
-
-  /* Check for right conversion of edge to surface parameter and correct if needed */
-  /* Checking u parameter */
-  if (surface_params != NULL) {
-    double parametric_bounds[4];
-    surface->Bounds (parametric_bounds[0], parametric_bounds[1], parametric_bounds[2], parametric_bounds[3]);
-    if (surface->IsUClosed ()) {
-      for (int i_face_node = 0; i_face_node < num_face_nodes; ++i_face_node) {
-        if (surface_params[i_face_node * 2] == parametric_bounds[0]) {
-          if (face_params[0] == parametric_bounds[1]) {
-            face_params[0] = parametric_bounds[0];
-          }
-        }
-        else if (surface_params[i_face_node * 2] == parametric_bounds[1]) {
-          if (face_params[0] == parametric_bounds[0]) {
-            face_params[0] = parametric_bounds[1];
-          }
-        }
-      }
-    }
-    /* Checking v parameter */
-    if (surface->IsVClosed ()) {
-      for (int i_face_node = 0; i_face_node < num_face_nodes; ++i_face_node) {
-        if (surface_params[i_face_node * 2 + 1] == parametric_bounds[0]) {
-          if (face_params[1] == parametric_bounds[1]) {
-            face_params[1] = parametric_bounds[0];
-          }
-        }
-        else if (surface_params[i_face_node * 2 + 1] == parametric_bounds[1]) {
-          if (face_params[1] == parametric_bounds[0]) {
-            face_params[1] = parametric_bounds[1];
-          }
-        }
-      }
-    }
-  }
-}
-
-void
-t8_geometry_cad::t8_geom_get_face_parametric_bounds (const int surface_index, double *bounds) const
-{
-  const Handle_Geom_Surface cad_surface = t8_geom_get_cad_surface (surface_index);
-  cad_surface->Bounds (bounds[0], bounds[1], bounds[2], bounds[3]);
-}
-
-void
-t8_geometry_cad::t8_geom_get_edge_parametric_bounds (const int edge_index, double *bounds) const
-{
-  const Handle_Geom_Curve cad_edge = t8_geom_get_cad_curve (edge_index);
-  bounds[0] = cad_edge->FirstParameter ();
-  bounds[1] = cad_edge->LastParameter ();
-}
-
-int
-t8_geometry_cad::t8_geom_is_edge_closed (int edge_index) const
-{
-  const Handle_Geom_Curve cad_edge = t8_geom_get_cad_curve (edge_index);
-  return cad_edge->IsClosed ();
-}
-
-int
-t8_geometry_cad::t8_geom_is_surface_closed (int geometry_index, int parameter) const
-{
-  const Handle_Geom_Surface cad_surface = t8_geom_get_cad_surface (geometry_index);
-  switch (parameter) {
-  case 0:
-    return cad_surface->IsUClosed ();
-    break;
-  case 1:
-    return cad_surface->IsVClosed ();
-    break;
-  default:
-    SC_ABORT_NOT_REACHED ();
-    break;
   }
 }
 
@@ -1648,6 +1268,40 @@ t8_geometry_cad_destroy (t8_geometry_cad_c **geom)
 
   delete *geom;
   *geom = NULL;
+}
+
+gp_Pnt
+t8_geometry_cad::process_curve (const int edge_index, const double interpolated_curve_param) const
+{
+  gp_Pnt pnt;
+
+  /* Retrieve the curve of the edge */
+  auto curve = cad_manager->t8_geom_get_cad_curve (edges[edge_index]);
+
+  /* Check if curve is valid */
+  T8_ASSERT (!curve.IsNull ());
+
+  /* Calculate point on curve with interpolated parameters */
+  curve->D0 (interpolated_curve_param, pnt);
+
+  return pnt;
+}
+gp_Pnt
+t8_geometry_cad::process_surface (const int face_index, const double *interpolated_surface_params,
+                                  const int offset) const
+{
+  gp_Pnt pnt;
+
+  /* Retrieve the surface of the edge */
+  auto surface = cad_manager->t8_geom_get_cad_surface (faces[face_index]);
+
+  /* Check if surface is valid */
+  T8_ASSERT (!surface.IsNull ());
+
+  /* Compute point on surface with interpolated parameters */
+  surface->D0 (interpolated_surface_params[offset], interpolated_surface_params[offset + 1], pnt);
+
+  return pnt;
 }
 
 T8_EXTERN_C_END ();

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.hxx
@@ -34,7 +34,7 @@
 #include <t8_cmesh/t8_cmesh_types.h>
 #include <t8_geometry/t8_geometry_implementations/t8_geometry_cad.h>
 #include <t8_data/t8_cad.hxx>
-
+#include <memory>
 #include <TopoDS_Shape.hxx>
 #include <TopExp.hxx>
 #include <gp_Pnt.hxx>
@@ -142,7 +142,7 @@ struct t8_geometry_cad: public t8_geometry_with_vertices
     return true;
   }
 
-  t8_cad *
+  std::shared_ptr<t8_cad>
   get_cad_manager () const
   {
     return cad_manager;
@@ -212,7 +212,7 @@ struct t8_geometry_cad: public t8_geometry_with_vertices
   const int *edges; /**< The linked edges of the currently active tree. */
   const int *faces; /**< The linked faces of the currently active tree. */
 
-  t8_cad *cad_manager; /**< The CAD manager of the geometry. */
+  std::shared_ptr<t8_cad> cad_manager; /**< The CAD manager of the geometry. */
 
   gp_Pnt
   process_curve (const int edge_index, const double interpolated_curve_param) const;

--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.hxx
@@ -3,7 +3,7 @@
   t8code is a C library to manage a collection (a forest) of multiple
   connected adaptive space-trees of general element classes in parallel.
 
-  Copyright (C) 2015 the developers
+  Copyright (C) 2025 the developers
 
   t8code is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -33,6 +33,7 @@
 #include <t8_geometry/t8_geometry_with_vertices.hxx>
 #include <t8_cmesh/t8_cmesh_types.h>
 #include <t8_geometry/t8_geometry_implementations/t8_geometry_cad.h>
+#include <t8_data/t8_cad.hxx>
 
 #include <TopoDS_Shape.hxx>
 #include <TopExp.hxx>
@@ -141,165 +142,11 @@ struct t8_geometry_cad: public t8_geometry_with_vertices
     return true;
   }
 
-  /** Check if a cad_curve is a line.
-   * \param [in] curve_index      The index of the cad_curve.
-   * \return                      1 if curve is a line, 0 if curve is not a line.
-   */
-  int
-  t8_geom_is_line (const int curve_index) const;
-
-  /** Check if a cad_surface is a plane.
-   * \param [in] surface_index      The index of the cad_surface.
-   * \return                        1 if surface is a plane linear, 0 if surface is not a plane.
-   */
-  int
-  t8_geom_is_plane (const int surface_index) const;
-
-  /** Get an cad point from the cad_shape.
-   * \param [in] index      The index of the point in the cad_shape.
-   * \return                The cad point.
-   */
-  const gp_Pnt
-  t8_geom_get_cad_point (const int index) const;
-
-  /** Get an cad curve from the cad_shape.
-   * \param [in] index      The index of the curve in the cad_shape.
-   * \return                The cad curve.
-   */
-  const Handle_Geom_Curve
-  t8_geom_get_cad_curve (const int index) const;
-
-  /** Get an cad surface from the cad_shape.
-   * \param [in] index      The index of the surface in the cad_shape.
-   * \return                The cad surface.
-   */
-  const Handle_Geom_Surface
-  t8_geom_get_cad_surface (const int index) const;
-
-  /** Get the cad_shape_vertex2edge_map.
-   * \return                The cad_shape_vertex_map.
-   */
-  const TopTools_IndexedMapOfShape
-  t8_geom_get_cad_shape_vertex_map () const;
-
-  /** Get the cad_shape_edge2face_map.
-   * \return                The cad_shape_edge_map.
-   */
-  const TopTools_IndexedMapOfShape
-  t8_geom_get_cad_shape_edge_map () const;
-
-  /** Get the cad_shape_face_map.
-   * \return                The cad_shape_face_map.
-   */
-  const TopTools_IndexedMapOfShape
-  t8_geom_get_cad_shape_face_map () const;
-
-  /** Check if two cad points share a common cad edge.
-   * \param [in]  vertex1_index  The index of the first cad point.
-   * \param [in]  vertex2_index  The index of the second cad point.
-   * \return                    Index of the shared edge. 0 if there is no shared edge.
-   */
-  int
-  t8_geom_get_common_edge (const int vertex1_index, const int vertex2_index) const;
-
-  /** Check if two cad edges share a common cad face.
-   * \param [in]  edge1_index    The index of the first cad edge.
-   * \param [in]  edge2_index    The index of the second cad edge.
-   * \return                    Index of the shared face. 0 if there is no shared face.
-   */
-  int
-  t8_geom_get_common_face (const int edge1_index, const int edge2_index) const;
-
-  /** Check if a cad vertex lies on an cad edge.
-   * \param [in]  vertex_index   The index of the cad vertex.
-   * \param [in]  edge_index     The index of the cad edge.
-   * \return                    1 if vertex lies on edge, otherwise 0.
-   */
-  int
-  t8_geom_is_vertex_on_edge (const int vertex_index, const int edge_index) const;
-
-  /** Check if a cad vertex lies on an cad edge.
-   * \param [in]  edge_index     The index of the cad vertex.
-   * \param [in]  face_index     The index of the cad edge.
-   * \return                    1 if vertex lies on edge, otherwise 0.
-   */
-  int
-  t8_geom_is_edge_on_face (const int edge_index, const int face_index) const;
-
-  /** Check if a cad vertex lies on an cad face.
-   * \param [in]  vertex_index   The index of the cad vertex.
-   * \param [in]  face_index     The index of the cad face.
-   * \return                    1 if vertex lies on face, otherwise 0.
-   */
-  int
-  t8_geom_is_vertex_on_face (const int vertex_index, const int face_index) const;
-
-  /** Retrieves the parameter of an cad vertex on an cad edge.
-   *  The vertex has to lie on the edge.
-   * \param [in]  vertex_index   The index of the cad vertex.
-   * \param [in]  edge_index     The index of the cad edge.
-   * \param [out] edge_param     The parameter of the vertex on the edge.
-   */
-  void
-  t8_geom_get_parameter_of_vertex_on_edge (const int vertex_index, const int edge_index, double *edge_param) const;
-
-  /** Retrieves the parameters of an cad vertex on a cad face.
-   *  The vertex has to lie on the face.
-   * \param [in]  vertex_index   The index of the cad vertex.
-   * \param [in]  face_index     The index of the cad face.
-   * \param [out] face_params    The parameters of the vertex on the face.
-   */
-  void
-  t8_geom_get_parameters_of_vertex_on_face (const int vertex_index, const int face_index, double *face_params) const;
-
-  /** Converts the parameters of an cad edge to the corresponding parameters on an cad face.
-   * The edge has to lie on the face.
-   * For the conversion of edge parameters of mesh elements to topological face parameters of a closed surface, it is additionally
-   * checked, whether the conversion was correct, to prevent disorted elements.
-   * \param [in]  edge_index     The index of the cad edge, which parameters should be converted to face parameters.
-   * \param [in]  face_index     The index of the cad face, on to which the edge parameters should be converted.
-   * \param [in]  num_face_nodes The number of the face nodes of the evaluated element. Only needed for closed surface check, otherwise NULL.
-   * \param [in]  edge_param     The parameter on the edge.
-   * \param [in]  surface_params The parameters of the surface nodes.
-   *                             When provided, there are additional checks for closed geometries.
-   *                             If there are no surface parameter
-   *                             to pass in to the function, you can pass NULL.
-   * \param [out] face_params    The corresponding parameters on the face.
-   */
-  void
-  t8_geom_edge_parameter_to_face_parameters (const int edge_index, const int face_index, const int num_face_nodes,
-                                             const double edge_param, const double *surface_params,
-                                             double *face_params) const;
-
-  /** Finds the parametric bounds of an cad face.
-   * \param [in]  surface_index   The index of the cad face.
-   * \param [out] bounds          The parametric bounds of the cad face.
-   */
-  void
-  t8_geom_get_face_parametric_bounds (const int surface_index, double *bounds) const;
-
-  /** Finds the parametric bounds of an cad edge.
-   * \param [in]  edge_index   The index of the cad edge.
-   * \param [out] bounds       The parametric bounds of the cad edge.
-   */
-  void
-  t8_geom_get_edge_parametric_bounds (const int edge_index, double *bounds) const;
-
-  /** Checks if an edge is closed in its U parameter.
-   * \param [in]  edge_index   The index of the closed edge.
-   * \return                   1 if edge is closed in U. 0 if edge is not closed in U.
-   */
-  int
-  t8_geom_is_edge_closed (int edge_index) const;
-
-  /** Checks if a surface is closed in its U parameter or V parameter.
-   * \param [in]  geometry_index   The index of the closed geometry.
-   * \param [in]  parameter        The parameter, which should be check for closeness.
-   *                               0 stands for the U parameter and 1 for the V parameter.
-   * \return                       1 if geometry is closed in U. 0 if geometry is not closed in U.
-   */
-  int
-  t8_geom_is_surface_closed (int geometry_index, int parameter) const;
+  t8_cad *
+  get_cad_manager () const
+  {
+    return cad_manager;
+  }
 
  private:
   /**
@@ -362,16 +209,16 @@ struct t8_geometry_cad: public t8_geometry_with_vertices
   t8_geom_evaluate_cad_prism (t8_cmesh_t cmesh, t8_gloidx_t gtreeid, const double *ref_coords, const size_t num_coords,
                               double *out_coords) const;
 
-  const int *edges;                                /**< The linked edges of the currently active tree. */
-  const int *faces;                                /**< The linked faces of the currently active tree. */
-  TopoDS_Shape cad_shape;                          /**< cad geometry */
-  TopTools_IndexedMapOfShape cad_shape_vertex_map; /**< Map of all TopoDS_Vertex in shape. */
-  TopTools_IndexedMapOfShape cad_shape_edge_map;   /**< Map of all TopoDS_Edge in shape. */
-  TopTools_IndexedMapOfShape cad_shape_face_map;   /**< Map of all TopoDS_Face in shape. */
-  TopTools_IndexedDataMapOfShapeListOfShape
-    cad_shape_vertex2edge_map; /**< Maps all TopoDS_Vertex of shape to all its connected TopoDS_Edge */
-  TopTools_IndexedDataMapOfShapeListOfShape
-    cad_shape_edge2face_map; /**< Maps all TopoDS_Edge of shape to all its connected TopoDS_Face */
+  const int *edges; /**< The linked edges of the currently active tree. */
+  const int *faces; /**< The linked faces of the currently active tree. */
+
+  t8_cad *cad_manager; /**< The CAD manager of the geometry. */
+
+  gp_Pnt
+  process_curve (const int edge_index, const double interpolated_curve_param) const;
+
+  gp_Pnt
+  process_surface (const int face_index, const double *interpolated_surface_params, const int offset) const;
 };
 
 #endif /* !T8_GEOMETRY_CAD_HXX */


### PR DESCRIPTION
**_Describe your changes here:_**

Creates a new class `t8_cad` which now manages the OCC shapes. This way the geometry isn't the sole owner anymore and the shapes can be re-used in other parts of t8code.
closes #1825

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).