### PR TITLE
fix doxygen in t8_forest/t8_forest_search

### DIFF
--- a/src/t8_forest/t8_forest_search/t8_forest_search.cxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.cxx
@@ -151,7 +151,7 @@ T8_EXTERN_C_BEGIN ();
  */
 struct t8_forest_c_search
 {
-  t8_search<void *> *cpp_search;    /**< The C++ search object. */
+  t8_search<void *> *cpp_search; /**< The C++ search object. */
 };
 
 void
@@ -199,7 +199,7 @@ t8_forest_search_destroy (t8_forest_search_c_wrapper search)
  */
 struct t8_forest_search_with_queries
 {
-  t8_search_with_queries<void *, void *> *cpp_search;   /**< The C++ search object with queries. */
+  t8_search_with_queries<void *, void *> *cpp_search; /**< The C++ search object with queries. */
 };
 
 void
@@ -270,8 +270,8 @@ t8_forest_search_with_queries_destroy (t8_forest_search_with_queries_c_wrapper s
  */
 struct t8_forest_search_with_batched_queries
 {
-  t8_search_with_batched_queries<void *, void *> *cpp_search;     /**< The C++ search object. */
-  t8_search_batched_queries_callback_c_wrapper queries_callback;  /**< The C++ query object. */
+  t8_search_with_batched_queries<void *, void *> *cpp_search;    /**< The C++ search object. */
+  t8_search_batched_queries_callback_c_wrapper queries_callback; /**< The C++ query object. */
 
   /**
    * A wrapper function that converts the C callback to the C++ callback.

--- a/src/t8_forest/t8_forest_search/t8_forest_search.cxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.cxx
@@ -146,9 +146,12 @@ t8_search_base::do_search ()
 /* #################### t8_forest_search c interface #################### */
 T8_EXTERN_C_BEGIN ();
 
+/**
+ * The structure that contains the C++ search object. Needed for the C interface.
+ */
 struct t8_forest_c_search
 {
-  t8_search<void *> *cpp_search;
+  t8_search<void *> *cpp_search;    /**< The C++ search object. */
 };
 
 void
@@ -191,9 +194,12 @@ t8_forest_search_destroy (t8_forest_search_c_wrapper search)
   search->cpp_search = NULL;
 }
 
+/**
+ * The structure that contains the C++ search object with queries. Needed for the C interface.
+ */
 struct t8_forest_search_with_queries
 {
-  t8_search_with_queries<void *, void *> *cpp_search;
+  t8_search_with_queries<void *, void *> *cpp_search;   /**< The C++ search object with queries. */
 };
 
 void
@@ -259,11 +265,27 @@ t8_forest_search_with_queries_destroy (t8_forest_search_with_queries_c_wrapper s
   search->cpp_search = NULL;
 }
 
+/**
+ * The structure that contains the C++ search object with batched queries. Needed for the C interface.
+ */
 struct t8_forest_search_with_batched_queries
 {
-  t8_search_with_batched_queries<void *, void *> *cpp_search;
-  t8_search_batched_queries_callback_c_wrapper queries_callback;
+  t8_search_with_batched_queries<void *, void *> *cpp_search;     /**< The C++ search object. */
+  t8_search_batched_queries_callback_c_wrapper queries_callback;  /**< The C++ query object. */
 
+  /**
+   * A wrapper function that converts the C callback to the C++ callback.
+   * \param[in] forest                  the forest on which the search is performed
+   * \param[in] ltreeid                 the local tree id of the tree being searched
+   * \param[in] element                 the element being searched
+   * \param[in] is_leaf                 whether the element is a leaf
+   * \param[in] leaf_elements           the array of leaf elements
+   * \param[in] tree_leaf_index         the index of the first leaf in the tree
+   * \param[in] queries                 a vector of pointers to the queries
+   * \param[in] active_query_indices    a vector of indices of the active queries
+   * \param[out] query_matches          a vector of booleans indicating whether each query matched
+   * \param[in] user_data               a pointer to user data
+   */
   void
   wrapped_queries_callback (const t8_forest_t forest, const t8_locidx_t ltreeid, const t8_element_t *element,
                             const bool is_leaf, const t8_element_array_t *leaf_elements,

--- a/src/t8_forest/t8_forest_search/t8_forest_search.h
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.h
@@ -32,16 +32,61 @@
 
 T8_EXTERN_C_BEGIN ();
 
+/**
+ * A call-back function used by \ref t8_forest_init_search for searching elements. Is called on an element and the
+ * search criterion should be checked on that element. Return true if the search criterion is met, false otherwise.
+ * 
+ * \param[in] forest              the forest
+ * \param[in] ltreeid             the local tree id of the current tree in the cmesh.
+ * \param[in] element             the element for which the search criterion is checked
+ * \param[in] is_leaf             true if and only if \a element is a leaf element
+ * \param[in] leaf_elements       the leaf elements in \a forest
+ * \param[in] tree_leaf_index     the local index of the first leaf in \a leaf_elements
+ * \param[in] user_data           a user data pointer that can be set by the user
+ * \returns                       non-zero if the search criterion is met, zero otherwise.
+ */
 typedef int (*t8_search_element_callback_c_wrapper) (t8_forest_t forest, const t8_locidx_t ltreeid,
                                                      const t8_element_t *element, const int is_leaf,
                                                      const t8_element_array_t *leaf_elements,
                                                      const t8_locidx_t tree_leaf_index, void *user_data);
 
+/** A call-back function used by \ref t8_forest_init_search_with_queries for searching elements and
+ * executing queries. Is called on an element and all queries are checked on that element. All positive
+ * queries are passed further down to the children of the element up to leaf elements of the tree.
+ * The results of the check are stored in \a query_matches.
+ * 
+ * \param[in] forest              the forest
+ * \param[in] ltreeid             the local tree id of the current tree in the cmesh.
+ * \param[in] element             the element for which the search criterion is checked
+ * \param[in] is_leaf             true if and only if \a element is a leaf element
+ * \param[in] leaf_elements       the leaf elements in \a forest
+ * \param[in] tree_leaf_index     the local index of the first leaf in \a leaf_elements
+ * \param[in] queries             a pointer to an array of queries
+ * \param[in] user_data           a user data pointer that can be set by the user
+ */
 typedef int (*t8_search_queries_callback_c_wrapper) (t8_forest_t forest, const t8_locidx_t ltreeid,
                                                      const t8_element_t *element, const int is_leaf,
                                                      const t8_element_array_t *leaf_elements,
                                                      const t8_locidx_t tree_leaf_index, void *queries, void *user_data);
 
+/** A call-back function used by \ref t8_forest_init_search_with_batched_queries for searching elements and
+ * executing batched queries. Is called on an element and all queries are checked on that element. All positive
+ * queries are passed further down to the children of the element up to leaf elements of the tree.
+ * The results of the check are stored in \a query_matches.
+ * 
+ * \param[in] forest              the forest
+ * \param[in] ltreeid             the local tree id of the current tree in the cmesh.
+ * \param[in] element             the element for which the search criterion is checked
+ * \param[in] is_leaf             true if and only if \a element is a leaf element
+ * \param[in] leaf_elements       the leaf elements in \a forest
+ * \param[in] tree_leaf_index     the local index of the first leaf in \a leaf_elements
+ * \param[in] queries             a pointer to an array of queries
+ * \param[in] active_query_indices a pointer to an array of indices of active queries in \a queries
+ * \param[in,out] query_matches   a pointer to an array of length \a num_active_queries.
+ *                                If query_matches[i] is true, then the element 'matches' the query of the
+ *                                active query with index active_query_indices[i].
+ * \param[in] user_data           a user data pointer that can be set by the user
+ */
 typedef void (*t8_search_batched_queries_callback_c_wrapper) (t8_forest_t forest, const t8_locidx_t ltreeid,
                                                               const t8_element_t *element, const int is_leaf,
                                                               const t8_element_array_t *leaf_elements,
@@ -49,59 +94,155 @@ typedef void (*t8_search_batched_queries_callback_c_wrapper) (t8_forest_t forest
                                                               const size_t *active_query_indices, int *query_matches,
                                                               void *user_data);
 
+/** A wrapper around the forest search context */
 typedef struct t8_forest_c_search *t8_forest_search_c_wrapper;
 
+/** Initialize the forest search context
+ * \param[in,out] search           the search context to initialize
+ * \param[in] element_callback     the callback function that checks the search criterion on an element
+ * \param[in] forest               the forest on which the search is performed
+ */
 void
 t8_forest_init_search (t8_forest_search_c_wrapper search, t8_search_element_callback_c_wrapper element_callback,
                        const t8_forest_t forest);
+
+/** Update the forest on which the search is performed
+ * \param[in,out] search           the search context to update
+ * \param[in] forest               the new forest to use
+ */
 void
 t8_forest_search_update_forest (t8_forest_search_c_wrapper search, const t8_forest_t forest);
+
+/** Update the user data pointer in the search context
+ * \param[in,out] search           the search context to update
+ * \param[in] udata                the new user data pointer to use
+ */
 void
 t8_forest_search_update_user_data (t8_forest_search_c_wrapper search, void *udata);
+
+/** Perform the search
+ * \param[in,out] search           the search context to use
+ */
 void
 t8_forest_search_do_search (t8_forest_search_c_wrapper search);
+
+/** Destroy the search context
+ * \param[in,out] search           the search context to destroy
+ */
 void
 t8_forest_search_destroy (t8_forest_search_c_wrapper search);
 
+/**
+ * A wrapper around the forest search with queries context
+ */
 typedef struct t8_forest_search_with_queries *t8_forest_search_with_queries_c_wrapper;
 
+/**
+ * Initialize the forest search with queries context
+ * \param[in,out] search_with_queries the search with queries context to initialize
+ * \param[in] element_callback        the callback function that checks the search criterion on an element
+ * \param[in] queries_callback        the callback function that checks the queries on an element
+ * \param[in] queries                 a pointer to an array of queries
+ * \param[in] num_queries             the number of queries in the array
+ * \param[in] forest                  the forest on which the search is performed
+ */
 void
 t8_forest_init_search_with_queries (t8_forest_search_with_queries_c_wrapper search_with_queries,
                                     t8_search_element_callback_c_wrapper element_callback,
                                     t8_search_queries_callback_c_wrapper queries_callback, void **queries,
                                     const size_t num_queries, const t8_forest_t forest);
+
+/** Update the forest on which the search with queries is performed
+ * \param[in,out] search_with_queries the search with queries context to update
+ * \param[in] forest                  the new forest to use
+ */
 void
 t8_forest_search_with_queries_update_forest (t8_forest_search_with_queries_c_wrapper search_with_queries,
                                              const t8_forest_t forest);
+
+/** Update the user data pointer in the search with queries context
+ * \param[in,out] search_with_queries the search with queries context to update
+ * \param[in] udata                   the new user data pointer to use
+ */
 void
 t8_forest_search_with_queries_update_user_data (t8_forest_search_with_queries_c_wrapper search_with_queries,
                                                 void *udata);
+
+/** Update the queries in the search with queries context
+ * \param[in,out] search_with_queries the search with queries context to update
+ * \param[in] queries                 a pointer to an array of queries
+ * \param[in] num_queries             the number of queries in the array
+ */
 void
 t8_forest_search_with_queries_update_queries (t8_forest_search_with_queries_c_wrapper search_with_queries,
                                               void **queries, const size_t num_queries);
+
+/** Destroy the search with queries context
+ * \param[in,out] search the search with queries context to destroy
+ */
 void
 t8_forest_search_with_queries_destroy (t8_forest_search_with_queries_c_wrapper search);
+
+/** Perform the search with queries
+ * \param[in,out] search             the search with queries context to use
+ */
 void
 t8_forest_search_with_queries_do_search (t8_forest_search_with_queries_c_wrapper search);
 
+/**
+ * A wrapper around the forest search with batched queries context
+ */
 typedef struct t8_forest_search_with_batched_queries *t8_forest_search_with_batched_queries_c_wrapper;
 
+/**
+ * Initialize the forest search with batched queries context
+ * \param[in,out] search_with_queries the search with batched queries context to initialize
+ * \param[in] element_callback        the callback function that checks the search criterion on an element
+ * \param[in] queries_callback        the callback function that checks the batched queries on an element
+ * \param[in] queries                 a pointer to an array of queries
+ * \param[in] num_queries             the number of queries in the array
+ * \param[in] forest                  the forest on which the search is performed
+ */
 void
 t8_forest_init_search_with_batched_queries (t8_forest_search_with_batched_queries_c_wrapper search_with_queries,
                                             t8_search_element_callback_c_wrapper element_callback,
                                             t8_search_batched_queries_callback_c_wrapper queries_callback,
                                             void **queries, const size_t num_queries, const t8_forest_t forest);
+
+/** Update the forest on which the search with batched queries is performed
+ * \param[in,out] search_with_queries the search with batched queries context to update
+ * \param[in] forest                  the new forest to use
+ */
 void
 t8_forest_search_with_batched_queries_update_forest (
   t8_forest_search_with_batched_queries_c_wrapper search_with_queries, const t8_forest_t forest);
+
+/** Update the user data pointer in the search with batched queries context
+ * \param[in,out] search_with_queries the search with batched queries context to update
+ * \param[in] udata                   the new user data pointer to use
+ */
 void
 t8_forest_search_with_batched_queries_update_user_data (
   t8_forest_search_with_batched_queries_c_wrapper search_with_queries, void *udata);
+
+/** Update the queries in the search with batched queries context
+ * \param[in,out] search_with_queries the search with batched queries context to update
+ * \param[in] queries                 a pointer to an array of queries
+ * \param[in] num_queries             the number of queries in the array
+ */
 void
 t8_forest_search_with_batched_queries_update_queries (
   t8_forest_search_with_batched_queries_c_wrapper search_with_queries, void **queries, const size_t num_queries);
+
+/** Destroy the search with batched queries context
+ * \param[in,out] search the search with batched queries context to destroy
+ */
 void
 t8_forest_search_with_batched_queries_destroy (t8_forest_search_with_batched_queries_c_wrapper search);
+
+/** Perform the search with batched queries
+ * \param[in,out] search             the search with batched queries context to use
+ */
 void
 t8_forest_search_with_batched_queries_do_search (t8_forest_search_with_batched_queries_c_wrapper search);
 

--- a/src/t8_forest/t8_forest_search/t8_forest_search.hxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.hxx
@@ -38,7 +38,7 @@
 #include <ranges>
 
 /**
- * \typedef t8_search_element_callback
+ *  t8_search_element_callback
  *  A callback function type used for searching elements in a forest.
  *
  * This callback function is invoked during the search process in a forest. It allows
@@ -82,7 +82,7 @@ using t8_search_query_callback = std::function<bool (
   const t8_element_array_t *leaf_elements, const t8_locidx_t tree_leaf_index, const Query_T &query, Udata *user_data)>;
 
 /**
- * \typedef t8_search_batched_queries_callback
+ *  t8_search_batched_queries_callback
  *  A callback function type used for search queries within a forest. Processes a batch of queries.
  *
  * \tparam Query_T The type of the query.
@@ -106,7 +106,7 @@ using t8_search_batched_queries_callback = std::function<void (
   const std::vector<size_t> &active_query_indices, std::vector<bool> &query_matches, Udata *user_data)>;
 
 /**
- * \typedef t8_partition_search_element_callback
+ *  t8_partition_search_element_callback
  *  A callback function type used for searching elements in the partition of a forest.
  *
  * This callback function is invoked during the partition search process in a forest. It allows
@@ -128,7 +128,7 @@ using t8_partition_search_element_callback
                         const int pfirst, const int plast, Udata *user_data)>;
 
 /**
- * \typedef t8_partition_search_query_callback
+ *  t8_partition_search_query_callback
  *  A callback function type used for searching queries in the partition of a forest.
  *
  * \tparam Query_T The type of the query.
@@ -148,7 +148,7 @@ using t8_partition_search_query_callback
                         const int pfirst, const int plast, const Query_T &query, Udata *user_data)>;
 
 /**
- * \typedef t8_partition_search_batched_queries_callback
+ *  t8_partition_search_batched_queries_callback
  *  A callback function type used for searching queries in the partition of a forest. Processes a batch of queries.
  *
  * \tparam Query_T The type of the query.

--- a/src/t8_forest/t8_forest_search/t8_forest_search.hxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.hxx
@@ -331,7 +331,7 @@ class t8_search_base {
 template <typename Udata = void>
 class t8_search: public t8_search_base {
  public:
- /**
+  /**
   * Constructor for the t8_search class.
   * \param[in] element_callback A callback function to be called for each element during the search.
   * \param[in] forest A pointer to the forest to be searched. Defaults to nullptr
@@ -564,7 +564,7 @@ class t8_search_with_queries: public t8_search<Udata> {
 template <typename Query_T, typename Udata = void>
 class t8_search_with_batched_queries: public t8_search<Udata> {
  public:
- /**
+  /**
   * Constructor for the t8_search_with_batched_queries class.
   * \param[in] element_callback A callback function to be called for each element during the search.
   * \param[in] queries_callback A callback function to be called for processing batched queries.
@@ -831,7 +831,7 @@ class t8_partition_search: public t8_partition_search_base {
   Udata *user_data;
 
  private:
- /**
+  /**
   *  In the partition search without queries, the search never stops due to empty queries.
   */
   bool
@@ -1027,7 +1027,7 @@ class t8_partition_search_with_queries: public t8_partition_search<Udata> {
 template <typename Query_T, typename Udata = void>
 class t8_partition_search_with_batched_queries: public t8_partition_search<Udata> {
  public:
- /**
+  /**
   * Constructor for the t8_partition_search_with_batched_queries class.
   * This constructor initializes a t8_partition_search_with_batched_queries object with the given
   * element callback, queries callback, forest, and user data. If the forest is not null, it increments

--- a/src/t8_forest/t8_forest_search/t8_forest_search.hxx
+++ b/src/t8_forest/t8_forest_search/t8_forest_search.hxx
@@ -39,7 +39,7 @@
 
 /**
  * \typedef t8_search_element_callback
- * \brief A callback function type used for searching elements in a forest.
+ *  A callback function type used for searching elements in a forest.
  *
  * This callback function is invoked during the search process in a forest. It allows
  * custom operations to be performed on each element encountered during the search.
@@ -62,8 +62,7 @@ using t8_search_element_callback = std::function<bool (
   const t8_element_array_t *leaf_elements, const t8_locidx_t tree_leaf_index, Udata *user_data)>;
 
 /**
- * \typedef t8_search_queries_callback
- * \brief A callback function type used for search queries within a forest.
+ *  A callback function type used for search queries within a forest.
  *
  * \tparam Query_T The type of the query.
  * \tparam Udata The type of user data, defaults to void.
@@ -84,7 +83,7 @@ using t8_search_query_callback = std::function<bool (
 
 /**
  * \typedef t8_search_batched_queries_callback
- * \brief A callback function type used for search queries within a forest. Processes a batch of queries.
+ *  A callback function type used for search queries within a forest. Processes a batch of queries.
  *
  * \tparam Query_T The type of the query.
  * \tparam Udata The type of user data, defaults to void.
@@ -108,7 +107,7 @@ using t8_search_batched_queries_callback = std::function<void (
 
 /**
  * \typedef t8_partition_search_element_callback
- * \brief A callback function type used for searching elements in the partition of a forest.
+ *  A callback function type used for searching elements in the partition of a forest.
  *
  * This callback function is invoked during the partition search process in a forest. It allows
  * custom operations to be performed on each element encountered during the search.
@@ -130,7 +129,7 @@ using t8_partition_search_element_callback
 
 /**
  * \typedef t8_partition_search_query_callback
- * \brief A callback function type used for searching queries in the partition of a forest.
+ *  A callback function type used for searching queries in the partition of a forest.
  *
  * \tparam Query_T The type of the query.
  * \tparam Udata The type of user data, defaults to void.
@@ -150,7 +149,7 @@ using t8_partition_search_query_callback
 
 /**
  * \typedef t8_partition_search_batched_queries_callback
- * \brief A callback function type used for searching queries in the partition of a forest. Processes a batch of queries.
+ *  A callback function type used for searching queries in the partition of a forest. Processes a batch of queries.
  *
  * \tparam Query_T The type of the query.
  * \tparam Udata The type of user data, defaults to void.
@@ -171,9 +170,12 @@ using t8_partition_search_batched_queries_callback = std::function<void (
   const std::vector<Query_T> &queries, const std::vector<size_t> &active_query_indices,
   std::vector<bool> &query_matches, Udata *user_data)>;
 
+/**
+ * A base class that performs a search in a forest.
+ */
 class t8_search_base {
  public:
-  /**  \brief Constructor for the t8_search_base class.
+  /**   Constructor for the t8_search_base class.
    *
    *
    * This constructor initializes a t8_search_base object with the given forest.
@@ -190,7 +192,7 @@ class t8_search_base {
     }
   }
 
-  /**  \brief Update the forest for the search.
+  /**   Update the forest for the search.
    *
    * This function updates the forest for the search. If the current forest is not null,
    * it decrements the reference count of the forest. It then asserts that the new forest
@@ -210,7 +212,7 @@ class t8_search_base {
     this->forest = forest;
   }
 
-  /**  \brief Destructor for the t8_search_base class.
+  /**   Destructor for the t8_search_base class.
    *
    * This destructor decrements the reference count of the forest if it is not null.
    */
@@ -221,13 +223,16 @@ class t8_search_base {
     }
   }
 
-  /**  \brief Perform the search.
+  /**   Perform the search.
    *
    * This function performs the search in the forest. 
    */
   void
   do_search ();
 
+  /**
+   * The forest on which the search is performed.
+   */
   t8_forest_t forest;
 
  private:
@@ -241,7 +246,7 @@ class t8_search_base {
   void
   search_tree (const t8_locidx_t ltreeid);
 
-  /** \brief Recursively searches the tree.
+  /**  Recursively searches the tree.
    *
    * This function performs a recursive search operation on the tree identified by the given local tree ID.
    * It uses the given \a element_callback function to process each element encountered during the search.
@@ -257,14 +262,14 @@ class t8_search_base {
   search_recursion (const t8_locidx_t ltreeid, t8_element_t *element, const t8_scheme *ts,
                     t8_element_array_t *leaf_elements, const t8_locidx_t tree_lindex_of_first_leaf);
 
-  /** \brief Checks if the search should stop due to empty queries.
+  /**  Checks if the search should stop due to empty queries.
    * 
    */
   virtual bool
   stop_due_to_queries ()
     = 0;
 
-  /** \brief Checks an element during the search.
+  /**  Checks an element during the search.
    *
    * This function is called for each element encountered during the search.
    * It passes the arguments to the callback function provided by the user.
@@ -282,7 +287,7 @@ class t8_search_base {
                  const t8_element_array_t *leaf_elements, const t8_locidx_t tree_leaf_index)
     = 0;
 
-  /** \brief Checks queries during the search.
+  /**  Checks queries during the search.
    * 
    * This function is called to check queries during the search.
    * It passes the arguments to the callback function provided by the user.
@@ -300,7 +305,7 @@ class t8_search_base {
     = 0;
 
   /**
-   * \brief  Function the gives the user the opportunity to update the queries after 
+   *   Function the gives the user the opportunity to update the queries after 
    *         each step in the recursion.
    *
    * \param old_query_indices 
@@ -319,9 +324,19 @@ class t8_search_base {
     = 0;
 };
 
+/**
+ * A class that performs a search in a forest.
+ * \tparam Udata The type of user data to be used in the search.
+ */
 template <typename Udata = void>
 class t8_search: public t8_search_base {
  public:
+ /**
+  * Constructor for the t8_search class.
+  * \param[in] element_callback A callback function to be called for each element during the search.
+  * \param[in] forest A pointer to the forest to be searched. Defaults to nullptr
+  * \param[in] user_data A pointer to user-defined data to be passed to the callback function. Defaults to nullptr.
+  */
   t8_search (t8_search_element_callback<Udata> element_callback, t8_forest_t forest = nullptr,
              Udata *user_data = nullptr)
     : t8_search_base (forest), element_callback (element_callback)
@@ -331,7 +346,7 @@ class t8_search: public t8_search_base {
     }
   }
 
-  /** \brief Updates the user data associated with the object.
+  /**  Updates the user data associated with the object.
    *
    * This function sets the user data pointer to the provided Udata object.
    *
@@ -345,17 +360,35 @@ class t8_search: public t8_search_base {
     }
   }
 
+  /**
+   * Destructor for the t8_search class.
+   */
   virtual ~t8_search () = default;
 
+  /**
+   * The user data associated with the object.
+   */
   Udata *user_data;
 
  private:
+  /**
+   * Checks if the search should stop due to empty queries.
+   */
   bool
   stop_due_to_queries () override
   {
     return false;
   }
 
+  /**
+   * Checks an element during the search by invoking the user-defined callback function.
+   * \param[in] ltreeid The local tree ID of the current element.
+   * \param[in] element A pointer to the current element being processed.
+   * \param[in] is_leaf A bool indicating whether the current element is a leaf or not.
+   * \param[in] leaf_elements A pointer to an array of leaf elements.
+   * \param[in] tree_leaf_index The index of the current leaf element within the tree.
+   * \return True if the search should continue, false otherwise.
+   */
   bool
   check_element (const t8_locidx_t ltreeid, const t8_element_t *element, const bool is_leaf,
                  const t8_element_array_t *leaf_elements, const t8_locidx_t tree_leaf_index) override
@@ -364,6 +397,15 @@ class t8_search: public t8_search_base {
     return this->element_callback (this->forest, ltreeid, element, is_leaf, leaf_elements, tree_leaf_index, user_data);
   }
 
+  /**
+   * A no-op implementation of the check_queries function.
+   * \param[in] new_active_queries A vector of indices of active queries.
+   * \param[in] ltreeid The local tree ID of the current element.
+   * \param[in] element A pointer to the current element being processed.
+   * \param[in] is_leaf A bool indicating whether the current element is a leaf or not.
+   * \param[in] leaf_elements A pointer to an array of leaf elements.
+   * \param[in] tree_leaf_index The index of the current leaf element within the tree.
+   */
   void
   check_queries ([[maybe_unused]] std::vector<size_t> &new_active_queries, [[maybe_unused]] const t8_locidx_t ltreeid,
                  [[maybe_unused]] const t8_element_t *element, [[maybe_unused]] const bool is_leaf,
@@ -373,23 +415,33 @@ class t8_search: public t8_search_base {
     return;
   }
 
+  /**
+   * A no-op implementation of the update_queries function.
+   * \param[in] old_query_indices A vector of indices of old queries.
+   */
   void
   update_queries ([[maybe_unused]] std::vector<size_t> &old_query_indices) override
   {
     return;
   }
 
+  /**
+   * A no-op implementation of the init_queries function.
+   */
   void
   init_queries () override
   {
     return;
   }
 
+  /**
+   * The element callback function used during the search.
+   */
   t8_search_element_callback<Udata> element_callback;
 };
 
 /** 
- * \brief A class that performs a search in a forest with queries.
+ *  A class that performs a search in a forest with queries.
  * Uses a filter-view to filter out the active queries. It is recommended to use this version of the search
  * if the number of queries is small or if the queries do not need any further computations to be evaluated. 
  * 
@@ -399,6 +451,14 @@ class t8_search: public t8_search_base {
 template <typename Query_T, typename Udata = void>
 class t8_search_with_queries: public t8_search<Udata> {
  public:
+  /**
+   * Constructor for the t8_search_with_queries class.
+   * \param[in] element_callback A callback function to be called for each element during the search.
+   * \param[in] queries_callback A callback function to be called for each query during the search.
+   * \param[in] queries A reference to a vector of queries to be processed.
+   * \param[in] forest A pointer to the forest to be searched. Defaults to nullptr
+   * \param[in] user_data A pointer to user-defined data to be passed to the callback function. Defaults to nullptr.
+   */
   t8_search_with_queries (t8_search_element_callback<Udata> element_callback,
                           t8_search_query_callback<Query_T, Udata> queries_callback, std::vector<Query_T> &queries,
                           const t8_forest_t forest = nullptr, Udata *user_data = nullptr)
@@ -406,23 +466,42 @@ class t8_search_with_queries: public t8_search<Udata> {
   {
   }
 
+  /**
+   * Update the queries for the search.
+   * \param[in] queries A reference to a vector of queries to be processed.
+   */
   void
   update_queries (std::vector<Query_T> &queries)
   {
     this->queries = queries;
   }
 
+  /**
+   * Destructor for the t8_search_with_queries class.
+   */
   ~t8_search_with_queries ()
   {
   }
 
  private:
+  /**
+   * Checks if the search should stop due to empty queries.
+   */
   bool
   stop_due_to_queries () override
   {
     return this->active_queries.empty ();
   }
 
+  /**
+   * Checks the queries against the current element.
+   * \param[in] new_active_queries A reference to a vector of new active query indices.
+   * \param[in] ltreeid The ID of the local tree.
+   * \param[in] element A pointer to the current element being checked.
+   * \param[in] is_leaf A boolean indicating if the current element is a leaf.
+   * \param[in] leaf_elements A pointer to an array of leaf elements.
+   * \param[in] tree_leaf_index The index of the current element in the leaf array.
+   */
   void
   check_queries (std::vector<size_t> &new_active_queries, const t8_locidx_t ltreeid, const t8_element_t *element,
                  const bool is_leaf, const t8_element_array_t *leaf_elements,
@@ -438,12 +517,19 @@ class t8_search_with_queries: public t8_search<Udata> {
     }
   }
 
+  /**
+   * Updates the queries for the search.
+   * \param[in] old_query_indices A reference to a vector of queries to be processed.
+   */
   void
   update_queries (std::vector<size_t> &old_query_indices) override
   {
     this->active_queries = old_query_indices;
   }
 
+  /**
+   * Initializes the queries for the search.
+   */
   void
   init_queries () override
   {
@@ -451,13 +537,22 @@ class t8_search_with_queries: public t8_search<Udata> {
     std::iota (this->active_queries.begin (), this->active_queries.end (), 0);
   }
 
+  /**
+   * A reference to a vector of queries to be processed.
+   */
   t8_search_query_callback<Query_T, Udata> queries_callback;
+  /**
+   * A reference to a vector of queries to be processed.
+   */
   std::vector<Query_T> &queries;
+  /**
+   * A vector of indices of active queries.
+   */
   std::vector<size_t> active_queries;
 };
 
 /**
- * \brief A class that performs a search in a forest with batched queries.
+ * A class that performs a search in a forest with batched queries.
  * 
  * All active queries are passed to the callback function, which processes them in a batch. It is recommended to 
  * use this version of the searcch if further computations have to be done to evaluate the queries. That way these
@@ -469,6 +564,14 @@ class t8_search_with_queries: public t8_search<Udata> {
 template <typename Query_T, typename Udata = void>
 class t8_search_with_batched_queries: public t8_search<Udata> {
  public:
+ /**
+  * Constructor for the t8_search_with_batched_queries class.
+  * \param[in] element_callback A callback function to be called for each element during the search.
+  * \param[in] queries_callback A callback function to be called for processing batched queries.
+  * \param[in] queries A reference to a vector of queries to be processed.
+  * \param[in] forest A pointer to the forest to be searched. Defaults to nullptr
+  * \param[in] user_data A pointer to user-defined data to be passed to the callback function. Defaults to nullptr.
+  */
   t8_search_with_batched_queries (t8_search_element_callback<Udata> element_callback,
                                   t8_search_batched_queries_callback<Query_T, Udata> queries_callback,
                                   std::vector<Query_T> &queries, const t8_forest_t forest = nullptr,
@@ -477,20 +580,40 @@ class t8_search_with_batched_queries: public t8_search<Udata> {
   {
   }
 
+  /**
+   * Update the queries for the search.
+   * \param[in] queries A reference to a vector of queries to be processed.
+   */
   void
   update_queries (std::vector<Query_T> &queries)
   {
     this->queries = queries;
   }
 
+  /**
+   * Destructor for the t8_search_with_batched_queries class.
+   */
   virtual ~t8_search_with_batched_queries () = default;
 
  private:
+  /**
+   * Checks if the search should stop due to empty queries.
+   */
   bool
   stop_due_to_queries () override
   {
     return this->active_queries.empty ();
   }
+
+  /**
+   * Checks the queries against the current element.
+   * \param[in] new_active_queries A reference to a vector of new active query indices.
+   * \param[in] ltreeid The ID of the local tree.
+   * \param[in] element A pointer to the current element being checked.
+   * \param[in] is_leaf A boolean indicating if the current element is a leaf.
+   * \param[in] leaf_elements A pointer to an array of leaf elements.
+   * \param[in] tree_leaf_index The index of the current element in the leaf array.
+   */
   void
   check_queries (std::vector<size_t> &new_active_queries, const t8_locidx_t ltreeid, const t8_element_t *element,
                  const bool is_leaf, const t8_element_array_t *leaf_elements,
@@ -506,12 +629,19 @@ class t8_search_with_batched_queries: public t8_search<Udata> {
     }
   }
 
+  /**
+   * Updates the queries for the search.
+   * \param[in] old_query_indices A reference to a vector of queries to be processed.
+   */
   void
   update_queries (std::vector<size_t> &old_query_indices) override
   {
     this->active_queries = old_query_indices;
   }
 
+  /**
+   * Initializes the queries for the search.
+   */
   void
   init_queries () override
   {
@@ -519,14 +649,26 @@ class t8_search_with_batched_queries: public t8_search<Udata> {
     std::iota (this->active_queries.begin (), this->active_queries.end (), 0);
   }
 
+  /**
+   * The callback function for processing batched queries.
+   */
   t8_search_batched_queries_callback<Query_T, Udata> queries_callback;
+  /**
+   * A reference to a vector of queries to be processed.
+   */
   std::vector<Query_T> &queries;
+  /**
+   * A vector of indices of active queries.
+   */
   std::vector<size_t> active_queries;
 };
 
+/**
+ * A class that performs a search in the partition of a forest.
+ */
 class t8_partition_search_base {
  public:
-  /**  \brief Constructor for the t8_partition_search_base class.
+  /**  Constructor for the t8_partition_search_base class.
    *
    *
    * This constructor initializes a t8_partition_search_base object with the
@@ -543,7 +685,7 @@ class t8_partition_search_base {
     }
   }
 
-  /**  \brief Update the forest for the search.
+  /**  Update the forest for the search.
    *
    * This function updates the forest for the search. If the current forest is not null,
    * it decrements the reference count of the forest. It then asserts that the new forest
@@ -563,7 +705,7 @@ class t8_partition_search_base {
     this->forest = forest;
   }
 
-  /**  \brief Destructor for the t8_partition_search_base class.
+  /**   Destructor for the t8_partition_search_base class.
    *
    * This destructor decrements the reference count of the forest if it is not null.
    */
@@ -574,33 +716,35 @@ class t8_partition_search_base {
     }
   }
 
-  /**  \brief Perform the search.
+  /**   Perform the search.
    *
    * This function performs the search in the forest.
    */
   void
   do_search ();
 
+  /**
+   * A pointer to the forest whose partition is searched.
+   */
   t8_forest_t forest;
 
  private:
-  /** \brief Checks if the search should stop due to empty queries.
+  /**  Checks if the search should stop due to empty queries.
    *
    */
   virtual bool
   stop_due_to_queries ()
     = 0;
 
-  /** \brief Checks an element during the search.
+  /**  Checks an element during the search.
    *
    * This function is called for each element encountered during the search.
    * It passes the arguments to the callback function provided by the user.
    *
    * \param[in] ltreeid The local tree ID of the current element.
    * \param[in] element A pointer to the current element being processed.
-   * \param[in] is_leaf A bool indicating whether the current element is a leaf (non-zero) or not (zero).
-   * \param[in] leaf_elements A pointer to an array of leaf elements.
-   * \param[in] tree_leaf_index The index of the current leaf element within the tree.
+   * \param[in] pfirst The first processor that owns part of \a element.
+   * \param[in] plast The last processor that owns part of \a element.
    *
    * \return True if the search should continue, false otherwise.
    */
@@ -608,7 +752,7 @@ class t8_partition_search_base {
   check_element (const t8_locidx_t ltreeid, const t8_element_t *element, const int pfirst, const int plast)
     = 0;
 
-  /** \brief Checks queries during the search.
+  /**  Checks queries during the search.
    *
    * This function is called to check queries during the search.
    * It passes the arguments to the callback function provided by the user.
@@ -616,9 +760,8 @@ class t8_partition_search_base {
    * \param[in] new_active_queries A vector of indices of active queries.
    * \param[in] ltreeid The local tree ID of the current element.
    * \param[in] element A pointer to the current element being processed.
-   * \param[in] is_leaf A bool indicating whether the current element is a leaf (non-zero) or not (zero).
-   * \param[in] leaf_elements A pointer to an array of leaf elements.
-   * \param[in] tree_leaf_index The index of the current leaf element within the tree.
+   * \param[in] pfirst The first processor that owns part of \a element.
+   * \param[in] plast The last processor that owns part of \a element.
    */
   virtual void
   check_queries (std::vector<size_t> &new_active_queries, const t8_locidx_t ltreeid, const t8_element_t *element,
@@ -626,8 +769,7 @@ class t8_partition_search_base {
     = 0;
 
   /**
-   * \brief  Function the gives the user the opportunity to update the queries after
-   *         each step in the recursion.
+   * Function the gives the user the opportunity to update the queries after each step in the recursion.
    *
    * \param old_query_indices
    */
@@ -636,18 +778,30 @@ class t8_partition_search_base {
     = 0;
 
   /**
-   * @brief Function gives the user the opportunity to set the queries to the initial
-   *        full set before searching each tree.
-   *
+   * Function gives the user the opportunity to set the queries to the initial full set before searching each tree.
    */
   virtual void
   init_queries ()
     = 0;
 };
 
+/**
+ * A class that performs a search in the partition of a forest and supports the usage of user data.
+ * \tparam Udata 
+ */
 template <typename Udata = void>
 class t8_partition_search: public t8_partition_search_base {
  public:
+  /**
+  * Constructor for the t8_partition_search class.
+  * This constructor initializes a t8_partition_search object with the given element callback,
+  * forest, and user data. If the forest is not null, it increments the reference count
+  * of the forest and asserts that the forest is committed.
+  * 
+  * \param[in] element_callback A callback function of type t8_partition_search_element_callback<Udata>.
+  * \param[in] forest A pointer to a t8_forest_t object. Defaults to nullptr.
+  * \param[in] user_data A pointer to a Udata object. Defaults to nullptr.
+  */
   t8_partition_search (t8_partition_search_element_callback<Udata> element_callback, t8_forest_t forest = nullptr,
                        Udata *user_data = nullptr)
     : t8_partition_search_base (forest), element_callback (element_callback)
@@ -657,7 +811,7 @@ class t8_partition_search: public t8_partition_search_base {
     }
   }
 
-  /** \brief Updates the user data associated with the object.
+  /**  Updates the user data associated with the object.
    *
    * This function sets the user data pointer to the provided Udata object.
    *
@@ -671,15 +825,29 @@ class t8_partition_search: public t8_partition_search_base {
     }
   }
 
+  /**
+   * A pointer to the user data associated with the object.
+   */
   Udata *user_data;
 
  private:
+ /**
+  *  In the partition search without queries, the search never stops due to empty queries.
+  */
   bool
   stop_due_to_queries () override
   {
     return false;
   }
 
+  /**
+   *  In the partition search without queries, the element check simply forwards the call to the user callback.
+   * \param[in] ltreeid The local tree ID of the current element.
+   * \param[in] element A pointer to the current element being processed.
+   * \param[in] pfirst The first processor that owns part of \a element.
+   * \param[in] plast The last processor that owns part of \a element.
+   * \return True if the search should continue, false otherwise.
+   */
   bool
   check_element (const t8_locidx_t ltreeid, const t8_element_t *element, const int pfirst, const int plast) override
   {
@@ -687,6 +855,14 @@ class t8_partition_search: public t8_partition_search_base {
     return this->element_callback (this->forest, ltreeid, element, pfirst, plast, user_data);
   }
 
+  /**
+   *  In the partition search without queries, no queries are checked.
+   * \param[in] new_active_queries A vector of indices of active queries.
+   * \param[in] ltreeid The local tree ID of the current element.
+   * \param[in] element A pointer to the current element being processed.
+   * \param[in] pfirst The first processor that owns part of \a element.
+   * \param[in] plast The last processor that owns part of \a element.
+   */
   void
   check_queries ([[maybe_unused]] std::vector<size_t> &new_active_queries, [[maybe_unused]] const t8_locidx_t ltreeid,
                  [[maybe_unused]] const t8_element_t *element, [[maybe_unused]] const int pfirst,
@@ -695,23 +871,33 @@ class t8_partition_search: public t8_partition_search_base {
     return;
   }
 
+  /**
+   *  In the partition search without queries, no queries are updated.
+   * \param[in] old_query_indices A vector of indices of old queries.
+   */
   void
   update_queries ([[maybe_unused]] std::vector<size_t> &old_query_indices)
   {
     return;
   }
 
+  /**
+   *  In the partition search without queries, no queries are initialized.
+   */
   void
   init_queries () override
   {
     return;
   }
 
+  /**
+   *  The element callback function.
+   */
   t8_partition_search_element_callback<Udata> element_callback;
 };
 
 /**
- * \brief A class that performs a search in the partition of a forest with queries.
+ *  A class that performs a search in the partition of a forest with queries.
  * Uses a filter-view to filter out the active queries. It is recommended to use this version of the search
  * if the number of queries is small or if the queries do not need any further computations to be evaluated.
  *
@@ -721,6 +907,18 @@ class t8_partition_search: public t8_partition_search_base {
 template <typename Query_T, typename Udata = void>
 class t8_partition_search_with_queries: public t8_partition_search<Udata> {
  public:
+  /**
+   * Constructor for the t8_partition_search_with_queries class.
+   * This constructor initializes a t8_partition_search_with_queries object with the given
+   * element callback, queries callback, forest, and user data. If the forest is not null, it increments
+   * the reference count of the forest and asserts that the forest is committed.
+   * 
+   * \param[in] element_callback A callback function of type t8_partition_search_element_callback<Udata>.
+   * \param[in] queries_callback A callback function of type t8_partition_search_query_callback<Query_T, Udata>.
+   * \param[in] queries A reference to a vector of Query_T objects.
+   * \param[in] forest A pointer to a t8_forest_t object. Defaults to nullptr.
+   * \param[in] user_data A pointer to a Udata object. Defaults to nullptr.
+   */
   t8_partition_search_with_queries (t8_partition_search_element_callback<Udata> element_callback,
                                     t8_partition_search_query_callback<Query_T, Udata> queries_callback,
                                     std::vector<Query_T> &queries, const t8_forest_t forest = nullptr,
@@ -729,24 +927,45 @@ class t8_partition_search_with_queries: public t8_partition_search<Udata> {
       queries (queries)
   {
   }
-
+  /**
+   * Updates the queries associated with the object.
+   *
+   * \param[in] queries A reference to a vector of Query_T objects.
+   */
   void
   update_queries (std::vector<Query_T> &queries)
   {
     this->queries = queries;
   }
 
+  /**
+   * Destructor for the t8_partition_search_with_queries class.
+   */
   ~t8_partition_search_with_queries ()
   {
   }
 
  private:
+  /**
+   * Stops the search if there are no active queries.
+   *
+   * \return True if the search should stop, false otherwise.
+   */
   bool
   stop_due_to_queries () override
   {
     return this->active_queries.empty ();
   }
 
+  /**
+   * Checks queries during the search by invoking the user-provided callback function.
+   *
+   * \param[in] new_active_queries A vector of indices of active queries.
+   * \param[in] ltreeid The local tree ID of the current element.
+   * \param[in] element A pointer to the current element being processed.
+   * \param[in] pfirst The first processor that owns part of \a element.
+   * \param[in] plast The last processor that owns part of \a element.
+   */
   void
   check_queries (std::vector<size_t> &new_active_queries, const t8_locidx_t ltreeid, const t8_element_t *element,
                  const int pfirst, const int plast) override
@@ -761,26 +980,42 @@ class t8_partition_search_with_queries: public t8_partition_search<Udata> {
     }
   }
 
+  /**
+   * Updates the queries associated with the object.
+   *
+   * \param[in] old_query_indices A vector of indices of old queries.
+   */
   void
   update_queries (std::vector<size_t> &old_query_indices)
   {
     this->active_queries = old_query_indices;
   }
 
+  /**
+   * Initializes the queries associated with the object.
+   */
   void
   init_queries () override
   {
     this->active_queries.resize (this->queries.size ());
     std::iota (this->active_queries.begin (), this->active_queries.end (), 0);
   }
-
+  /**
+   * Callback function for processing queries.
+   */
   t8_partition_search_query_callback<Query_T, Udata> queries_callback;
+  /**
+   * A reference to a vector of queries.
+   */
   std::vector<Query_T> &queries;
+  /**
+   * A vector of indices of active queries.
+   */
   std::vector<size_t> active_queries;
 };
 
 /**
- * \brief A class that performs a search in the partition of a forest with batched queries.
+ * A class that performs a search in the partition of a forest with batched queries.
  *
  * All active queries are passed to the callback function, which processes them in a batch. It is recommended to
  * use this version of the searcch if further computations have to be done to evaluate the queries. That way these
@@ -792,6 +1027,18 @@ class t8_partition_search_with_queries: public t8_partition_search<Udata> {
 template <typename Query_T, typename Udata = void>
 class t8_partition_search_with_batched_queries: public t8_partition_search<Udata> {
  public:
+ /**
+  * Constructor for the t8_partition_search_with_batched_queries class.
+  * This constructor initializes a t8_partition_search_with_batched_queries object with the given
+  * element callback, queries callback, forest, and user data. If the forest is not null, it increments
+  * the reference count of the forest and asserts that the forest is committed.
+  * 
+  * \param[in] element_callback A callback function of type t8_partition_search_element_callback<Udata>.
+  * \param[in] queries_callback A callback function of type t8_partition_search_batched_queries_callback<Query_T, Udata>.
+  * \param[in] queries A reference to a vector of Query_T objects.
+  * \param[in] forest A pointer to a t8_forest_t object. Defaults to nullptr.
+  * \param[in] user_data A pointer to a Udata object. Defaults to nullptr.
+  */
   t8_partition_search_with_batched_queries (
     t8_partition_search_element_callback<Udata> element_callback,
     t8_partition_search_batched_queries_callback<Query_T, Udata> queries_callback, std::vector<Query_T> &queries,
@@ -800,23 +1047,41 @@ class t8_partition_search_with_batched_queries: public t8_partition_search<Udata
       queries (queries)
   {
   }
-
+  /**
+   * Updates the queries associated with the object.
+   */
   void
   update_queries (std::vector<Query_T> &queries)
   {
     this->queries = queries;
   }
 
+  /**
+   * Destructor for the t8_partition_search_with_batched_queries class.
+   */
   ~t8_partition_search_with_batched_queries ()
   {
   }
 
  private:
+  /**
+   * In the partition search with batched queries, the search stops if there are no active queries left.
+   * \return True if the search should stop, false otherwise.
+   */
   bool
   stop_due_to_queries () override
   {
     return this->active_queries.empty ();
   }
+
+  /**
+   * Checks queries during the search by invoking the user-provided callback function.
+   * \param[in] new_active_queries A vector of indices of active queries.
+   * \param[in] ltreeid The local tree ID of the current element.
+   * \param[in] element A pointer to the current element being processed.
+   * \param[in] pfirst The first processor that owns part of \a element.
+   * \param[in] plast The last processor that owns part of \a element.
+   */
   void
   check_queries (std::vector<size_t> &new_active_queries, const t8_locidx_t ltreeid, const t8_element_t *element,
                  const int pfirst, const int plast) override
@@ -832,12 +1097,18 @@ class t8_partition_search_with_batched_queries: public t8_partition_search<Udata
     std::swap (new_active_queries, this->active_queries);
   }
 
+  /**
+   * Updates the queries associated with the object.
+   * \param[in] old_query_indices A vector of indices of old queries.
+   */
   void
   update_queries (std::vector<size_t> &old_query_indices)
   {
     this->active_queries = old_query_indices;
   }
-
+  /**
+   * Initializes the queries associated with the object.
+   */
   void
   init_queries () override
   {
@@ -845,8 +1116,19 @@ class t8_partition_search_with_batched_queries: public t8_partition_search<Udata
     std::iota (this->active_queries.begin (), this->active_queries.end (), 0);
   }
 
+  /**
+   * Callback function for processing batched queries.
+   */
   t8_partition_search_batched_queries_callback<Query_T, Udata> queries_callback;
+
+  /**
+   * A reference to a vector of queries.
+   */
   std::vector<Query_T> &queries;
+
+  /**
+   * A vector of indices of active queries.
+   */
   std::vector<size_t> active_queries;
 };
 


### PR DESCRIPTION
Closes #1745 

Fixes all doxygen errors in t8_forest/t8_forest_search/*


**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).