### PR TITLE
Bugfix: Corrected outdated debug flag in t8_forest_iterate.cxx

### DIFF
--- a/src/t8_forest/t8_forest_iterate.cxx
+++ b/src/t8_forest/t8_forest_iterate.cxx
@@ -434,14 +434,14 @@ t8_forest_iterate_replace (t8_forest_t forest_new, t8_forest_t forest_old, t8_fo
               }
             }
             T8_ASSERT (family_size <= scheme->element_get_num_children (tree_class, elem_new));
-#if T8_DEBUG
+#if T8_ENABLE_DEBUG
             /* Check whether elem_old is the first element of the family */
             for (t8_locidx_t ielem = 1;
                  ielem < scheme->element_get_num_children (tree_class, elem_old) && ielem_old - ielem >= 0; ielem++) {
               const t8_element_t *elem_old_debug
                 = t8_forest_get_leaf_element_in_tree (forest_old, itree, ielem_old - ielem);
               scheme->element_get_parent (tree_class, elem_old_debug, elem_parent);
-              SC_CHECK_ABORT (!scheme->t8_element_equal (elem_new, elem_parent),
+              SC_CHECK_ABORT (!scheme->element_is_equal (tree_class, elem_new, elem_parent),
                               "elem_old is not the first of the family.");
             }
 #endif


### PR DESCRIPTION
Closes #1863

**_Describe your changes here:_**

Just a minor bugfix I stumbled over during the t8code week. Since it's actually changing code, I decided to separate it from the doxygen fixes.


**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).