### PR TITLE
Improvement: Rename variables from t to element in t8 scheme default

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common.hxx
@@ -247,18 +247,18 @@ class t8_default_scheme_common: public t8_crtp_operator<TUnderlyingEclassScheme,
   }
 
   /** Count how many leaf descendants of a given uniform level an element would produce.
-   * \param [in] t     The element to be checked.
+   * \param [in] element     The element to be checked.
    * \param [in] level A refinement level.
-   * \return Suppose \a t is uniformly refined up to level \a level. The return value
+   * \return Suppose \a element is uniformly refined up to level \a level. The return value
    * is the resulting number of elements (of the given level).
    * Each default element (except pyramids) refines into 2^{dim * (level - level(t))}
    * children.
    * \note This function is overwritten by the pyramid implementation.
    */
   inline t8_gloidx_t
-  element_count_leaves (const t8_element_t *t, int level) const
+  element_count_leaves (const t8_element_t *element, int level) const
   {
-    const int element_level = this->underlying ().element_get_level (t);
+    const int element_level = this->underlying ().element_get_level (element);
     const int dim = t8_eclass_to_dimension[eclass];
     return count_leaves_from_level (element_level, level, dim);
   }

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
@@ -631,12 +631,12 @@ t8_default_scheme_hex::element_init ([[maybe_unused]] const int length, [[maybe_
 
 #if T8_ENABLE_DEBUG
 int
-t8_default_scheme_hex::element_is_valid (const t8_element_t *elem) const
+t8_default_scheme_hex::element_is_valid (const t8_element_t *element) const
 {
   /* TODO: additional checks? do we set pad8 or similar?
    */
-  return p8est_quadrant_is_extended ((const p8est_quadrant_t *) elem)
-         && T8_QUAD_GET_TDIM ((const p8est_quadrant_t *) elem) == 3;
+  return p8est_quadrant_is_extended ((const p8est_quadrant_t *) element)
+         && T8_QUAD_GET_TDIM ((const p8est_quadrant_t *) element) == 3;
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.hxx
@@ -559,8 +559,8 @@ class t8_default_scheme_hex: public t8_default_scheme_common<t8_default_scheme_h
 #if T8_ENABLE_DEBUG
   /** Query whether a given element can be considered as 'valid' and it is
    *  safe to perform any of the above algorithms on it.
-   * \param [in]      t  The element to be checked.
-   * \return          True if \a elem is safe to use. False otherwise.
+   * \param [in]      element  The element to be checked.
+   * \return          True if \a element is safe to use. False otherwise.
    * \note            An element that is constructed with \ref element_new
    *                  must pass this test.
    * \note            An element for which \ref element_init was called must pass
@@ -572,7 +572,7 @@ class t8_default_scheme_hex: public t8_default_scheme_common<t8_default_scheme_h
    *                  in the implementation of each of the functions in this file.
    */
   int
-  element_is_valid (const t8_element_t *t) const;
+  element_is_valid (const t8_element_t *element) const;
 
   /**
   * Print a given element. For a example for a triangle print the coordinates

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
@@ -401,9 +401,9 @@ t8_default_scheme_line::refines_irregular () const
 
 #if T8_ENABLE_DEBUG
 int
-t8_default_scheme_line::element_is_valid (const t8_element_t *elem) const
+t8_default_scheme_line::element_is_valid (const t8_element_t *element) const
 {
-  return t8_dline_is_valid ((const t8_dline_t *) elem);
+  return t8_dline_is_valid ((const t8_dline_t *) element);
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.hxx
@@ -570,8 +570,8 @@ class t8_default_scheme_line: public t8_default_scheme_common<t8_default_scheme_
 #if T8_ENABLE_DEBUG
   /** Query whether a given element can be considered as 'valid' and it is
    *  safe to perform any of the above algorithms on it.
-   * \param [in]      t  The element to be checked.
-   * \return          True if \a t is safe to use. False otherwise.
+   * \param [in]      element  The element to be checked.
+   * \return          True if \a element is safe to use. False otherwise.
    * \note            An element that is constructed with \ref element_new
    *                  must pass this test.
    * \note            An element for which \ref element_init was called must pass
@@ -583,7 +583,7 @@ class t8_default_scheme_line: public t8_default_scheme_common<t8_default_scheme_
    *                  in the implementation of each of the functions in this file.
    */
   int
-  element_is_valid (const t8_element_t *t) const;
+  element_is_valid (const t8_element_t *element) const;
 
   /**
   * Print a given element. For a example for a triangle print the coordinates

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c
@@ -23,96 +23,96 @@
 #include <t8_schemes/t8_default/t8_default_line/t8_dline_bits.h>
 
 int
-t8_dline_get_level (const t8_dline_t *l)
+t8_dline_get_level (const t8_dline_t *line)
 {
-  return l->level;
+  return line->level;
 }
 
 void
-t8_dline_copy (const t8_dline_t *l, t8_dline_t *dest)
+t8_dline_copy (const t8_dline_t *line, t8_dline_t *dest)
 {
-  memcpy (dest, l, sizeof (t8_dline_t));
+  memcpy (dest, line, sizeof (t8_dline_t));
 }
 
 int
-t8_dline_compare (const t8_dline_t *l1, const t8_dline_t *l2)
+t8_dline_compare (const t8_dline_t *line1, const t8_dline_t *line2)
 {
   t8_linearidx_t id1, id2;
 
   /* Compute the linear ids of the elements */
-  id1 = l1->x;
-  id2 = l2->x;
+  id1 = line1->x;
+  id2 = line2->x;
   if (id1 == id2) {
     /* The linear ids are the same, the line with the smaller level
      * is considered smaller */
-    return l1->level - l2->level;
+    return line1->level - line2->level;
   }
   /* return negative if id1 < id2, zero if id1 = id2, positive if id1 > id2 */
   return id1 < id2 ? -1 : id1 != id2;
 }
 
 int
-t8_dline_equal (const t8_dline_t *l1, const t8_dline_t *l2)
+t8_dline_equal (const t8_dline_t *line1, const t8_dline_t *line2)
 {
-  return (l1->level == l2->level && l1->x == l2->x);
+  return (line1->level == line2->level && line1->x == line2->x);
 }
 
 void
-t8_dline_parent (const t8_dline_t *l, t8_dline_t *parent)
+t8_dline_parent (const t8_dline_t *line, t8_dline_t *parent)
 {
   t8_dline_coord_t h;
 
-  T8_ASSERT (l->level > 0);
+  T8_ASSERT (line->level > 0);
 
   /* Get the length of l */
-  h = T8_DLINE_LEN (l->level);
+  h = T8_DLINE_LEN (line->level);
 
   /* Set coordinates of parent */
-  parent->x = l->x & ~h;
+  parent->x = line->x & ~h;
   /* Set the parent's level */
-  parent->level = l->level - 1;
+  parent->level = line->level - 1;
 }
 
 void
-t8_dline_ancestor (const t8_dline_t *l, int level, t8_dline_t *ancestor)
+t8_dline_ancestor (const t8_dline_t *line, int level, t8_dline_t *ancestor)
 {
   /* Compute the new x-coordinate by setting all bits in positions
    * greater than level to zero. */
-  ancestor->x = l->x & ~(T8_DLINE_LEN (level) - 1);
+  ancestor->x = line->x & ~(T8_DLINE_LEN (level) - 1);
   /* set the level */
   ancestor->level = level;
 }
 
 void
-t8_dline_child (const t8_dline_t *l, int childid, t8_dline_t *child)
+t8_dline_child (const t8_dline_t *line, int childid, t8_dline_t *child)
 {
   t8_dline_coord_t h;
 
-  T8_ASSERT (l->level < T8_DLINE_MAXLEVEL);
+  T8_ASSERT (line->level < T8_DLINE_MAXLEVEL);
   T8_ASSERT (childid == 0 || childid == 1);
 
   /* Compute the length of the child */
-  h = T8_DLINE_LEN (l->level + 1);
+  h = T8_DLINE_LEN (line->level + 1);
   /* If childid = 0 then the children x coord is the same as l's,
    * if childid = 1 then it is x + h.
    */
-  child->x = l->x + (childid == 0 ? 0 : h);
+  child->x = line->x + (childid == 0 ? 0 : h);
   /* The children level */
-  child->level = l->level + 1;
+  child->level = line->level + 1;
 }
 
 void
-t8_dline_face_neighbour (const t8_dline_t *l, t8_dline_t *neigh, int face, int *dual_face)
+t8_dline_face_neighbour (const t8_dline_t *line, t8_dline_t *neigh, int face, int *dual_face)
 {
   T8_ASSERT (0 <= face && face < T8_DLINE_FACES);
 
-  neigh->level = l->level;
+  neigh->level = line->level;
   switch (face) {
   case 0:
-    neigh->x = l->x - T8_DLINE_LEN (l->level);
+    neigh->x = line->x - T8_DLINE_LEN (line->level);
     break;
   case 1:
-    neigh->x = l->x + T8_DLINE_LEN (l->level);
+    neigh->x = line->x + T8_DLINE_LEN (line->level);
     break;
   }
   if (dual_face != NULL) {
@@ -122,24 +122,24 @@ t8_dline_face_neighbour (const t8_dline_t *l, t8_dline_t *neigh, int face, int *
 }
 
 void
-t8_dline_nearest_common_ancestor (const t8_dline_t *t1, const t8_dline_t *t2, t8_dline_t *r)
+t8_dline_nearest_common_ancestor (const t8_dline_t *line1, const t8_dline_t *line2, t8_dline_t *nca)
 {
   int level;
   t8_dline_coord_t exclusive_or;
 
   /* At first we compute the first level at which the two x-coordinates differ */
-  exclusive_or = t1->x ^ t2->x;
+  exclusive_or = line1->x ^ line2->x;
   level = SC_LOG2_32 (exclusive_or) + 1;
 
   T8_ASSERT (level <= T8_DLINE_MAXLEVEL);
 
   /* Compute the new x-coordinate by zeroing out all higher levels */
-  r->x = t1->x & ~((1 << level) - 1);
-  r->level = SC_MIN (T8_DLINE_MAXLEVEL - level, SC_MIN (t1->level, t2->level));
+  nca->x = line1->x & ~((1 << level) - 1);
+  nca->level = SC_MIN (T8_DLINE_MAXLEVEL - level, SC_MIN (line1->level, line2->level));
 }
 
 int
-t8_dline_ancestor_id (const t8_dline_t *l, int level)
+t8_dline_ancestor_id (const t8_dline_t *line, int level)
 {
   t8_dline_coord_t h;
 
@@ -153,44 +153,44 @@ t8_dline_ancestor_id (const t8_dline_t *l, int level)
 
   /* If the h bit is set in l's x coordinate, then acestor id is 1
    * else 0. */
-  return (l->x & h) != 0;
+  return (line->x & h) != 0;
 }
 
 int
-t8_dline_face_parent_face (const t8_dline_t *l, int face)
+t8_dline_face_parent_face (const t8_dline_t *line, int face)
 {
   T8_ASSERT (0 <= face && face < T8_DLINE_FACES);
 
-  if (l->level == 0) {
+  if (line->level == 0) {
     return face;
   }
   /* If the child id is 0 and face is 0, then the parent's face is 0.
    * If the child id is 1 and face is 1, then the parent's face is 1.
    * In the other cases, this is an inner face. */
-  return t8_dline_child_id (l) == face ? face : -1;
+  return t8_dline_child_id (line) == face ? face : -1;
 }
 
 int
-t8_dline_child_id (const t8_dline_t *elem)
+t8_dline_child_id (const t8_dline_t *line)
 {
-  T8_ASSERT (elem->level < T8_DLINE_MAXLEVEL);
+  T8_ASSERT (line->level < T8_DLINE_MAXLEVEL);
   /* bitshifting the Levelbit to first position & check if it is 1 or 0 */
-  return ((elem->x >> (T8_DLINE_MAXLEVEL - elem->level)) & 1);
+  return ((line->x >> (T8_DLINE_MAXLEVEL - line->level)) & 1);
 }
 
 void
-t8_dline_childrenpv (const t8_dline_t *elem, t8_dline_t *c[T8_DLINE_CHILDREN])
+t8_dline_childrenpv (const t8_dline_t *line, t8_dline_t *c[T8_DLINE_CHILDREN])
 {
-  const int8_t level = elem->level;
+  const int8_t level = line->level;
 
-  T8_ASSERT (elem->level < T8_DLINE_MAXLEVEL);
+  T8_ASSERT (line->level < T8_DLINE_MAXLEVEL);
 
   /* Set the Level, Level increases */
   c[0]->level = level + 1;
   c[1]->level = level + 1;
   /* Set the coordinates of the children */
-  c[0]->x = elem->x;
-  c[1]->x = elem->x + T8_DLINE_LEN (c[1]->level);
+  c[0]->x = line->x;
+  c[1]->x = line->x + T8_DLINE_LEN (c[1]->level);
 }
 
 int
@@ -225,7 +225,7 @@ t8_dline_is_familypv (const t8_dline_t *f[])
 }
 
 int
-t8_dline_is_root_boundary (const t8_dline_t *p, int face)
+t8_dline_is_root_boundary (const t8_dline_t *line, int face)
 {
   /* A line is at the boundary if and only if
    * face = 0 and x = 0
@@ -233,43 +233,43 @@ t8_dline_is_root_boundary (const t8_dline_t *p, int face)
    * face = 1 and x = Maximum x - length of line
    */
   if (face == 0) {
-    return p->x == 0;
+    return line->x == 0;
   }
   else {
-    return p->x == T8_DLINE_ROOT_LEN - T8_DLINE_LEN (p->level);
+    return line->x == T8_DLINE_ROOT_LEN - T8_DLINE_LEN (line->level);
   }
 }
 
 int
-t8_dline_is_inside_root (const t8_dline_t *l)
+t8_dline_is_inside_root (const t8_dline_t *line)
 {
-  return (l->x >= 0 && l->x < T8_DLINE_ROOT_LEN);
+  return (line->x >= 0 && line->x < T8_DLINE_ROOT_LEN);
 }
 
 void
-t8_dline_init_linear_id (t8_dline_t *l, int level, t8_linearidx_t id)
+t8_dline_init_linear_id (t8_dline_t *line, int level, t8_linearidx_t id)
 {
   T8_ASSERT (0 <= level && level <= T8_DLINE_MAXLEVEL);
   T8_ASSERT (id < ((t8_linearidx_t) 1) << level);
 
   /* Set the level */
-  l->level = level;
+  line->level = level;
   /* Set the new x coordinate */
-  l->x = id << (T8_DLINE_MAXLEVEL - level);
+  line->x = id << (T8_DLINE_MAXLEVEL - level);
 }
 
 void
-t8_dline_successor (const t8_dline_t *l, t8_dline_t *succ, int level)
+t8_dline_successor (const t8_dline_t *line, t8_dline_t *succ, int level)
 {
   t8_dline_coord_t h = 0;
 
-  T8_ASSERT (1 <= level && level <= l->level);
-  T8_ASSERT (l->x < T8_DLINE_ROOT_LEN - T8_DLINE_LEN (level));
+  T8_ASSERT (1 <= level && level <= line->level);
+  T8_ASSERT (line->x < T8_DLINE_ROOT_LEN - T8_DLINE_LEN (level));
 
   /* To compute the successor we zero out all bits in places bigger
    * than level and then we add the length of a line of level. */
   h = T8_DLINE_LEN (level) - 1;
-  succ->x = l->x & ~h;
+  succ->x = line->x & ~h;
   succ->x += T8_DLINE_LEN (level);
   succ->level = level;
 }
@@ -304,87 +304,87 @@ t8_dline_transform_face (const t8_dline_t *line1, t8_dline_t *line2, int orienta
 }
 
 void
-t8_dline_first_descendant (const t8_dline_t *l, t8_dline_t *s, int level)
+t8_dline_first_descendant (const t8_dline_t *line, t8_dline_t *desc, int level)
 {
-  T8_ASSERT (level >= l->level && level <= T8_DLINE_MAXLEVEL);
+  T8_ASSERT (level >= line->level && level <= T8_DLINE_MAXLEVEL);
 
-  s->level = level;
-  s->x = l->x;
+  desc->level = level;
+  desc->x = line->x;
 }
 
 void
-t8_dline_last_descendant (const t8_dline_t *l, t8_dline_t *s, int level)
+t8_dline_last_descendant (const t8_dline_t *line, t8_dline_t *desc, int level)
 {
-  T8_ASSERT (level >= l->level && level <= T8_DLINE_MAXLEVEL);
+  T8_ASSERT (level >= line->level && level <= T8_DLINE_MAXLEVEL);
 
-  s->level = level;
-  s->x = l->x + T8_DLINE_LEN (l->level) - T8_DLINE_LEN (level);
+  desc->level = level;
+  desc->x = line->x + T8_DLINE_LEN (line->level) - T8_DLINE_LEN (level);
 }
 
 void
-t8_dline_vertex_integer_coords (const t8_dline_t *elem, const int vertex, int coords[])
+t8_dline_vertex_integer_coords (const t8_dline_t *line, const int vertex, int coords[])
 {
   T8_ASSERT (vertex == 0 || vertex == 1);
   if (vertex == 0) {
-    coords[0] = elem->x;
+    coords[0] = line->x;
   }
   else if (vertex == 1) {
-    coords[0] = elem->x + T8_DLINE_LEN (elem->level);
+    coords[0] = line->x + T8_DLINE_LEN (line->level);
   }
 }
 
 void
-t8_dline_vertex_ref_coords (const t8_dline_t *elem, const int vertex, double coordinates[1])
+t8_dline_vertex_ref_coords (const t8_dline_t *line, const int vertex, double coordinates[1])
 {
   /* we need to set and initial value to prevent compiler warning. */
   int coords_int = -1;
   T8_ASSERT (vertex == 0 || vertex == 1);
 
   /* Compute integer coordinates and divide by root length. */
-  t8_dline_vertex_integer_coords (elem, vertex, &coords_int);
+  t8_dline_vertex_integer_coords (line, vertex, &coords_int);
   coordinates[0] = coords_int / (double) T8_DLINE_ROOT_LEN;
 }
 
 void
-t8_dline_compute_reference_coords (const t8_dline_t *elem, const double *ref_coords, const size_t num_coords,
+t8_dline_compute_reference_coords (const t8_dline_t *line, const double *ref_coords, const size_t num_coords,
                                    const size_t skip_coords, double *out_coords)
 {
-  T8_ASSERT (t8_dline_is_valid (elem));
+  T8_ASSERT (t8_dline_is_valid (line));
   for (size_t coord = 0; coord < num_coords; ++coord) {
     const size_t offset = coord * (1 + skip_coords);
     const size_t offset_3d = coord * 3;
-    out_coords[offset] = elem->x;
-    out_coords[offset] += T8_DLINE_LEN (elem->level) * ref_coords[offset_3d];
+    out_coords[offset] = line->x;
+    out_coords[offset] += T8_DLINE_LEN (line->level) * ref_coords[offset_3d];
     out_coords[offset] /= (double) T8_DLINE_ROOT_LEN;
   }
 }
 
 t8_linearidx_t
-t8_dline_linear_id (const t8_dline_t *elem, int level)
+t8_dline_linear_id (const t8_dline_t *line, int level)
 {
   t8_linearidx_t id;
 
   T8_ASSERT (level <= T8_DLINE_MAXLEVEL && level >= 0);
 
   /* this preserves the high bits from negative numbers */
-  id = elem->x >> (T8_DLINE_MAXLEVEL - level);
+  id = line->x >> (T8_DLINE_MAXLEVEL - level);
 
   return id;
 }
 
 int
-t8_dline_is_valid (const t8_dline_t *l)
+t8_dline_is_valid (const t8_dline_t *line)
 {
   t8_dline_coord_t max_coord;
 
   max_coord = ((int64_t) 2 * T8_DLINE_ROOT_LEN) - 1;
   /* A line is valid if its level and its x coordinates are in the
    * correct bounds of the root three and its left and right neighbor */
-  return 0 <= l->level && l->level <= T8_DLINE_MAXLEVEL && -T8_DLINE_ROOT_LEN <= l->x && l->x <= max_coord;
+  return 0 <= line->level && line->level <= T8_DLINE_MAXLEVEL && -T8_DLINE_ROOT_LEN <= line->x && line->x <= max_coord;
 }
 
 void
-t8_dline_init (t8_dline_t *l)
+t8_dline_init (t8_dline_t *line)
 {
-  l->level = l->x = 0;
+  line->level = line->x = 0;
 }

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
@@ -34,119 +34,119 @@
 T8_EXTERN_C_BEGIN ();
 
 /** Compute the level of a line.
- * \param [in] l    Line whose level is computed.
- * \return          The level of \a l.
+ * \param [in] line    Line whose level is computed.
+ * \return          The level of \a line.
  */
 int
-t8_dline_get_level (const t8_dline_t *l);
+t8_dline_get_level (const t8_dline_t *line);
 
 /** Copy all values from one line to another.
- * \param [in] l    The line to be copied.
+ * \param [in] line    The line to be copied.
  * \param [in,out] dest Existing line whose data will be filled with the data
- *                   of \a l.
+ *                   of \a line.
  */
 void
-t8_dline_copy (const t8_dline_t *l, t8_dline_t *dest);
+t8_dline_copy (const t8_dline_t *line, t8_dline_t *dest);
 
-/** Compare two elements. returns negative if l1 < l2, zero if l1 equals l2
- *  and positive if l1 > l2.
- *  If l2 is a copy of l1 then the elements are equal.
+/** Compare two elements. returns negative if line1 < line2, zero if line1 equals line2
+ *  and positive if line1 > line2.
+ *  If line2 is a copy of line1 then the elements are equal.
  */
 int
-t8_dline_compare (const t8_dline_t *l1, const t8_dline_t *l2);
+t8_dline_compare (const t8_dline_t *line1, const t8_dline_t *line2);
 
 /** Check if two elements are equal.
-* \param [in] elem1  The first element.
-* \param [in] elem2  The second element.
+* \param [in] line1  The first element.
+* \param [in] line2  The second element.
 * \return            1 if the elements are equal, 0 if they are not equal
 */
 int
-t8_dline_equal (const t8_dline_t *elem1, const t8_dline_t *elem2);
+t8_dline_equal (const t8_dline_t *line1, const t8_dline_t *line2);
 
 /** Compute the parent of a line.
- * \param [in]  l   The input line.
+ * \param [in]  line   The input line.
  * \param [in,out] parent Existing line whose data will be filled with the parent
- *                  data of \a l.
+ *                  data of \a line.
  */
 void
-t8_dline_parent (const t8_dline_t *l, t8_dline_t *parent);
+t8_dline_parent (const t8_dline_t *line, t8_dline_t *parent);
 
 /** Compute the ancestor of a line at a given level.
- * \param [in]  t   Input line.
- * \param [in]  level A smaller level than \a t.
+ * \param [in]  line   Input line.
+ * \param [in]  level A smaller level than \a line.
  * \param [in,out] ancestor Existing line whose data will
- *                  be filled with the data of \a t's ancestor on
+ *                  be filled with the data of \a line's ancestor on
  *                  level \a level.
- * \note The line \a ancestor may point to the same line as \a t.
+ * \note The line \a ancestor may point to the same line as \a line.
  */
 void
-t8_dline_ancestor (const t8_dline_t *t, int level, t8_dline_t *ancestor);
+t8_dline_ancestor (const t8_dline_t *line, int level, t8_dline_t *ancestor);
 
 /** Compute the childid-th child in Morton order of a line.
- * \param [in] l    Input Line.
+ * \param [in] line    Input Line.
  * \param [in] childid The id of the child, 0 or 1, in Morton order.
  * \param [in,out] child  Existing Line whose data will be filled
  * 		    with the date of l's childid-th child.
  */
 void
-t8_dline_child (const t8_dline_t *l, int childid, t8_dline_t *child);
+t8_dline_child (const t8_dline_t *line, int childid, t8_dline_t *child);
 
 /** Compute the face neighbor of a line.
- * \param [in]     l      Input line.
+ * \param [in]     line      Input line.
  * \param [in,out] neigh  Existing line whose data will be filled.
  * \param [in]     face   The face across which to generate the neighbor.
  * \param [out]    dual_face If not NULL, the face number as seen from \a neigh
  *                        is stored.
- * \note \a l may point to the same line as \a n.
+ * \note \a line may point to the same line as \a neigh.
  */
 void
-t8_dline_face_neighbour (const t8_dline_t *l, t8_dline_t *neigh, int face, int *dual_face);
+t8_dline_face_neighbour (const t8_dline_t *line, t8_dline_t *neigh, int face, int *dual_face);
 
 /** Computes the nearest common ancestor of two lines in the same tree.
- * \param [in]     t1 First input line.
- * \param [in]     t2 Second input line.
- * \param [in,out] r Existing line whose data will be filled.
- * \note \a l1, \a l2, \a r may point to the same line.
+ * \param [in]     line1 First input line.
+ * \param [in]     line2 Second input line.
+ * \param [in,out] nca Existing line whose data will be filled.
+ * \note \a line1, \a line2, \a nca may point to the same line.
  */
 void
-t8_dline_nearest_common_ancestor (const t8_dline_t *t1, const t8_dline_t *t2, t8_dline_t *r);
+t8_dline_nearest_common_ancestor (const t8_dline_t *line1, const t8_dline_t *line2, t8_dline_t *nca);
 
 /** Compute the position of the ancestor of this child at level \a level within
  * its siblings.
- * \param [in] l  line to be considered.
+ * \param [in] line  line to be considered.
  * \param [in] level level to be considered.
  * \return Returns its child id 0 or 1.
  */
 int
-t8_dline_ancestor_id (const t8_dline_t *l, int level);
+t8_dline_ancestor_id (const t8_dline_t *line, int level);
 
 /** Given a face of a line return the face number
  * of the parent of the line that matches the line's face. Or return -1 if
  * no face of the parent matches the face.
 
- * \param [in]  l       The line.
+ * \param [in]  line       The line.
  * \param [in]  face    The number of the face.
- * \return              If \a face of \a l is also a face of \a l's parent,
+ * \return              If \a face of \a line is also a face of \a line's parent,
  *                      the face number of this face. Otherwise -1.
  */
 int
-t8_dline_face_parent_face (const t8_dline_t *l, int face);
+t8_dline_face_parent_face (const t8_dline_t *line, int face);
 
 /** Compute the position of the ancestor of this child at level \a level within
  * its siblings.
- * \param [in] t  line to be considered.
+ * \param [in] line  line to be considered.
  * \return Returns its child id in 0,1
  */
 int
-t8_dline_child_id (const t8_dline_t *t);
+t8_dline_child_id (const t8_dline_t *line);
 
 /** Compute the 2 children of a line, array version.
- * \param [in]     t  Input line.
+ * \param [in]     line  Input line.
  * \param [in,out] c  Pointers to the 2 computed children in Morton order.
  *                    t may point to the same quadrant as c[0].
  */
 void
-t8_dline_childrenpv (const t8_dline_t *t, t8_dline_t *c[T8_DLINE_CHILDREN]);
+t8_dline_childrenpv (const t8_dline_t *line, t8_dline_t *c[T8_DLINE_CHILDREN]);
 
 /** Check whether a collection of two lines is a family in Morton order.
  * \param [in]     f  An array of two lines.
@@ -156,38 +156,38 @@ int
 t8_dline_is_familypv (const t8_dline_t *f[]);
 
 /** Compute whether a given line shares a given face with its root tree.
- * \param [in] p        The input line.
- * \param [in] face     A face of \a p.
+ * \param [in] line       The input line.
+ * \param [in] face     A face of \a line.
  * \return              True if \a face is a subface of the line's root element.
  */
 int
-t8_dline_is_root_boundary (const t8_dline_t *p, int face);
+t8_dline_is_root_boundary (const t8_dline_t *line, int face);
 
 /** Test if a line lies inside of the root line,
  *  that is the line of level 0, anchor node (0,0)
- *  \param [in]     l Input line.
- *  \return true    If \a l lies inside of the root line.
+ *  \param [in]     line Input line.
+ *  \return true    If \a line lies inside of the root line.
  */
 int
-t8_dline_is_inside_root (const t8_dline_t *l);
+t8_dline_is_inside_root (const t8_dline_t *line);
 
 /** Initialize a line as the line with a given global id in a uniform
  *  refinement of a given level. *
- * \param [in,out] l  Existing line whose data will be filled.
+ * \param [in,out] line  Existing line whose data will be filled.
  * \param [in] id     Index to be considered.
  * \param [in] level  level of uniform grid to be considered.
  */
 void
-t8_dline_init_linear_id (t8_dline_t *l, int level, t8_linearidx_t id);
+t8_dline_init_linear_id (t8_dline_t *line, int level, t8_linearidx_t id);
 
 /** Computes the successor of a line in a uniform grid of level \a level.
- * \param [in] l  line whose id will be computed.
+ * \param [in] line  line whose id will be computed.
  * \param [in,out] succ Existing line whose data will be filled with the
- *                data of \a l's successor on level \a level.
+ *                data of \a line's successor on level \a level.
  * \param [in] level level of uniform grid to be considered.
  */
 void
-t8_dline_successor (const t8_dline_t *l, t8_dline_t *succ, int level);
+t8_dline_successor (const t8_dline_t *line, t8_dline_t *succ, int level);
 
 /** Suppose we have two trees that share a common face f.
  *  Given a Line e that is a subface of f in one of the trees
@@ -217,47 +217,47 @@ t8_dline_extrude_face (const t8_dvertex_t *face, int root_face, t8_dline_t *line
 
 /** Compute the first descendant of a line at a given level. This is the descendant of
  * the line in a uniform level refinement that has the smallest id.
- * \param [in] l        Line whose descendant is computed.
- * \param [out] s       Existing line whose data will be filled with the data
- *                      of \a l's first descendant on level \a level.
- * \param [in] level    The refinement level. Must be greater than \a l's refinement
+ * \param [in] line       Line whose descendant is computed.
+ * \param [out] desc       Existing line whose data will be filled with the data
+ *                      of \a line's first descendant on level \a level.
+ * \param [in] level    The refinement level. Must be greater than \a line's refinement
  *                      level.
  */
 void
-t8_dline_first_descendant (const t8_dline_t *l, t8_dline_t *s, int level);
+t8_dline_first_descendant (const t8_dline_t *line, t8_dline_t *desc, int level);
 
 /** Compute the last descendant of a line at a given level. This is the descendant of
  * the line in a uniform level refinement that has the largest id.
- * \param [in] l        Line whose descendant is computed.
- * \param [out] s       Existing line whose data will be filled with the data
- *                      of \a l's last descendant on level \a level.
- * \param [in] level    The refinement level. Must be greater than \a l's refinement
+ * \param [in] line        Line whose descendant is computed.
+ * \param [out] desc       Existing line whose data will be filled with the data
+ *                      of \a line's last descendant on level \a level.
+ * \param [in] level    The refinement level. Must be greater than \a line's refinement
  *                      level.
  */
 void
-t8_dline_last_descendant (const t8_dline_t *l, t8_dline_t *s, int level);
+t8_dline_last_descendant (const t8_dline_t *line, t8_dline_t *desc, int level);
 
 /** Compute the first or second vertex of a line.
- * \param [in] elem     Line whose vertex is computed.
- * \param [in] vertex   The number of the vertex of \a elem
+ * \param [in] line     Line whose vertex is computed.
+ * \param [in] vertex   The number of the vertex of \a line
  * \param [out] coords   The coordinates of the computed vertex
  */
 void
-t8_dline_vertex_integer_coords (const t8_dline_t *elem, const int vertex, int coords[]);
+t8_dline_vertex_integer_coords (const t8_dline_t *line, const int vertex, int coords[]);
 
 /** Compute the coordinates of a vertex of a line when the 
  * tree (level 0 line) is embedded in [0,1]^1.
- * \param [in] elem    Input line.
+ * \param [in] line    Input line.
  * \param [in] vertex The number of the vertex.
  * \param [out] coordinates An array of 1 double that
  * 		     will be filled with the reference coordinates of the vertex.
  */
 void
-t8_dline_vertex_ref_coords (const t8_dline_t *elem, const int vertex, double coordinates[1]);
+t8_dline_vertex_ref_coords (const t8_dline_t *line, const int vertex, double coordinates[1]);
 
 /** Convert points in the reference space of a line element to points in the
  *  reference space of the tree (level 0) embedded in [0,1]^1.
- * \param [in]  elem       Input line.
+ * \param [in]  line       Input line.
  * \param [in]  ref_coords The reference coordinates in the line
  *                         (\a num_coords times \f$ [0,1]^1 \f$)
  * \param [in]  num_coords Number of coordinates to evaluate
@@ -270,31 +270,31 @@ t8_dline_vertex_ref_coords (const t8_dline_t *elem, const int vertex, double coo
  *                         of the points on the line.
  */
 void
-t8_dline_compute_reference_coords (const t8_dline_t *elem, const double *ref_coords, const size_t num_coords,
+t8_dline_compute_reference_coords (const t8_dline_t *line, const double *ref_coords, const size_t num_coords,
                                    const size_t skip_coords, double *out_coords);
 
 /** Computes the linear position of a line in an uniform grid.
- * \param [in] elem  Pointer to a line element whose id will be computed.
+ * \param [in] line  Pointer to a line element whose id will be computed.
  * \param [in] level Refinement level of the line element.
  * \return Returns the linear position of this line on a grid.
  */
 t8_linearidx_t
-t8_dline_linear_id (const t8_dline_t *elem, int level);
+t8_dline_linear_id (const t8_dline_t *line, int level);
 
 /** Query whether all entries of a line are in valid ranges.
- * \param [in] l  line to be considered.
- * \return        True, if \a l is a valid line and it is safe to call any
- *                function in this file on \a l.
+ * \param [in] line  line to be considered.
+ * \return        True, if \a line is a valid line and it is safe to call any
+ *                function in this file on \a line.
  *                False otherwise.
  */
 int
-t8_dline_is_valid (const t8_dline_t *l);
+t8_dline_is_valid (const t8_dline_t *line);
 
 /** Set default values for a line, such that it passes \ref t8_dline_is_valid.
- * \param [in] l  line to be initialized
+ * \param [in] line  line to be initialized
  */
 void
-t8_dline_init (t8_dline_t *l);
+t8_dline_init (t8_dline_t *line);
 
 T8_EXTERN_C_END ();
 

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
@@ -397,10 +397,10 @@ t8_default_scheme_prism::element_get_anchor (const t8_element_t *elem, int ancho
 }
 
 void
-t8_default_scheme_prism::element_get_vertex_integer_coords (const t8_element_t *elem, int vertex, int coords[]) const
+t8_default_scheme_prism::element_get_vertex_integer_coords (const t8_element_t *element, int vertex, int coords[]) const
 {
-  T8_ASSERT (element_is_valid (elem));
-  t8_dprism_vertex_integer_coords ((const t8_dprism_t *) elem, vertex, coords);
+  T8_ASSERT (element_is_valid (element));
+  t8_dprism_vertex_integer_coords ((const t8_dprism_t *) element, vertex, coords);
 }
 
 void
@@ -436,10 +436,10 @@ t8_default_scheme_prism::refines_irregular (void) const
 #if T8_ENABLE_DEBUG
 
 int
-t8_default_scheme_prism::element_is_valid (const t8_element_t *elem) const
+t8_default_scheme_prism::element_is_valid (const t8_element_t *element) const
 {
-  T8_ASSERT (elem != NULL);
-  return t8_dprism_is_valid ((const t8_dprism_t *) elem);
+  T8_ASSERT (element != NULL);
+  return t8_dprism_is_valid ((const t8_dprism_t *) element);
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.hxx
@@ -497,13 +497,13 @@ class t8_default_scheme_prism: public t8_default_scheme_common<t8_default_scheme
   /** Compute the integer coordinates of a given element vertex. The default scheme implements the Morton type SFCs. 
    * In these SFCs the elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and L the maximum 
    * refinement level. All element vertices have integer coordinates in this cube.
-   *   \param [in] t        The element to be considered.
+   *   \param [in] element       The element to be considered.
    *   \param [in] vertex   The id of the vertex whose coordinates shall be computed.
    *   \param [out] coords  An array of at least as many integers as the element's dimension whose entries will be 
    *                        filled with the coordinates of \a vertex.
    */
   void
-  element_get_vertex_integer_coords (const t8_element_t *t, int vertex, int coords[]) const;
+  element_get_vertex_integer_coords (const t8_element_t *element, int vertex, int coords[]) const;
 
   /** Compute the coordinates of a given element vertex inside a reference tree
    *  that is embedded into [0,1]^d (d = dimension).
@@ -541,7 +541,7 @@ class t8_default_scheme_prism: public t8_default_scheme_common<t8_default_scheme
 #if T8_ENABLE_DEBUG
   /** Query whether a given element can be considered as 'valid' and it is
    *  safe to perform any of the above algorithms on it.
-   * \param [in]      t  The element to be checked.
+   * \param [in]      element  The element to be checked.
    * \return          True if \a t is safe to use. False otherwise.
    * \note            An element that is constructed with \ref element_new
    *                  must pass this test.
@@ -554,7 +554,7 @@ class t8_default_scheme_prism: public t8_default_scheme_common<t8_default_scheme
    *                  in the implementation of each of the functions in this file.
    */
   int
-  element_is_valid (const t8_element_t *t) const;
+  element_is_valid (const t8_element_t *element) const;
 
   /**
   * Print a given element. For a example for a triangle print the coordinates

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
@@ -304,11 +304,11 @@ t8_default_scheme_pyramid::element_get_shape (const t8_element_t *elem) const
 }
 
 t8_gloidx_t
-t8_default_scheme_pyramid::element_count_leaves (const t8_element_t *t, int level) const
+t8_default_scheme_pyramid::element_count_leaves (const t8_element_t *element, int level) const
 {
-  const int element_level = element_get_level (t);
+  const int element_level = element_get_level (element);
   const int dim = t8_eclass_to_dimension[eclass];
-  const t8_element_shape_t element_shape = element_get_shape (t);
+  const t8_element_shape_t element_shape = element_get_shape (element);
   if (element_shape == T8_ECLASS_PYRAMID) {
     const int level_diff = level - element_level;
     return element_level > level ? 0 : 2 * sc_intpow64 (8, level_diff) - sc_intpow64 (6, level_diff);
@@ -383,10 +383,11 @@ t8_default_scheme_pyramid::element_get_anchor (const t8_element_t *elem, int anc
 }
 
 void
-t8_default_scheme_pyramid::element_get_vertex_integer_coords (const t8_element_t *t, int vertex, int coords[]) const
+t8_default_scheme_pyramid::element_get_vertex_integer_coords (const t8_element_t *element, int vertex,
+                                                              int coords[]) const
 {
-  T8_ASSERT (element_is_valid (t));
-  t8_dpyramid_compute_integer_coords ((const t8_dpyramid_t *) t, vertex, coords);
+  T8_ASSERT (element_is_valid (element));
+  t8_dpyramid_compute_integer_coords ((const t8_dpyramid_t *) element, vertex, coords);
 }
 
 void
@@ -426,10 +427,10 @@ t8_default_scheme_pyramid::refines_irregular () const
 
 #if T8_ENABLE_DEBUG
 int
-t8_default_scheme_pyramid::element_is_valid (const t8_element_t *elem) const
+t8_default_scheme_pyramid::element_is_valid (const t8_element_t *element) const
 {
-  T8_ASSERT (elem != NULL);
-  return t8_dpyramid_is_valid ((const t8_dpyramid_t *) elem);
+  T8_ASSERT (element != NULL);
+  return t8_dpyramid_is_valid ((const t8_dpyramid_t *) element);
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.hxx
@@ -295,7 +295,7 @@ class t8_default_scheme_pyramid: public t8_default_scheme_common<t8_default_sche
   element_get_shape (const t8_element_t *elem) const;
 
   /** Count how many leaf descendants of a given uniform level an element would produce.
-   * \param [in] t     The element to be checked.
+   * \param [in] element     The element to be checked.
    * \param [in] level A refinement level.
    * \return Suppose \a t is uniformly refined up to level \a level. The return value
    * is the resulting number of elements (of the given level).
@@ -303,7 +303,7 @@ class t8_default_scheme_pyramid: public t8_default_scheme_common<t8_default_sche
    * children.
    */
   t8_gloidx_t
-  element_count_leaves (const t8_element_t *t, const int level) const;
+  element_count_leaves (const t8_element_t *element, const int level) const;
 
   /** Compute the shape of the face of an element.
    * \param [in] elem   The element.
@@ -517,13 +517,13 @@ class t8_default_scheme_pyramid: public t8_default_scheme_common<t8_default_sche
   /** Compute the integer coordinates of a given element vertex. The default scheme implements the Morton type SFCs. 
    * In these SFCs the elements are positioned in a cube [0,1]^(dL) with dimension d (=0,1,2,3) and  L the maximum 
    * refinement level. All element vertices have integer coordinates in this cube.
-   *   \param [in] t      The element to be considered.
+   *   \param [in] element      The element to be considered.
    *   \param [in] vertex The id of the vertex whose coordinates shall be computed.
    *   \param [out] coords An array of at least as many integers as the element's dimension
    *                      whose entries will be filled with the coordinates of \a vertex.
    */
   void
-  element_get_vertex_integer_coords (const t8_element_t *t, int vertex, int coords[]) const;
+  element_get_vertex_integer_coords (const t8_element_t *element, int vertex, int coords[]) const;
 
   /** Compute the coordinates of a given element vertex inside a reference tree
    *  that is embedded into [0,1]^d (d = dimension).
@@ -561,7 +561,7 @@ class t8_default_scheme_pyramid: public t8_default_scheme_common<t8_default_sche
 #if T8_ENABLE_DEBUG
   /** Query whether a given element can be considered as 'valid' and it is
    *  safe to perform any of the above algorithms on it.
-   * \param [in]      t  The element to be checked.
+   * \param [in]      element  The element to be checked.
    * \return          True if \a t is safe to use. False otherwise.
    * \note            An element that is constructed with \ref element_new
    *                  must pass this test.
@@ -574,7 +574,7 @@ class t8_default_scheme_pyramid: public t8_default_scheme_common<t8_default_sche
    *                  in the implementation of each of the functions in this file.
    */
   int
-  element_is_valid (const t8_element_t *t) const;
+  element_is_valid (const t8_element_t *element) const;
 
   /**
   * Print a given element. For a example for a triangle print the coordinates

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_dpyramid_bits.c
@@ -166,10 +166,10 @@ t8_dpyramid_is_inside_pyra (const t8_dpyramid_t *tet, const t8_dpyramid_t *check
 /**
  * The i first bits give the anchor coordinate for a possible ancestor of level i for tet.
  * We can store the last tetrahedra ancestor in ancestor.
- * \param[in] tet   Inpute pyramid in the shape of a tet
+ * \param[in] tet   Input pyramid in the shape of a tet
  * \param[in] level the maximal level to check whether \a tet lies in a pyramid
  * \param[in] ancestor   Can be NULL or an allocated element. If allocated, it will be filled with the data of the last tetrahedral ancestor 
- * \return          0, if the pyramid is insed of a tetrahedron*/
+ * \return          0, if the pyramid is inside of a tetrahedron*/
 static int
 t8_dpyramid_is_inside_tet (const t8_dpyramid_t *tet, const int level, t8_dpyramid_t *ancestor)
 {

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
@@ -745,11 +745,11 @@ t8_default_scheme_quad::refines_irregular () const
 
 #if T8_ENABLE_DEBUG
 int
-t8_default_scheme_quad::element_is_valid (const t8_element_t *elem) const
+t8_default_scheme_quad::element_is_valid (const t8_element_t *element) const
 {
   /* TODO: additional checks? do we set pad8 or similar?
    */
-  return p4est_quadrant_is_extended ((const p4est_quadrant_t *) elem);
+  return p4est_quadrant_is_extended ((const p4est_quadrant_t *) element);
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
@@ -590,8 +590,8 @@ class t8_default_scheme_quad: public t8_default_scheme_common<t8_default_scheme_
 #if T8_ENABLE_DEBUG
   /** Query whether a given element can be considered as 'valid' and it is
    *  safe to perform any of the above algorithms on it.
-   * \param [in]      t  The element to be checked.
-   * \return          True if \a t is safe to use. False otherwise.
+   * \param [in]      element  The element to be checked.
+   * \return          True if \a element is safe to use. False otherwise.
    * \note            An element that is constructed with \ref element_new
    *                  must pass this test.
    * \note            An element for which \ref element_init was called must pass
@@ -603,7 +603,7 @@ class t8_default_scheme_quad: public t8_default_scheme_common<t8_default_scheme_
    *                  in the implementation of each of the functions in this file.
    */
   int
-  element_is_valid (const t8_element_t *t) const;
+  element_is_valid (const t8_element_t *element) const;
 
   /**
   * Print a given element. For a example for a triangle print the coordinates

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.cxx
@@ -490,10 +490,10 @@ t8_default_scheme_tet::refines_irregular () const
 
 #if T8_ENABLE_DEBUG
 int
-t8_default_scheme_tet::element_is_valid (const t8_element_t *t) const
+t8_default_scheme_tet::element_is_valid (const t8_element_t *element) const
 
 {
-  return t8_dtet_is_valid ((const t8_dtet_t *) t);
+  return t8_dtet_is_valid ((const t8_dtet_t *) element);
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.hxx
@@ -510,8 +510,8 @@ class t8_default_scheme_tet: public t8_default_scheme_common<t8_default_scheme_t
 #if T8_ENABLE_DEBUG
   /** Query whether a given element can be considered as 'valid' and it is
    *  safe to perform any of the above algorithms on it.
-   * \param [in]      t  The element to be checked.
-   * \return          True if \a t is safe to use. False otherwise.
+   * \param [in]      element  The element to be checked.
+   * \return          True if \a element is safe to use. False otherwise.
    * \note            An element that is constructed with \ref element_new
    *                  must pass this test.
    * \note            An element for which \ref element_init was called must pass
@@ -523,7 +523,7 @@ class t8_default_scheme_tet: public t8_default_scheme_common<t8_default_scheme_t
    *                  in the implementation of each of the functions in this file.
    */
   int
-  element_is_valid (const t8_element_t *t) const;
+  element_is_valid (const t8_element_t *element) const;
 
   /**
   * Print a given element. For a example for a triangle print the coordinates

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
@@ -54,7 +54,7 @@ t8_dtet_compute_vertex_ref_coords (const t8_dtet_t *elem, int vertex, double coo
 
 /** Convert points in the reference space of a tet element to points in the
  *  reference space of the tree (level 0) embedded in \f$ [0,1]^3 \f$.
- * \param [in]  elem       Input tet.
+ * \param [in]  tet       Input tet.
  * \param [in]  ref_coords The reference coordinates in the tet
  *                         (\a num_coords times \f$ [0,1]^3 \f$)
  * \param [in]  num_coords Number of coordinates to evaluate
@@ -63,71 +63,71 @@ t8_dtet_compute_vertex_ref_coords (const t8_dtet_t *elem, int vertex, double coo
  *                         of the points on the tet.
  */
 void
-t8_dtet_compute_reference_coords (const t8_dtet_t *elem, const double *ref_coords, const size_t num_coords,
+t8_dtet_compute_reference_coords (const t8_dtet_t *tet, const double *ref_coords, const size_t num_coords,
                                   double *out_coords);
 
 /** Compute the coordinates of the four vertices of a tetrahedron.
- * \param [in] elem         Input tetrahedron.
+ * \param [in] tet         Input tetrahedron.
  * \param [out] coordinates An array of 4x3 t8_dtet_coord_t that will be filled with the coordinates of t's vertices.
  */
 void
-t8_dtet_compute_all_coords (const t8_dtet_t *elem, t8_dtet_coord_t coordinates[4][3]);
+t8_dtet_compute_all_coords (const t8_dtet_t *tet, t8_dtet_coord_t coordinates[4][3]);
 
 /** Copy the values of one tetrahedron to another.
- * \param [in] t Tetrahedron whose values will be copied.
- * \param [in,out] dest Existing tetrahedron whose data will be filled with the data of \a t. *
+ * \param [in] tet Tetrahedron whose values will be copied.
+ * \param [in,out] dest Existing tetrahedron whose data will be filled with the data of \a tet.
  */
 void
-t8_dtet_copy (const t8_dtet_t *t, t8_dtet_t *dest);
+t8_dtet_copy (const t8_dtet_t *tet, t8_dtet_t *dest);
 
 /** Compare two tets in their linear order.
- * \param [in] t1 Tetrahedron one.
- * \param [in] t2 Tetrahedron two.
- * \return        Returns negative if t1 < t2, zero if t1 = t2, positive if t1 > t2
+ * \param [in] tet1 Tetrahedron one.
+ * \param [in] tet2 Tetrahedron two.
+ * \return        Returns negative if tet1 < tet2, zero if tet1 = tet2, positive if tet1 > tet2
  */
 int
-t8_dtet_compare (const t8_dtet_t *t1, const t8_dtet_t *t2);
+t8_dtet_compare (const t8_dtet_t *tet1, const t8_dtet_t *tet2);
 
 /** Check if two elements are equal.
-* \param [in] elem1  The first element.
-* \param [in] elem2  The second element.
+* \param [in] tet1  The first element.
+* \param [in] tet2  The second element.
 * \return            1 if the elements are equal, 0 if they are not equal
 */
 int
-t8_dtet_equal (const t8_dtet_t *elem1, const t8_dtet_t *elem2);
+t8_dtet_equal (const t8_dtet_t *tet1, const t8_dtet_t *tet2);
 
 /** Compute the parent of a tetrahedron.
- * \param [in]  t Input tetrahedron.
- * \param [in,out] parent Existing tetrahedron whose data will be filled with the data of elem's parent.
+ * \param [in]  tet Input tetrahedron.
+ * \param [in,out] parent Existing tetrahedron whose data will be filled with the data of \a tet's parent.
  * \note \a t may point to the same tetrahedron as \a parent.
  */
 void
-t8_dtet_parent (const t8_dtet_t *t, t8_dtet_t *parent);
+t8_dtet_parent (const t8_dtet_t *tet, t8_dtet_t *parent);
 
 /** Compute the ancestor of a tetrahedron at a given level.
- * \param [in]  t   Input tetrahedron.
- * \param [in]  level A smaller level than \a t.
- * \param [in,out] ancestor Existing tetrahedron whose data will be filled with the data of \a t's ancestor on
+ * \param [in]  tet  Input tetrahedron.
+ * \param [in]  level A smaller level than \a tet.
+ * \param [in,out] ancestor Existing tetrahedron whose data will be filled with the data of \a tet's ancestor on
  *                  level \a level.
- * \note The tetrahedron \a ancestor may point to the same tetrahedron as \a t.
+ * \note The tetrahedron \a ancestor may point to the same tetrahedron as \a tet.
  */
 void
-t8_dtet_ancestor (const t8_dtet_t *t, int level, t8_dtet_t *ancestor);
+t8_dtet_ancestor (const t8_dtet_t *tet, int level, t8_dtet_t *ancestor);
 
 /** Compute the childid-th child in Morton order of a tetrahedron t.
- * \param [in] elem    Input tetrahedron.
+ * \param [in] tet    Input tetrahedron.
  * \param [in,out] childid The id of the child, 0..7 in Bey order.
  * \param [out] child  Existing tetrahedron whose data will be filled with the date of t's childid-th child.
  */
 void
-t8_dtet_child (const t8_dtet_t *elem, int childid, t8_dtet_t *child);
+t8_dtet_child (const t8_dtet_t *tet, int childid, t8_dtet_t *child);
 
 /** Compute the 8 children of a tetrahedron, array version.
- * \param [in]     t  Input tetrahedron.
+ * \param [in]     tet  Input tetrahedron.
  * \param [in,out] c  Pointers to the 8 computed children in Morton order. t may point to the same quadrant as c[0].
  */
 void
-t8_dtet_childrenpv (const t8_dtet_t *t, t8_dtet_t *c[T8_DTET_CHILDREN]);
+t8_dtet_childrenpv (const t8_dtet_t *tet, t8_dtet_t *c[T8_DTET_CHILDREN]);
 
 /** Check whether a collection of eight tetrahedra is a family in Morton order.
  * \param [in]     f  An array of eight tetrahedra.
@@ -137,31 +137,31 @@ int
 t8_dtet_is_familypv (const t8_dtet_t *f[]);
 
 /** Compute a specific sibling of a tetrahedron.
- * \param [in]     elem  Input tetrahedron.
+ * \param [in]     tet  Input tetrahedron.
  * \param [in,out] sibling  Existing tetrahedron whose data will be filled with the data of sibling no. sibling_id of 
- *                          elem.
+ *                          \a tet.
  * \param [in]     sibid The id of the sibling computed, 0..7 in Bey order.
  */
 void
-t8_dtet_sibling (const t8_dtet_t *elem, int sibid, t8_dtet_t *sibling);
+t8_dtet_sibling (const t8_dtet_t *tet, int sibid, t8_dtet_t *sibling);
 
 /** Compute the face neighbor of a tetrahedron.
- * \param [in]     t      Input tetrahedron.
+ * \param [in]     tet      Input tetrahedron.
  * \param [in]     face   The face across which to generate the neighbor.
- * \param [in,out] n      Existing tetrahedron whose data will be filled.
- * \note \a t may point to the same tetrahedron as \a n.
+ * \param [in,out] neigh      Existing tetrahedron whose data will be filled.
+ * \note \a tet may point to the same tetrahedron as \a neigh.
  */
 int
-t8_dtet_face_neighbour (const t8_dtet_t *t, int face, t8_dtet_t *n);
+t8_dtet_face_neighbour (const t8_dtet_t *tet, int face, t8_dtet_t *neigh);
 
 /** Computes the nearest common ancestor of two tetrahedra in the same tree.
- * \param [in]     t1 First input tetrahedron.
- * \param [in]     t2 Second input tetrahedron.
- * \param [in,out] r Existing tetrahedron whose data will be filled.
- * \note \a t1, \a t2, \a r may point to the same tetrahedron.
+ * \param [in]     tet1 First input tetrahedron.
+ * \param [in]     tet2 Second input tetrahedron.
+ * \param [in,out] nca Existing tetrahedron whose data will be filled.
+ * \note \a tet1, \a tet2, \a nca may point to the same tetrahedron.
  */
 void
-t8_dtet_nearest_common_ancestor (const t8_dtet_t *t1, const t8_dtet_t *t2, t8_dtet_t *r);
+t8_dtet_nearest_common_ancestor (const t8_dtet_t *tet1, const t8_dtet_t *tet2, t8_dtet_t *nca);
 
 /** Given a tetrahedron and a face of the tetrahedron, compute all children of the tetrahedron that touch the face.
  * \param [in] tet      The tetrahedron.
@@ -197,187 +197,187 @@ t8_dtet_face_parent_face (const t8_dtet_t *tet, int face);
 
 /** Given a tetrahedron and a face of this tetrahedron. If the face lies on the tree boundary, return the face number 
  * of the tree face. If not the return value is arbitrary.
- * \param [in] t    The tetrahedron.
- * \param [in] face The index of a face of \a t.
+ * \param [in] tet    The tetrahedron.
+ * \param [in] face The index of a face of \a tet.
  * \return The index of the tree face that \a face is a subface of, if \a face is on a tree boundary.
- *         Any arbitrary integer if \a is not at a tree boundary.
+ *         Any arbitrary integer if \a face is not at a tree boundary.
  * \note For boundary tetrahedra, this function is the inverse of \ref t8_dtet_root_face_to_face.
  */
 int
-t8_dtet_tree_face (t8_dtet_t *t, int face);
+t8_dtet_tree_face (t8_dtet_t *tet, int face);
 
 /** Given a tetrahedron and a face of the root tetrahedron. If the tetrahedron lies on the tree boundary, 
  * return the corresponding face number of the tetrahedron. If not the return value is arbitrary.
- * \param [in] t    The tetrahedron.
+ * \param [in] tet    The tetrahedron.
  * \param [in] root_face The index of a face of the root tetrahedron.
- * \return The index of the face of \a t that is a subface of \a root_face, if \a t is on the tree boundary.
- *         Any arbitrary integer if \a t is not at a tree boundary.
+ * \return The index of the face of \a tet that is a subface of \a root_face, if \a tet is on the tree boundary.
+ *         Any arbitrary integer if \a tet is not at a tree boundary.
  * \note For boundary tetrahedra, this function is the inverse of \ref t8_dtet_tree_face.
  */
 int
-t8_dtet_root_face_to_face (t8_dtet_t *t, int root_face);
+t8_dtet_root_face_to_face (t8_dtet_t *tet, int root_face);
 
 /** Test if a tetrahedron lies inside of the root tetrahedron, that is the tetrahedron of level 0, anchor node (0,0,0)
  *  and type 0.
- *  \param [in] t   Input tetrahedron.
- *  \return true    If \a t lies inside of the root tetrahedron.
+ *  \param [in] tet   Input tetrahedron.
+ *  \return true    If \a tet lies inside of the root tetrahedron.
  */
 int
-t8_dtet_is_inside_root (t8_dtet_t *t);
+t8_dtet_is_inside_root (t8_dtet_t *tet);
 
 /** Compute whether a given tetrahedron shares a given face with its root tree.
- * \param [in] t    The input tet.
- * \param [in] face A face of \a t.
+ * \param [in] tet    The input tet.
+ * \param [in] face A face of \a tet.
  * \return          True if \a face is a subface of the tet's root element.
  */
 int
-t8_dtet_is_root_boundary (const t8_dtet_t *t, int face);
+t8_dtet_is_root_boundary (const t8_dtet_t *tet, int face);
 
 /** Test if two tetrahedra have the same coordinates, type and level.
- * \return true if \a t1 describes the same tetrahedron as \a t2.
+ * \return true if \a tet1 describes the same tetrahedron as \a tet2.
  */
 int
-t8_dtet_is_equal (const t8_dtet_t *t1, const t8_dtet_t *t2);
+t8_dtet_is_equal (const t8_dtet_t *tet1, const t8_dtet_t *tet2);
 
 /** Test if two tetrahedra are siblings.
- * \param [in] t1 First tetrahedron to be tested.
- * \param [in] t2 Second tetrahedron to be tested.
- * \return true if \a t1 is equal to or a sibling of \a t2.
+ * \param [in] tet1 First tetrahedron to be tested.
+ * \param [in] tet2 Second tetrahedron to be tested.
+ * \return true if \a tet1 is equal to or a sibling of \a tet2.
  */
 int
-t8_dtet_is_sibling (const t8_dtet_t *t1, const t8_dtet_t *t2);
+t8_dtet_is_sibling (const t8_dtet_t *tet1, const t8_dtet_t *tet2);
 
 /** Test if a tetrahedron is the parent of another tetrahedron.
- * \param [in] t tetrahedron to be tested.
- * \param [in] c Possible child tetrahedron.
- * \return true if \a t is the parent of \a c.
+ * \param [in] tet tetrahedron to be tested.
+ * \param [in] child Possible child tetrahedron.
+ * \return true if \a tet is the parent of \a child.
  */
 int
-t8_dtet_is_parent (const t8_dtet_t *t, const t8_dtet_t *c);
+t8_dtet_is_parent (const t8_dtet_t *tet, const t8_dtet_t *child);
 
 /** Test if a tetrahedron is an ancestor of another tetrahedron.
- * \param [in] t tetrahedron to be tested.
- * \param [in] c Descendent tetrahedron.
- * \return true if \a t is equal to or an ancestor of \a c.
+ * \param [in] tet tetrahedron to be tested.
+ * \param [in] anc Descendent tetrahedron.
+ * \return true if \a tet is equal to or an ancestor of \a anc.
  */
 int
-t8_dtet_is_ancestor (const t8_dtet_t *t, const t8_dtet_t *c);
+t8_dtet_is_ancestor (const t8_dtet_t *tet, const t8_dtet_t *anc);
 
 /** Computes the linear position of a tetrahedron in a uniform grid.
- * \param [in] t  tetrahedron whose id will be computed.
+ * \param [in] tet  tetrahedron whose id will be computed.
  * \param [in] level level of uniform grid to be considered.
  * \return Returns the linear position of this tetrahedron on a grid of level \a level.
  * \note This id is not the Morton index.
  */
 t8_linearidx_t
-t8_dtet_linear_id (const t8_dtet_t *t, int level);
+t8_dtet_linear_id (const t8_dtet_t *tet, int level);
 
 /**
  * Same as init_linear_id, but we only consider the subtree. Used for computing the index of a
  * tetrahedron lying in a pyramid
- * \param [in, out] t   Existing triangle whose data will be filled
+ * \param [in, out] tet   Existing tet whose data will be filled
  * \param id            Index to be considered
  * \param start_level   The level of the root of the subtree
  * \param end_level     Level of uniform grid to be considered
  * \param parenttype    The type of the parent.
  */
 void
-t8_dtet_init_linear_id_with_level (t8_dtet_t *t, t8_linearidx_t id, int start_level, int end_level,
+t8_dtet_init_linear_id_with_level (t8_dtet_t *tet, t8_linearidx_t id, int start_level, int end_level,
                                    t8_dtet_type_t parenttype);
 
 /** Initialize a tetrahedron as the tetrahedron with a given global id in a uniform refinement of a given level.
- * \param [in,out] t  Existing tetrahedron whose data will be filled.
+ * \param [in,out] tet  Existing tetrahedron whose data will be filled.
  * \param [in] id     Index to be considered.
  * \param [in] level  level of uniform grid to be considered.
  */
 void
-t8_dtet_init_linear_id (t8_dtet_t *t, t8_linearidx_t id, int level);
+t8_dtet_init_linear_id (t8_dtet_t *tet, t8_linearidx_t id, int level);
 
 /** Initialize a tetrahedron as the root tetrahedron (type 0 at level 0)
- * \param [in,out] t Existing tetrahedron whose data will be filled.
+ * \param [in,out] tet Existing tetrahedron whose data will be filled.
  */
 void
-t8_dtet_init_root (t8_dtet_t *t);
+t8_dtet_init_root (t8_dtet_t *tet);
 
 /** Computes the successor of a tetrahedron in a uniform grid of level \a level.
- * \param [in] t  tetrahedron whose id will be computed.
- * \param [out] s Existing tetrahedron whose data will be filled with the
+ * \param [in] tet  tetrahedron whose id will be computed.
+ * \param [out] succ Existing tetrahedron whose data will be filled with the
  *                data of t's successor on level \a level.
  * \param [in] level level of uniform grid to be considered.
  */
 void
-t8_dtet_successor (const t8_dtet_t *t, t8_dtet_t *s, int level);
+t8_dtet_successor (const t8_dtet_t *tet, t8_dtet_t *succ, int level);
 
 /** Compute the first descendant of a tetrahedron at a given level. This is the descendant of
  * the tetrahedron in a uniform maxlevel refinement that has the smaller id.
- * \param [in] t        tetrahedron whose descendant is computed.
- * \param [in] level    A given level. Must be greater or equal to \a t's level.
+ * \param [in] tet        tetrahedron whose descendant is computed.
+ * \param [in] level    A given level. Must be greater or equal to \a tet's level.
  * \param [out] s       Existing tetrahedron whose data will be filled with the data
  *                      of t's first descendant.
  */
 void
-t8_dtet_first_descendant (const t8_dtet_t *t, t8_dtet_t *s, int level);
+t8_dtet_first_descendant (const t8_dtet_t *tet, t8_dtet_t *s, int level);
 
 /** Compute the last descendant of a tetrahedron at a given level. This is the descendant of
- * the tetrahedron in a uniform maxlevel refinement that has the bigges id.
- * \param [in] t        tetrahedron whose descendant is computed.
- * \param [in] level    A given level. Must be greater or equal to \a t's level.
+ * the tetrahedron in a uniform maxlevel refinement that has the biggest id.
+ * \param [in] tet        tetrahedron whose descendant is computed.
+ * \param [in] level    A given level. Must be greater or equal to \a tet's level.
  * \param [out] s       Existing tetrahedron whose data will be filled with the data of t's last descendant.
  */
 void
-t8_dtet_last_descendant (const t8_dtet_t *t, t8_dtet_t *s, int level);
+t8_dtet_last_descendant (const t8_dtet_t *tet, t8_dtet_t *s, int level);
 
 /** Compute the descendant of a tetrahedron in a given corner.
- * \param [in] t        Tetrahedron whose descendant is computed.
+ * \param [in] tet        Tetrahedron whose descendant is computed.
  * \param [out] s       Existing tetrahedron whose data will be filled with the data of t's descendant in \a corner.
  * \param [in]  corner  The corner in which the descendant should lie.
- * \param [in]  level   The refinement level of the descendant. Must be greater or equal to \a t's level.
+ * \param [in]  level   The refinement level of the descendant. Must be greater or equal to \a tet's level.
  */
 void
-t8_dtet_corner_descendant (const t8_dtet_t *t, t8_dtet_t *s, int corner, int level);
+t8_dtet_corner_descendant (const t8_dtet_t *tet, t8_dtet_t *s, int corner, int level);
 
 /** Computes the predecessor of a tetrahedron in a uniform grid of level \a level.
- * \param [in] t     tetrahedron whose id will be computed.
+ * \param [in] tet     tetrahedron whose id will be computed.
  * \param [in,out] s Existing tetrahedron whose data will be filled with the data of t's predecessor on level \a level.
  * \param [in] level level of uniform grid to be considered.
  */
 void
-t8_dtet_predecessor (const t8_dtet_t *t, t8_dtet_t *s, int level);
+t8_dtet_predecessor (const t8_dtet_t *tet, t8_dtet_t *s, int level);
 
 /** Compute the position of the ancestor of this child at level \a level within its siblings.
- * \param [in] t  tetrahedron to be considered.
+ * \param [in] tet  tetrahedron to be considered.
  * \param [in] level level to be considered.
  * \return Returns its child id in 0..7
  */
 int
-t8_dtet_ancestor_id (const t8_dtet_t *t, int level);
+t8_dtet_ancestor_id (const t8_dtet_t *tet, int level);
 
 /** Compute the position of the ancestor of this child at level \a level within its siblings.
- * \param [in] t  tetrahedron to be considered.
+ * \param [in] tet  tetrahedron to be considered.
  * \return Returns its child id in 0..7
  */
 int
-t8_dtet_child_id (const t8_dtet_t *t);
+t8_dtet_child_id (const t8_dtet_t *tet);
 
 /** Return the level of a tetrahedron.
- * \param [in] t  tetrahedron to be considered.
- * \return        The level of \a t.
+ * \param [in] tet  tetrahedron to be considered.
+ * \return        The level of \a tet.
  */
 int
-t8_dtet_get_level (const t8_dtet_t *t);
+t8_dtet_get_level (const t8_dtet_t *tet);
 
 /** Query whether all entries of a tet are in valid ranges.
- * \param [in] t  tet to be considered.
- * \return        True, if \a t is a valid tet and it is safe to call any function on \a t. False otherwise.
+ * \param [in] tet tet to be considered.
+ * \return        True, if \a tet is a valid tet and it is safe to call any function on \a tet. False otherwise.
  */
 int
-t8_dtet_is_valid (const t8_dtet_t *t);
+t8_dtet_is_valid (const t8_dtet_t *tet);
 
 /** Set sensible default values for a tet.
- * \param [in,out] t A tet.
+ * \param [in,out] tet A tet.
  */
 void
-t8_dtet_init (t8_dtet_t *t);
+t8_dtet_init (t8_dtet_t *tet);
 
 /** Packs an array of tet elements into contiguous memory. 
  * Tets are packed as x, y, z coordinates, type and level.

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
@@ -257,11 +257,11 @@ t8_dtet_is_parent (const t8_dtet_t *tet, const t8_dtet_t *child);
 
 /** Test if a tetrahedron is an ancestor of another tetrahedron.
  * \param [in] tet tetrahedron to be tested.
- * \param [in] anc Descendent tetrahedron.
- * \return true if \a tet is equal to or an ancestor of \a anc.
+ * \param [in] c Descendent tetrahedron.
+ * \return true if \a tet is equal to or an ancestor of \a c.
  */
 int
-t8_dtet_is_ancestor (const t8_dtet_t *tet, const t8_dtet_t *anc);
+t8_dtet_is_ancestor (const t8_dtet_t *tet, const t8_dtet_t *c);
 
 /** Computes the linear position of a tetrahedron in a uniform grid.
  * \param [in] tet  tetrahedron whose id will be computed.

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.cxx
@@ -503,9 +503,9 @@ t8_default_scheme_tri::refines_irregular () const
 
 #if T8_ENABLE_DEBUG
 int
-t8_default_scheme_tri::element_is_valid (const t8_element_t *t) const
+t8_default_scheme_tri::element_is_valid (const t8_element_t *element) const
 {
-  return t8_dtri_is_valid ((const t8_dtri_t *) t);
+  return t8_dtri_is_valid ((const t8_dtri_t *) element);
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.hxx
@@ -502,8 +502,8 @@ class t8_default_scheme_tri: public t8_default_scheme_common<t8_default_scheme_t
 #if T8_ENABLE_DEBUG
   /** Query whether a given element can be considered as 'valid' and it is
    *  safe to perform any of the above algorithms on it.
-   * \param [in]      t  The element to be checked.
-   * \return          True if \a t is safe to use. False otherwise.
+   * \param [in]      element  The element to be checked.
+   * \return          True if \a element is safe to use. False otherwise.
    * \note            An element that is constructed with \ref element_new
    *                  must pass this test.
    * \note            An element for which \ref element_init was called must pass
@@ -515,7 +515,7 @@ class t8_default_scheme_tri: public t8_default_scheme_common<t8_default_scheme_t
    *                  in the implementation of each of the functions in this file.
    */
   int
-  element_is_valid (const t8_element_t *t) const;
+  element_is_valid (const t8_element_t *element) const;
 
   /**
   * Print a given element. For a example for a triangle print the coordinates

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.c
@@ -33,7 +33,7 @@ typedef int8_t t8_dtri_cube_id_t;
 /* Compute the cube-id of t's ancestor of level "level" in constant time.
  * If "level" is greater then t->level then the cube-id 0 is returned. */
 static t8_dtri_cube_id_t
-compute_cubeid (const t8_dtri_t *t, int level)
+compute_cubeid (const t8_dtri_t *element, int level)
 {
   t8_dtri_cube_id_t id = 0;
   t8_dtri_coord_t h;
@@ -47,10 +47,10 @@ compute_cubeid (const t8_dtri_t *t, int level)
     return 0;
   }
 
-  id |= ((t->x & h) ? 0x01 : 0);
-  id |= ((t->y & h) ? 0x02 : 0);
+  id |= ((element->x & h) ? 0x01 : 0);
+  id |= ((element->y & h) ? 0x02 : 0);
 #ifdef T8_DTRI_TO_DTET
-  id |= ((t->z & h) ? 0x04 : 0);
+  id |= ((element->z & h) ? 0x04 : 0);
 #endif
 
   return id;
@@ -61,14 +61,14 @@ compute_cubeid (const t8_dtri_t *t, int level)
  * greater than t->level. This method runs in O(t->level - level).
  */
 static t8_dtri_type_t
-compute_type_ext (const t8_dtri_t *t, int level, t8_dtri_type_t known_type, int known_level)
+compute_type_ext (const t8_dtri_t *element, int level, t8_dtri_type_t known_type, int known_level)
 {
   int8_t type = known_type;
   t8_dtri_cube_id_t cid;
   int i;
 
   T8_ASSERT (0 <= level && level <= known_level);
-  T8_ASSERT (known_level <= t->level);
+  T8_ASSERT (known_level <= element->level);
   if (level == known_level) {
     return known_type;
   }
@@ -78,7 +78,7 @@ compute_type_ext (const t8_dtri_t *t, int level, t8_dtri_type_t known_type, int 
     return 0;
   }
   for (i = known_level; i > level; i--) {
-    cid = compute_cubeid (t, i);
+    cid = compute_cubeid (element, i);
     /* compute type as the type of T^{i+1}, that is T's ancestor of level i+1 */
     type = t8_dtri_cid_type_to_parenttype[cid][type];
   }
@@ -90,76 +90,77 @@ compute_type_ext (const t8_dtri_t *t, int level, t8_dtri_type_t known_type, int 
  * O(t->level - level).
  */
 static t8_dtri_type_t
-compute_type (const t8_dtri_t *t, int level)
+compute_type (const t8_dtri_t *element, int level)
 {
-  return compute_type_ext (t, level, t->type, t->level);
+  return compute_type_ext (element, level, element->type, element->level);
 }
 
 void
-t8_dtri_copy (const t8_dtri_t *t, t8_dtri_t *dest)
+t8_dtri_copy (const t8_dtri_t *element, t8_dtri_t *dest)
 {
-  if (t == dest) {
+  if (element == dest) {
     /* Do nothing if they are already the same. */
     return;
   }
-  memcpy (dest, t, sizeof (t8_dtri_t));
+  memcpy (dest, element, sizeof (t8_dtri_t));
 }
 
 int
-t8_dtri_equal (const t8_dtri_t *elem1, const t8_dtri_t *elem2)
+t8_dtri_equal (const t8_dtri_t *element1, const t8_dtri_t *element2)
 {
-  return (elem1->level == elem2->level && elem1->type == elem2->type && elem1->x == elem2->x && elem1->y == elem2->y
+  return (element1->level == element2->level && element1->type == element2->type && element1->x == element2->x
+          && element1->y == element2->y
 #ifdef T8_DTRI_TO_DTET
-          && elem1->z == elem2->z
+          && element1->z == element2->z
 #endif
   );
 }
 
 int
-t8_dtri_compare (const t8_dtri_t *t1, const t8_dtri_t *t2)
+t8_dtri_compare (const t8_dtri_t *element1, const t8_dtri_t *element2)
 {
   int maxlvl;
   t8_linearidx_t id1, id2;
 
   /* Compute the bigger level of the two */
-  maxlvl = SC_MAX (t1->level, t2->level);
+  maxlvl = SC_MAX (element1->level, element2->level);
   /* Compute the linear ids of the elements */
-  id1 = t8_dtri_linear_id (t1, maxlvl);
-  id2 = t8_dtri_linear_id (t2, maxlvl);
+  id1 = t8_dtri_linear_id (element1, maxlvl);
+  id2 = t8_dtri_linear_id (element2, maxlvl);
   if (id1 == id2) {
     /* The linear ids are the same, the triangle with the smaller level is considered smaller */
-    T8_ASSERT (t1->level != t2->level || t8_dtri_is_equal (t1, t2));
-    return t1->level - t2->level;
+    T8_ASSERT (element1->level != element2->level || t8_dtri_is_equal (element1, element2));
+    return element1->level - element2->level;
   }
   /* return negative if id1 < id2, zero if id1 = id2, positive if id1 > id2 */
   return id1 < id2 ? -1 : id1 != id2;
 }
 
 void
-t8_dtri_parent (const t8_dtri_t *t, t8_dtri_t *parent)
+t8_dtri_parent (const t8_dtri_t *element, t8_dtri_t *parent)
 {
   t8_dtri_cube_id_t cid;
   t8_dtri_coord_t h;
 
-  T8_ASSERT (t->level > 0);
+  T8_ASSERT (element->level > 0);
 
-  h = T8_DTRI_LEN (t->level);
+  h = T8_DTRI_LEN (element->level);
   /* Compute type of parent */
-  cid = compute_cubeid (t, t->level);
-  parent->type = t8_dtri_cid_type_to_parenttype[cid][t->type];
+  cid = compute_cubeid (element, element->level);
+  parent->type = t8_dtri_cid_type_to_parenttype[cid][element->type];
   /* Set coordinates of parent */
-  parent->x = t->x & ~h;
-  parent->y = t->y & ~h;
+  parent->x = element->x & ~h;
+  parent->y = element->y & ~h;
 #ifdef T8_DTRI_TO_DTET
-  parent->z = t->z & ~h;
+  parent->z = element->z & ~h;
 #endif
-  parent->level = t->level - 1;
+  parent->level = element->level - 1;
 }
 
 void
-t8_dtri_ancestor (const t8_dtri_t *t, int level, t8_dtri_t *ancestor)
+t8_dtri_ancestor (const t8_dtri_t *element, int level, t8_dtri_t *ancestor)
 {
-  /* TODO: find out, at which level difference it is faster to use    *
+  /* TODO: find out, at which level difference it is faster to use
    * the arithmetic computation of ancestor type
    * opposed to iteratively computing the parent type.
    */
@@ -173,22 +174,22 @@ t8_dtri_ancestor (const t8_dtri_t *t, int level, t8_dtri_t *ancestor)
 #endif
 #endif /* T8_DTRI_TO_DTET */
 
-  /* delta_{x,y} = t->{x,y} - ancestor->{x,y}
+  /* delta_{x,y} = element->{x,y} - ancestor->{x,y}
    * the difference of the coordinates.
    * Needed to compute the type of the ancestor. */
-  delta_x = t->x & (T8_DTRI_LEN (level) - 1);
-  delta_y = t->y & (T8_DTRI_LEN (level) - 1);
+  delta_x = element->x & (T8_DTRI_LEN (level) - 1);
+  delta_y = element->y & (T8_DTRI_LEN (level) - 1);
 #ifdef T8_DTRI_TO_DTET
-  delta_z = t->z & (T8_DTRI_LEN (level) - 1);
+  delta_z = element->z & (T8_DTRI_LEN (level) - 1);
 #endif
 
   /* The coordinates of the ancestor. It is necessary
    * to compute the delta first, since ancestor and t
    * could point to the same triangle. */
-  ancestor->x = t->x & ~(T8_DTRI_LEN (level) - 1);
-  ancestor->y = t->y & ~(T8_DTRI_LEN (level) - 1);
+  ancestor->x = element->x & ~(T8_DTRI_LEN (level) - 1);
+  ancestor->y = element->y & ~(T8_DTRI_LEN (level) - 1);
 #ifdef T8_DTRI_TO_DTET
-  ancestor->z = t->z & ~(T8_DTRI_LEN (level) - 1);
+  ancestor->z = element->z & ~(T8_DTRI_LEN (level) - 1);
 #endif
 
 #ifndef T8_DTRI_TO_DTET
@@ -202,7 +203,7 @@ t8_dtri_ancestor (const t8_dtri_t *t, int level, t8_dtri_t *ancestor)
   }
   else {
     T8_ASSERT (diff_xy == 0);
-    ancestor->type = t->type;
+    ancestor->type = element->type;
   }
 
 #else
@@ -224,7 +225,7 @@ t8_dtri_ancestor (const t8_dtri_t *t, int level, t8_dtri_t *ancestor)
   }
   else {
     T8_ASSERT (diff_xy == 0);
-    if (t->type == 0 || t->type == 1 || t->type == 5) {
+    if (element->type == 0 || element->type == 1 || element->type == 5) {
       possible_types[2] = possible_types[3] = possible_types[4] = 0;
     }
     else {
@@ -241,7 +242,7 @@ t8_dtri_ancestor (const t8_dtri_t *t, int level, t8_dtri_t *ancestor)
   }
   else {
     T8_ASSERT (diff_xz == 0);
-    if (t->type == 0 || t->type == 1 || t->type == 2) {
+    if (element->type == 0 || element->type == 1 || element->type == 2) {
       possible_types[3] = possible_types[4] = possible_types[5] = 0;
     }
     else {
@@ -258,7 +259,7 @@ t8_dtri_ancestor (const t8_dtri_t *t, int level, t8_dtri_t *ancestor)
   }
   else {
     T8_ASSERT (diff_yz == 0);
-    if (t->type == 1 || t->type == 2 || t->type == 3) {
+    if (element->type == 1 || element->type == 2 || element->type == 3) {
       possible_types[0] = possible_types[4] = possible_types[5] = 0;
     }
     else {
@@ -286,7 +287,7 @@ t8_dtri_ancestor (const t8_dtri_t *t, int level, t8_dtri_t *ancestor)
 
 /* Compute the coordinates of a given vertex of a triangle/tet */
 void
-t8_dtri_compute_integer_coords (const t8_dtri_t *elem, const int vertex, t8_dtri_coord_t coordinates[T8_DTRI_DIM])
+t8_dtri_compute_integer_coords (const t8_dtri_t *element, const int vertex, t8_dtri_coord_t coordinates[T8_DTRI_DIM])
 {
   /* Calculate the vertex coordinates of a triangle/tetrahedron in relation to its orientation. Orientations are 
    * described here: https://doi.org/10.1137/15M1040049
@@ -317,8 +318,8 @@ t8_dtri_compute_integer_coords (const t8_dtri_t *elem, const int vertex, t8_dtri
   t8_dtri_coord_t h;
   T8_ASSERT (0 <= vertex && vertex < T8_DTRI_FACES);
 
-  type = elem->type;
-  h = T8_DTRI_LEN (elem->level);
+  type = element->type;
+  h = T8_DTRI_LEN (element->level);
 #ifndef T8_DTRI_TO_DTET
   ei = type;
 #else
@@ -326,10 +327,10 @@ t8_dtri_compute_integer_coords (const t8_dtri_t *elem, const int vertex, t8_dtri
   ej = (ei + ((type % 2 == 0) ? 2 : 1)) % 3;
 #endif
 
-  coordinates[0] = elem->x;
-  coordinates[1] = elem->y;
+  coordinates[0] = element->x;
+  coordinates[1] = element->y;
 #ifdef T8_DTRI_TO_DTET
-  coordinates[2] = elem->z;
+  coordinates[2] = element->z;
 #endif
   if (vertex == 0) {
     return;
@@ -354,12 +355,12 @@ t8_dtri_compute_integer_coords (const t8_dtri_t *elem, const int vertex, t8_dtri
 }
 
 void
-t8_dtri_compute_vertex_ref_coords (const t8_dtri_t *elem, const int vertex, double coordinates[T8_DTRI_DIM])
+t8_dtri_compute_vertex_ref_coords (const t8_dtri_t *element, const int vertex, double coordinates[T8_DTRI_DIM])
 {
   int coords_int[T8_DTRI_DIM];
   T8_ASSERT (0 <= vertex && vertex < T8_DTRI_CORNERS);
 
-  t8_dtri_compute_integer_coords (elem, vertex, coords_int);
+  t8_dtri_compute_integer_coords (element, vertex, coords_int);
   /* Since the integer coordinates are coordinates w.r.t to
    * the embedding into [0,T8_DTRI_ROOT_LEN]^d, we just need
    * to divide them by the root length. */
@@ -371,7 +372,7 @@ t8_dtri_compute_vertex_ref_coords (const t8_dtri_t *elem, const int vertex, doub
 }
 
 void
-t8_dtri_compute_reference_coords (const t8_dtri_t *elem, const double *ref_coords, const size_t num_coords,
+t8_dtri_compute_reference_coords (const t8_dtri_t *element, const double *ref_coords, const size_t num_coords,
 #ifndef T8_DTRI_TO_DTET
                                   const size_t skip_coords,
 #endif
@@ -404,8 +405,8 @@ t8_dtri_compute_reference_coords (const t8_dtri_t *elem, const double *ref_coord
   t8_dtri_type_t type;
   t8_dtri_coord_t h;
 
-  type = elem->type;
-  h = T8_DTRI_LEN (elem->level);
+  type = element->type;
+  h = T8_DTRI_LEN (element->level);
 #ifndef T8_DTRI_TO_DTET
   const int tri_orientation = type;
 #else
@@ -423,10 +424,10 @@ t8_dtri_compute_reference_coords (const t8_dtri_t *elem, const double *ref_coord
 #else
     const size_t offset = 3 * coord;
 #endif
-    out_coords[offset + 0] = elem->x;
-    out_coords[offset + 1] = elem->y;
+    out_coords[offset + 0] = element->x;
+    out_coords[offset + 1] = element->y;
 #ifdef T8_DTRI_TO_DTET
-    out_coords[offset + 2] = elem->z;
+    out_coords[offset + 2] = element->z;
 #endif
 #ifndef T8_DTRI_TO_DTET
     out_coords[offset + tri_orientation] += h * ref_coords[offset_3d + 0];
@@ -451,7 +452,7 @@ t8_dtri_compute_reference_coords (const t8_dtri_t *elem, const double *ref_coord
 
 /* Compute the coordinates of each vertex of a triangle/tet */
 void
-t8_dtri_compute_all_coords (const t8_dtri_t *elem, t8_dtri_coord_t coordinates[T8_DTRI_FACES][T8_DTRI_DIM])
+t8_dtri_compute_all_coords (const t8_dtri_t *element, t8_dtri_coord_t coordinates[T8_DTRI_FACES][T8_DTRI_DIM])
 {
   /* Calculate the vertex coordinates of a triangle/tetrahedron in
    * relation to its orientation. Orientations are described here:
@@ -483,8 +484,8 @@ t8_dtri_compute_all_coords (const t8_dtri_t *elem, t8_dtri_coord_t coordinates[T
   int i;
   t8_dtri_coord_t h;
 
-  type = elem->type;
-  h = T8_DTRI_LEN (elem->level);
+  type = element->type;
+  h = T8_DTRI_LEN (element->level);
 #ifndef T8_DTRI_TO_DTET
   ei = type;
 #else
@@ -492,10 +493,10 @@ t8_dtri_compute_all_coords (const t8_dtri_t *elem, t8_dtri_coord_t coordinates[T
   ej = (ei + ((type % 2 == 0) ? 2 : 1)) % 3;
 #endif
 
-  coordinates[0][0] = elem->x;
-  coordinates[0][1] = elem->y;
+  coordinates[0][0] = element->x;
+  coordinates[0][1] = element->y;
 #ifdef T8_DTRI_TO_DTET
-  coordinates[0][2] = elem->z;
+  coordinates[0][2] = element->z;
 #endif
   for (i = 0; i < T8_DTRI_DIM; i++) {
     coordinates[1][i] = coordinates[0][i];
@@ -519,7 +520,7 @@ t8_dtri_compute_all_coords (const t8_dtri_t *elem, t8_dtri_coord_t coordinates[T
     int ivertex;
     t8_dtri_coord_t coords[T8_DTRI_DIM];
     for (ivertex = 0; ivertex < T8_DTRI_FACES; ivertex++) {
-      t8_dtri_compute_integer_coords (elem, ivertex, coords);
+      t8_dtri_compute_integer_coords (element, ivertex, coords);
       T8_ASSERT (coords[0] == coordinates[ivertex][0]);
       T8_ASSERT (coords[1] == coordinates[ivertex][1]);
 #ifdef T8_DTRI_TO_DTET
@@ -535,96 +536,96 @@ t8_dtri_compute_all_coords (const t8_dtri_t *elem, t8_dtri_coord_t coordinates[T
  * It is possible that the function is called with
  * elem = child */
 void
-t8_dtri_child (const t8_dtri_t *t, int childid, t8_dtri_t *child)
+t8_dtri_child (const t8_dtri_t *element, int childid, t8_dtri_t *child)
 {
   t8_dtri_t *c = (t8_dtri_t *) child;
   t8_dtri_coord_t t_coordinates[T8_DTRI_DIM];
   int vertex;
   int Bey_cid;
 
-  T8_ASSERT (t->level < T8_DTRI_MAXLEVEL);
+  T8_ASSERT (element->level < T8_DTRI_MAXLEVEL);
   T8_ASSERT (0 <= childid && childid < T8_DTRI_CHILDREN);
 
-  Bey_cid = t8_dtri_index_to_bey_number[t->type][childid];
+  Bey_cid = t8_dtri_index_to_bey_number[element->type][childid];
 
   /* Compute anchor coordinates of child */
   if (Bey_cid == 0) {
     /* TODO: would it be better do drop this if and
      *       capture it with (t->x+t->x)>>1 below? */
-    c->x = t->x;
-    c->y = t->y;
+    c->x = element->x;
+    c->y = element->y;
 #ifdef T8_DTRI_TO_DTET
-    c->z = t->z;
+    c->z = element->z;
 #endif
   }
   else {
     vertex = t8_dtri_beyid_to_vertex[Bey_cid];
     /* i-th anchor coordinate of child is (X_(0,i)+X_(vertex,i))/2
      * where X_(i,j) is the j-th coordinate of t's ith node */
-    t8_dtri_compute_integer_coords (t, vertex, t_coordinates);
-    c->x = (t->x + t_coordinates[0]) >> 1;
-    c->y = (t->y + t_coordinates[1]) >> 1;
+    t8_dtri_compute_integer_coords (element, vertex, t_coordinates);
+    c->x = (element->x + t_coordinates[0]) >> 1;
+    c->y = (element->y + t_coordinates[1]) >> 1;
 #ifdef T8_DTRI_TO_DTET
-    c->z = (t->z + t_coordinates[2]) >> 1;
+    c->z = (element->z + t_coordinates[2]) >> 1;
 #endif
   }
 
   /* Compute type of child */
-  c->type = t8_dtri_type_of_child[t->type][Bey_cid];
+  c->type = t8_dtri_type_of_child[element->type][Bey_cid];
 
-  c->level = t->level + 1;
+  c->level = element->level + 1;
 }
 
 void
-t8_dtri_childrenpv (const t8_dtri_t *t, t8_dtri_t *c[T8_DTRI_CHILDREN])
+t8_dtri_childrenpv (const t8_dtri_t *element, t8_dtri_t *children[T8_DTRI_CHILDREN])
 {
   t8_dtri_coord_t t_coordinates[T8_DTRI_FACES][T8_DTRI_DIM];
-  const int8_t level = t->level + 1;
+  const int8_t level = element->level + 1;
   int i;
   int Bey_cid;
   int vertex;
-  t8_dtri_type_t t_type = t->type;
+  t8_dtri_type_t t_type = element->type;
 
-  T8_ASSERT (t->level < T8_DTRI_MAXLEVEL);
-  t8_dtri_compute_all_coords (t, t_coordinates);
+  T8_ASSERT (element->level < T8_DTRI_MAXLEVEL);
+  t8_dtri_compute_all_coords (element, t_coordinates);
   /* We use t_coordinates[0] for t->x,y,z to ensure that the function is valid
-   * if called with t = c[0]. If we would use t->x later it would be the newly
-   * computed value c[0]->x. */
-  c[0]->x = t_coordinates[0][0]; /* t->x */
-  c[0]->y = t_coordinates[0][1]; /* t->y */
+   * if called with t = children[0]. If we would use t->x later it would be the newly
+   * computed value children[0]->x. */
+  children[0]->x = t_coordinates[0][0]; /* t->x */
+  children[0]->y = t_coordinates[0][1]; /* t->y */
 #ifdef T8_DTRI_TO_DTET
-  c[0]->z = t_coordinates[0][2]; /* t->z */
+  children[0]->z = t_coordinates[0][2]; /* t->z */
 #endif
-  c[0]->type = t_type;
-  c[0]->level = level;
+  children[0]->type = t_type;
+  children[0]->level = level;
   for (i = 1; i < T8_DTRI_CHILDREN; i++) {
     Bey_cid = t8_dtri_index_to_bey_number[t_type][i];
     vertex = t8_dtri_beyid_to_vertex[Bey_cid];
     /* i-th anchor coordinate of child is (X_(0,i)+X_(vertex,i))/2
      * where X_(i,j) is the j-th coordinate of t's ith node */
-    c[i]->x = (t_coordinates[0][0] + t_coordinates[vertex][0]) >> 1;
-    c[i]->y = (t_coordinates[0][1] + t_coordinates[vertex][1]) >> 1;
+    children[i]->x = (t_coordinates[0][0] + t_coordinates[vertex][0]) >> 1;
+    children[i]->y = (t_coordinates[0][1] + t_coordinates[vertex][1]) >> 1;
 #ifdef T8_DTRI_TO_DTET
-    c[i]->z = (t_coordinates[0][2] + t_coordinates[vertex][2]) >> 1;
+    children[i]->z = (t_coordinates[0][2] + t_coordinates[vertex][2]) >> 1;
 #endif
-    c[i]->type = t8_dtri_type_of_child[t_type][Bey_cid];
-    c[i]->level = level;
+    children[i]->type = t8_dtri_type_of_child[t_type][Bey_cid];
+    children[i]->level = level;
 #if T8_ENABLE_DEBUG
     {
       /* We check whether the child computed here equals to the child
        * computed in the t8_dtri_child function. */
       t8_dtri_t check_child;
-      /* We use c[0] here instead of t, since we explicitly allow t=c[0] as input
+      /* We use children[0] here instead of t, since we explicitly allow t=children[0] as input
        * and thus the values of t may be already overwritten. However the only
-       * difference from c[0] to t is in the level. */
-      c[0]->level--;
-      t8_dtri_child (c[0], i, &check_child);
-      T8_ASSERT (check_child.x == c[i]->x && check_child.y == c[i]->y);
-      T8_ASSERT (check_child.type == c[i]->type && check_child.level == c[i]->level);
+       * difference from children[0] to t is in the level. */
+      children[0]->level--;
+      t8_dtri_child (children[0], i, &check_child);
+      T8_ASSERT (check_child.x == children[i]->x && check_child.y == children[i]->y);
+      T8_ASSERT (check_child.type == children[i]->type && check_child.level == children[i]->level);
 #ifdef T8_DTRI_TO_DTET
-      T8_ASSERT (check_child.z == c[i]->z);
+      T8_ASSERT (check_child.z == children[i]->z);
 #endif
-      c[0]->level++;
+      children[0]->level++;
     }
 #endif
   }
@@ -666,18 +667,18 @@ t8_dtri_is_familypv (const t8_dtri_t *f[])
  * parent and child
  * TODO: CB agrees, make this as non-redundant as possible */
 void
-t8_dtri_sibling (const t8_dtri_t *elem, int sibid, t8_dtri_t *sibling)
+t8_dtri_sibling (const t8_dtri_t *element, int sibid, t8_dtri_t *sibling)
 {
   T8_ASSERT (0 <= sibid && sibid < T8_DTRI_CHILDREN);
-  T8_ASSERT (((const t8_dtri_t *) elem)->level > 0);
-  t8_dtri_parent (elem, sibling);
+  T8_ASSERT (((const t8_dtri_t *) element)->level > 0);
+  t8_dtri_parent (element, sibling);
   t8_dtri_child (sibling, sibid, sibling);
 }
 
 /* Saves the neighbour of T along face "face" in N
- * returns the facenumber of N along which T is its neighbour */
+ * returns the face number of N along which T is its neighbour */
 int
-t8_dtri_face_neighbour (const t8_dtri_t *t, int face, t8_dtri_t *n)
+t8_dtri_face_neighbour (const t8_dtri_t *element, int face, t8_dtri_t *neigh)
 {
   /* TODO: document what happens if outside of root tet */
   int type_new, type_old;
@@ -690,13 +691,13 @@ t8_dtri_face_neighbour (const t8_dtri_t *t, int face, t8_dtri_t *n)
 
   T8_ASSERT (0 <= face && face < T8_DTRI_FACES);
 
-  level = t->level;
-  type_old = t->type;
+  level = element->level;
+  type_old = element->type;
   type_new = type_old;
-  coords[0] = t->x;
-  coords[1] = t->y;
+  coords[0] = element->x;
+  coords[1] = element->y;
 #ifdef T8_DTRI_TO_DTET
-  coords[2] = t->z;
+  coords[2] = element->z;
 #endif
 
 #ifndef T8_DTRI_TO_DTET
@@ -741,18 +742,18 @@ t8_dtri_face_neighbour (const t8_dtri_t *t, int face, t8_dtri_t *n)
   }
   /* 3D end */
 #endif
-  n->x = coords[0];
-  n->y = coords[1];
+  neigh->x = coords[0];
+  neigh->y = coords[1];
 #ifdef T8_DTRI_TO_DTET
-  n->z = coords[2];
+  neigh->z = coords[2];
 #endif
-  n->level = level;
-  n->type = type_new;
+  neigh->level = level;
+  neigh->type = type_new;
   return ret;
 }
 
 void
-t8_dtri_nearest_common_ancestor (const t8_dtri_t *t1, const t8_dtri_t *t2, t8_dtri_t *r)
+t8_dtri_nearest_common_ancestor (const t8_dtri_t *element1, const t8_dtri_t *element2, t8_dtri_t *nca)
 {
   int maxlevel, c_level, r_level;
   t8_dtri_type_t t1_type_at_l, t2_type_at_l;
@@ -763,10 +764,10 @@ t8_dtri_nearest_common_ancestor (const t8_dtri_t *t1, const t8_dtri_t *t2, t8_dt
   uint32_t maxclor;
 
   /* Find the level of the nca */
-  exclorx = t1->x ^ t2->x;
-  exclory = t1->y ^ t2->y;
+  exclorx = element1->x ^ element2->x;
+  exclory = element1->y ^ element2->y;
 #ifdef T8_DTRI_TO_DTET
-  exclorz = t1->z ^ t2->z;
+  exclorz = element1->z ^ element2->z;
 
   maxclor = exclorx | exclory | exclorz;
 #else
@@ -776,25 +777,25 @@ t8_dtri_nearest_common_ancestor (const t8_dtri_t *t1, const t8_dtri_t *t2, t8_dt
 
   T8_ASSERT (maxlevel <= T8_DTRI_MAXLEVEL);
 
-  c_level = (int8_t) SC_MIN (T8_DTRI_MAXLEVEL - maxlevel, (int) SC_MIN (t1->level, t2->level));
+  c_level = (int8_t) SC_MIN (T8_DTRI_MAXLEVEL - maxlevel, (int) SC_MIN (element1->level, element2->level));
   r_level = c_level;
   /* c_level is the level of the nca cube surrounding t1 and t2.
    * If t1 and t2 have different types at this level, then we have to shrink this
    * level further. */
-  t1_type_at_l = compute_type (t1, c_level);
-  t2_type_at_l = compute_type (t2, c_level);
+  t1_type_at_l = compute_type (element1, c_level);
+  t2_type_at_l = compute_type (element2, c_level);
   while (t1_type_at_l != t2_type_at_l) {
     r_level--;
-    t1_type_at_l = compute_type_ext (t1, r_level, t1_type_at_l, r_level + 1);
-    t2_type_at_l = compute_type_ext (t2, r_level, t2_type_at_l, r_level + 1);
+    t1_type_at_l = compute_type_ext (element1, r_level, t1_type_at_l, r_level + 1);
+    t2_type_at_l = compute_type_ext (element2, r_level, t2_type_at_l, r_level + 1);
   }
   T8_ASSERT (r_level >= 0);
   /* Construct the ancestor of the first triangle at this level */
-  t8_dtri_ancestor (t1, r_level, r);
+  t8_dtri_ancestor (element1, r_level, nca);
 }
 
 void
-t8_dtri_children_at_face (const t8_dtri_t *tri, int face, t8_dtri_t *children[],
+t8_dtri_children_at_face (const t8_dtri_t *element, int face, t8_dtri_t *children[],
                           __attribute__ ((unused)) int num_children, int *child_indices)
 {
   int child_ids_local[T8_DTRI_FACE_CHILDREN], i, *child_ids;
@@ -811,27 +812,27 @@ t8_dtri_children_at_face (const t8_dtri_t *tri, int face, t8_dtri_t *children[],
 #ifndef T8_DTRI_TO_DTET
   /* Triangle version */
   /* The first child is '0' for faces 1 and 2 and '1+type' for face 0 */
-  child_ids[0] = face == 0 ? 1 + tri->type : 0;
+  child_ids[0] = face == 0 ? 1 + element->type : 0;
   /* The second child is '1 + type' for face 2 and '3' for faces 0 and 1 */
-  child_ids[1] = face == 2 ? 1 + tri->type : 3;
+  child_ids[1] = face == 2 ? 1 + element->type : 3;
 #else
   /* Tetrahedron version */
   for (i = 0; i < T8_DTET_FACE_CHILDREN; i++) {
-    child_ids[i] = t8_dtet_face_child_id_by_type[tri->type][face][i];
+    child_ids[i] = t8_dtet_face_child_id_by_type[element->type][face][i];
   }
 #endif
 
   /* Compute the children at the face.
    * We revert the order to compute children[0] last, since the usage
-   * allows for tri == children[0].
+   * allows for element == children[0].
    */
   for (i = T8_DTRI_FACE_CHILDREN - 1; i >= 0; i--) {
-    t8_dtri_child (tri, child_ids[i], children[i]);
+    t8_dtri_child (element, child_ids[i], children[i]);
   }
 }
 
 int
-t8_dtri_tree_face (__attribute__ ((unused)) t8_dtri_t *t, int face)
+t8_dtri_tree_face (__attribute__ ((unused)) t8_dtri_t *element, int face)
 {
   T8_ASSERT (0 <= face && face < T8_DTRI_FACES);
   /* TODO: Assert if boundary */
@@ -844,7 +845,7 @@ t8_dtri_tree_face (__attribute__ ((unused)) t8_dtri_t *t, int face)
   /* For tets only tets of type not 3 can have tree boundary faces.
    * All these tets of type not 0 (types 1, 2, 4, and 5) can only have one of
    * their faces as boundary face. */
-  switch (t->type) {
+  switch (element->type) {
   case 0:
     return face;
     break;
@@ -870,11 +871,11 @@ t8_dtri_tree_face (__attribute__ ((unused)) t8_dtri_t *t, int face)
 }
 
 int
-t8_dtri_root_face_to_face (__attribute__ ((unused)) t8_dtri_t *t, int root_face)
+t8_dtri_root_face_to_face (__attribute__ ((unused)) t8_dtri_t *element, int root_face)
 {
   T8_ASSERT (0 <= root_face && root_face < T8_DTRI_FACES);
 #ifndef T8_DTRI_TO_DTET
-  T8_ASSERT (t->type == 0);
+  T8_ASSERT (element->type == 0);
   /* For triangles of type 0 the face number coincides with the number of the
    * root tree face. Triangles of type 1 cannot lie on the boundary of the
    * tree and thus the return value can be arbitrary. */
@@ -883,8 +884,8 @@ t8_dtri_root_face_to_face (__attribute__ ((unused)) t8_dtri_t *t, int root_face)
   /* For tets only tets of type not 3 can have tree boundary faces.
    * All these tets of type not 0 (types 1, 2, 4, and 5) can only have one of
    * their faces as boundary face. */
-  T8_ASSERT (t->type != 3);
-  switch (t->type) {
+  T8_ASSERT (element->type != 3);
+  switch (element->type) {
   case 0:
     return root_face;
     break;
@@ -1100,31 +1101,31 @@ t8_dtri_transform_face (const t8_dtri_t *trianglein, t8_dtri_t *triangle2, int o
 #endif
 
 int
-t8_dtri_is_inside_root (t8_dtri_t *t)
+t8_dtri_is_inside_root (t8_dtri_t *element)
 {
   int is_inside;
 
-  if (t->level == 0) {
+  if (element->level == 0) {
     /* A level 0 simplex is only inside the root simplex if it
      * is the root simplex. */
-    return t->type == 0 && t->x == 0 && t->y == 0
+    return element->type == 0 && element->x == 0 && element->y == 0
 #ifdef T8_DTRI_TO_DTET
-           && t->z == 0
+           && element->z == 0
 #endif
       ;
   }
-  is_inside = (t->x >= 0 && t->x < T8_DTRI_ROOT_LEN) && (t->y >= 0) &&
+  is_inside = (element->x >= 0 && element->x < T8_DTRI_ROOT_LEN) && (element->y >= 0) &&
 #ifdef T8_DTRI_TO_DTET
-              (t->z >= 0) &&
+              (element->z >= 0) &&
 #endif
 #ifndef T8_DTRI_TO_DTET
-              (t->y - t->x <= 0) && (t->y == t->x ? t->type == 0 : 1) &&
+              (element->y - element->x <= 0) && (element->y == element->x ? element->type == 0 : 1) &&
 #else
-              (t->z - t->x <= 0) && (t->y - t->z <= 0) && (t->z == t->x ? (0 <= t->type && t->type < 3) : 1)
-              &&                                                     /* types 0, 1, 2 */
-              (t->y == t->z ? (0 == t->type || 4 <= t->type) : 1) && /* types 0, 4, 5 */
+              (element->z - element->x <= 0) && (element->y - element->z <= 0)
+              && (element->z == element->x ? (0 <= element->type && element->type < 3) : 1) && /* types 0, 1, 2 */
+              (element->y == element->z ? (0 == element->type || 4 <= element->type) : 1) &&   /* types 0, 4, 5 */
               /* If the anchor is on the x-y-z diagonal, only type 0 tets are inside root. */
-              ((t->x == t->y && t->y == t->z) ? t->type == 0 : 1) &&
+              ((element->x == element->y && element->y == element->z) ? element->type == 0 : 1) &&
 #endif
               1;
 #if T8_ENABLE_DEBUG
@@ -1132,27 +1133,27 @@ t8_dtri_is_inside_root (t8_dtri_t *t)
   {
     t8_dtri_t root;
     t8_dtri_init_root (&root);
-    T8_ASSERT (is_inside == t8_dtri_is_ancestor (&root, t));
+    T8_ASSERT (is_inside == t8_dtri_is_ancestor (&root, element));
   }
 #endif
   return is_inside;
 }
 
 int
-t8_dtri_is_root_boundary (const t8_dtri_t *t, int face)
+t8_dtri_is_root_boundary (const t8_dtri_t *element, int face)
 {
   /* Dependent on the type and the face we have to check
    * different conditions */
 #ifndef T8_DTRI_TO_DTET
-  switch (t->type) {
+  switch (element->type) {
   case 0:
     switch (face) {
     case 0:
-      return t->x == T8_DTRI_ROOT_LEN - T8_DTRI_LEN (t->level);
+      return element->x == T8_DTRI_ROOT_LEN - T8_DTRI_LEN (element->level);
     case 1:
-      return t->x == t->y;
+      return element->x == element->y;
     case 2:
-      return t->y == 0;
+      return element->y == 0;
     default:
       SC_ABORT_NOT_REACHED ();
     }
@@ -1162,35 +1163,35 @@ t8_dtri_is_root_boundary (const t8_dtri_t *t, int face)
     SC_ABORT_NOT_REACHED ();
   }
 #else
-  switch (t->type) {
+  switch (element->type) {
   case 0:
     switch (face) {
     case 0:
-      return t->x == T8_DTET_ROOT_LEN - T8_DTET_LEN (t->level);
+      return element->x == T8_DTET_ROOT_LEN - T8_DTET_LEN (element->level);
     case 1:
-      return t->x == t->z;
+      return element->x == element->z;
     case 2:
-      return t->y == t->z;
+      return element->y == element->z;
     case 3:
-      return t->y == 0;
+      return element->y == 0;
     default:
       SC_ABORT_NOT_REACHED ();
     }
   case 1:
     /* type 1 tets are only boundary at face 0 */
-    return face == 0 && t->x == T8_DTET_ROOT_LEN - T8_DTET_LEN (t->level);
+    return face == 0 && element->x == T8_DTET_ROOT_LEN - T8_DTET_LEN (element->level);
   case 2:
     /* type 1 tets are only boundary at face 2 */
-    return face == 2 && t->x == t->z;
+    return face == 2 && element->x == element->z;
   case 3:
     /* type 3 tets are never at the root boundary */
     return 0;
   case 4:
     /* type 4 tets are only boundary at face 1 */
-    return face == 1 && t->y == t->z;
+    return face == 1 && element->y == element->z;
   case 5:
     /* type 5 tets are only boundary at face 3 */
-    return face == 3 && t->y == 0;
+    return face == 3 && element->y == 0;
   default:
     SC_ABORT_NOT_REACHED ();
   }
@@ -1200,11 +1201,12 @@ t8_dtri_is_root_boundary (const t8_dtri_t *t, int face)
 }
 
 int
-t8_dtri_is_equal (const t8_dtri_t *t1, const t8_dtri_t *t2)
+t8_dtri_is_equal (const t8_dtri_t *element1, const t8_dtri_t *element2)
 {
-  return (t1->level == t2->level && t1->type == t2->type && t1->x == t2->x && t1->y == t2->y
+  return (element1->level == element2->level && element1->type == element2->type && element1->x == element2->x
+          && element1->y == element2->y
 #ifdef T8_DTRI_TO_DTET
-          && t1->z == t2->z
+          && element1->z == element2->z
 #endif
   );
 }
@@ -1212,7 +1214,7 @@ t8_dtri_is_equal (const t8_dtri_t *t1, const t8_dtri_t *t2)
 /* we check if t1 and t2 lie in the same subcube and have
  * the same level and parent type */
 int
-t8_dtri_is_sibling (const t8_dtri_t *t1, const t8_dtri_t *t2)
+t8_dtri_is_sibling (const t8_dtri_t *element1, const t8_dtri_t *element2)
 {
   t8_dtri_coord_t exclorx, exclory;
 #ifdef T8_DTRI_TO_DTET
@@ -1221,46 +1223,46 @@ t8_dtri_is_sibling (const t8_dtri_t *t1, const t8_dtri_t *t2)
 
   t8_dtri_cube_id_t cid1, cid2;
 
-  if (t1->level == 0) {
-    return t2->level == 0 && t1->x == t2->x && t1->y == t2->y &&
+  if (element1->level == 0) {
+    return element2->level == 0 && element1->x == element2->x && element1->y == element2->y &&
 #ifdef T8_DTRI_TO_DTET
-           t1->z == t2->z &&
+           element1->z == element2->z &&
 #endif
            1;
   }
 
-  exclorx = t1->x ^ t2->x;
-  exclory = t1->y ^ t2->y;
+  exclorx = element1->x ^ element2->x;
+  exclory = element1->y ^ element2->y;
 #ifdef T8_DTRI_TO_DTET
-  exclorz = t1->z ^ t2->z;
+  exclorz = element1->z ^ element2->z;
 #endif
-  cid1 = compute_cubeid (t1, t1->level);
-  cid2 = compute_cubeid (t2, t2->level);
+  cid1 = compute_cubeid (element1, element1->level);
+  cid2 = compute_cubeid (element2, element2->level);
 
-  return (t1->level == t2->level) && ((exclorx & ~T8_DTRI_LEN (t1->level)) == 0)
-         && ((exclory & ~T8_DTRI_LEN (t1->level)) == 0) &&
+  return (element1->level == element2->level) && ((exclorx & ~T8_DTRI_LEN (element1->level)) == 0)
+         && ((exclory & ~T8_DTRI_LEN (element1->level)) == 0) &&
 #ifdef T8_DTRI_TO_DTET
-         ((exclorz & ~T8_DTRI_LEN (t1->level)) == 0) &&
+         ((exclorz & ~T8_DTRI_LEN (element1->level)) == 0) &&
 #endif
-         t8_dtri_cid_type_to_parenttype[cid1][t1->type] == t8_dtri_cid_type_to_parenttype[cid2][t2->type];
+         t8_dtri_cid_type_to_parenttype[cid1][element1->type] == t8_dtri_cid_type_to_parenttype[cid2][element2->type];
 }
 
 int
-t8_dtri_is_parent (const t8_dtri_t *t, const t8_dtri_t *c)
+t8_dtri_is_parent (const t8_dtri_t *element, const t8_dtri_t *child)
 {
   t8_dtri_cube_id_t cid;
 
-  cid = compute_cubeid (c, c->level);
-  return (t->level + 1 == c->level) && (t->x == (c->x & ~T8_DTRI_LEN (c->level)))
-         && (t->y == (c->y & ~T8_DTRI_LEN (c->level))) &&
+  cid = compute_cubeid (child, child->level);
+  return (element->level + 1 == child->level) && (element->x == (child->x & ~T8_DTRI_LEN (child->level)))
+         && (element->y == (child->y & ~T8_DTRI_LEN (child->level))) &&
 #ifdef T8_DTRI_TO_DTET
-         (t->z == (c->z & ~T8_DTRI_LEN (c->level))) &&
+         (element->z == (child->z & ~T8_DTRI_LEN (child->level))) &&
 #endif
-         t->type == t8_dtri_cid_type_to_parenttype[cid][c->type] && 1;
+         element->type == t8_dtri_cid_type_to_parenttype[cid][child->type] && 1;
 }
 
 int
-t8_dtri_is_ancestor (const t8_dtri_t *t, const t8_dtri_t *c)
+t8_dtri_is_ancestor (const t8_dtri_t *element, const t8_dtri_t *child)
 {
   t8_dtri_coord_t n1, n2;
   t8_dtri_coord_t exclorx;
@@ -1272,17 +1274,17 @@ t8_dtri_is_ancestor (const t8_dtri_t *t, const t8_dtri_t *c)
 #endif
   int8_t type_t;
 
-  if (t->level > c->level) {
+  if (element->level > child->level) {
     return 0;
   }
-  if (t->level == c->level) {
-    return t8_dtri_is_equal (t, c);
+  if (element->level == child->level) {
+    return t8_dtri_is_equal (element, child);
   }
 
-  exclorx = (t->x ^ c->x) >> (T8_DTRI_MAXLEVEL - t->level);
-  exclory = (t->y ^ c->y) >> (T8_DTRI_MAXLEVEL - t->level);
+  exclorx = (element->x ^ child->x) >> (T8_DTRI_MAXLEVEL - element->level);
+  exclory = (element->y ^ child->y) >> (T8_DTRI_MAXLEVEL - element->level);
 #ifdef T8_DTRI_TO_DTET
-  exclorz = (t->z ^ c->z) >> (T8_DTRI_MAXLEVEL - t->level);
+  exclorz = (element->z ^ child->z) >> (T8_DTRI_MAXLEVEL - element->level);
 #endif
 
   if (exclorx == 0 && exclory == 0
@@ -1290,15 +1292,15 @@ t8_dtri_is_ancestor (const t8_dtri_t *t, const t8_dtri_t *c)
       && exclorz == 0
 #endif
   ) {
-    /* t and c have the same cube as ancestor.
+    /* element and child have the same cube as ancestor.
      * Now check if t has the correct type to be c's ancestor. */
-    type_t = t->type;
+    type_t = element->type;
 #ifndef T8_DTRI_TO_DTET
     /* 2D */
-    n1 = (type_t == 0) ? c->x - t->x : c->y - t->y;
-    n2 = (type_t == 0) ? c->y - t->y : c->x - t->x;
+    n1 = (type_t == 0) ? child->x - element->x : child->y - element->y;
+    n2 = (type_t == 0) ? child->y - element->y : child->x - element->x;
 
-    return !(n1 >= T8_DTRI_LEN (t->level) || n2 < 0 || n2 - n1 > 0 || (n2 == n1 && c->type == 1 - type_t));
+    return !(n1 >= T8_DTRI_LEN (element->level) || n2 < 0 || n2 - n1 > 0 || (n2 == n1 && child->type == 1 - type_t));
 #else
     /* 3D */
     /* Compute the coordinate directions according to this table:
@@ -1308,28 +1310,28 @@ t8_dtri_is_ancestor (const t8_dtri_t *t, const t8_dtri_t *c)
      * dir3       z  y  x  z  y  x
      */
     /* clang-format off */
-    n1 = type_t / 2 == 0 ? c->x - t->x :                      /* type(t) is 0 or 1 */
-           type_t / 2 == 2 ? c->z - t->z : c->y - t->y;       /* type(t) is (4 or 5) or (2 or 3) */
-    n2 = (type_t + 1) / 2 == 2 ? c->x - t->x :                /* type(t) is 3 or 4 */
-           (type_t + 1) / 2 == 1 ? c->z - t->z : c->y - t->y; /* type(t) is (1 or 2) or (0 or 5) */
-    dir3 = type_t % 3 == 2 ? c->x - t->x :                    /* type(t) is 2 or 5 */
-             type_t % 3 == 0 ? c->z - t->z : c->y - t->y;     /* type(t) is (0 or 3) or (1 or 4) */
+    n1 = type_t / 2 == 0 ? child->x - element->x :                      /* type(t) is 0 or 1 */
+           type_t / 2 == 2 ? child->z - element->z : child->y - element->y;       /* type(t) is (4 or 5) or (2 or 3) */
+    n2 = (type_t + 1) / 2 == 2 ? child->x - element->x :                /* type(t) is 3 or 4 */
+           (type_t + 1) / 2 == 1 ? child->z - element->z : child->y - element->y; /* type(t) is (1 or 2) or (0 or 5) */
+    dir3 = type_t % 3 == 2 ? child->x - element->x :                    /* type(t) is 2 or 5 */
+             type_t % 3 == 0 ? child->z - element->z : child->y - element->y;     /* type(t) is (0 or 3) or (1 or 4) */
     sign = (type_t % 2 == 0) ? 1 : -1;
     /* clang-format on */
 
     type_t += 6; /* We need to compute modulo six and want
                                    to avoid negative numbers when subtracting from type_t. */
 
-    return !(n1 >= T8_DTRI_LEN (t->level) || n2 < 0 || dir3 - n1 > 0 || n2 - dir3 > 0
+    return !(n1 >= T8_DTRI_LEN (element->level) || n2 < 0 || dir3 - n1 > 0 || n2 - dir3 > 0
              || (dir3 == n2
-                 && (c->type == (type_t + sign * 1) % 6 || c->type == (type_t + sign * 2) % 6
-                     || c->type == (type_t + sign * 3) % 6))
+                 && (child->type == (type_t + sign * 1) % 6 || child->type == (type_t + sign * 2) % 6
+                     || child->type == (type_t + sign * 3) % 6))
              || (dir3 == n1
-                 && (c->type == (type_t - sign * 1) % 6 || c->type == (type_t - sign * 2) % 6
-                     || c->type == (type_t - sign * 3) % 6))
+                 && (child->type == (type_t - sign * 1) % 6 || child->type == (type_t - sign * 2) % 6
+                     || child->type == (type_t - sign * 3) % 6))
              /* On the x-y-z diagonal only tets of the same type can be
               * ancestor of each other. */
-             || (dir3 == n2 && n2 == n1 && type_t - 6 != c->type));
+             || (dir3 == n2 && n2 == n1 && type_t - 6 != child->type));
 #endif
   }
   else {
@@ -1339,27 +1341,27 @@ t8_dtri_is_ancestor (const t8_dtri_t *t, const t8_dtri_t *c)
 
 /* Compute the linear id of the first descendant of a triangle/tet */
 static t8_linearidx_t
-t8_dtri_linear_id_first_desc (const t8_dtri_t *t, int level)
+t8_dtri_linear_id_first_desc (const t8_dtri_t *element, int level)
 {
   /* The id of the first descendant is the id of t in a uniform level
    * refinement */
-  return t8_dtri_linear_id (t, level);
+  return t8_dtri_linear_id (element, level);
 }
 
 /* Compute the linear id of the last descendant of a triangle/tet */
 static t8_linearidx_t
-t8_dtri_linear_id_last_desc (const t8_dtri_t *t, int level)
+t8_dtri_linear_id_last_desc (const t8_dtri_t *element, int level)
 {
   t8_linearidx_t id = 0, t_id;
   int exponent;
 
-  T8_ASSERT (level >= t->level);
+  T8_ASSERT (level >= element->level);
   /* The id of the last descendant at level consists of the id of t in
    * the first digits and then the local ids of all last children
    * (3 in 2d, 7 in 3d)
    */
-  t_id = t8_dtri_linear_id (t, t->level);
-  exponent = level - t->level;
+  t_id = t8_dtri_linear_id (element, element->level);
+  exponent = level - element->level;
   /* Set the last bits to the local ids of always choosing the last child
    * of t */
   id = (((t8_linearidx_t) 1) << T8_DTRI_DIM * exponent) - 1;
@@ -1370,53 +1372,53 @@ t8_dtri_linear_id_last_desc (const t8_dtri_t *t, int level)
 
 /* Construct the linear id of a descendant in a corner of t */
 static t8_linearidx_t
-t8_dtri_linear_id_corner_desc (const t8_dtri_t *t, int corner, int level)
+t8_dtri_linear_id_corner_desc (const t8_dtri_t *element, int corner, int level)
 {
   t8_linearidx_t id = 0, t_id, child_id;
   int it;
 
   T8_ASSERT (0 <= corner && corner < T8_DTRI_CORNERS);
-  T8_ASSERT (t->level <= level && level <= T8_DTRI_MAXLEVEL);
+  T8_ASSERT (element->level <= level && level <= T8_DTRI_MAXLEVEL);
 
   switch (corner) {
   case 0:
-    return t8_dtri_linear_id_first_desc (t, level);
+    return t8_dtri_linear_id_first_desc (element, level);
     break;
   case 1: /* Falls down to case 2 in 3D */
 #ifndef T8_DTRI_TO_DTET
     /* For type 0 triangles, the first corner descendant arises from always
      * taking the first child. For type 1 triangles it is always the second child. */
-    child_id = t8_dtri_parenttype_beyid_to_Iloc[t->type][1];
+    child_id = t8_dtri_parenttype_beyid_to_Iloc[element->type][1];
     break;
 #else
   case 2:
-    /* For tets, the first corner descnendant arises from always taking the n-th
+    /* For tets, the first corner descendant arises from always taking the n-th
      * child, where n is the local child id corresponding to Bey-id corner. */
-    child_id = t8_dtet_parenttype_beyid_to_Iloc[t->type][corner];
+    child_id = t8_dtet_parenttype_beyid_to_Iloc[element->type][corner];
     break;
 #endif
   case T8_DTRI_DIM:
     /* In 2D the 2nd corner and in 3D the 3rd corner correspond to the last
-     * descendant of t */
-    return t8_dtri_linear_id_last_desc (t, level);
+     * descendant of element. */
+    return t8_dtri_linear_id_last_desc (element, level);
     break;
   default:
     SC_ABORT_NOT_REACHED ();
   }
   /* This part is executed for corner 1 (2D) or corner 1 and 2 (3D) */
-  t_id = t8_dtri_linear_id (t, t->level);
-  for (it = 0; it < level - t->level; it++) {
+  t_id = t8_dtri_linear_id (element, element->level);
+  for (it = 0; it < level - element->level; it++) {
     /* Store child_id at every position of the new id after t's level and
      * up to level */
     id |= child_id << (T8_DTRI_DIM * it);
   }
   /* At the beginning add the linear id of t */
-  id |= t_id << (T8_DTRI_DIM * (level - t->level));
+  id |= t_id << (T8_DTRI_DIM * (level - element->level));
   return id;
 }
 
 t8_linearidx_t
-t8_dtri_linear_id (const t8_dtri_t *t, int level)
+t8_dtri_linear_id (const t8_dtri_t *element, int level)
 {
   t8_linearidx_t id = 0;
   int8_t type_temp = 0;
@@ -1426,21 +1428,21 @@ t8_dtri_linear_id (const t8_dtri_t *t, int level)
   int my_level;
 
   T8_ASSERT (0 <= level && level <= T8_DTRI_MAXLEVEL);
-  my_level = t->level;
+  my_level = element->level;
   exponent = 0;
   /* If the given level is bigger than t's level
    * we first fill up with the ids of t's descendants at t's
    * origin with the same type as t */
   if (level > my_level) {
     exponent = (level - my_level) * T8_DTRI_DIM;
-    type_temp = t->type;
+    type_temp = element->type;
     level = my_level;
   }
   else {
-    type_temp = compute_type (t, level);
+    type_temp = compute_type (element, level);
   }
   for (i = level; i > 0; i--) {
-    cid = compute_cubeid (t, i);
+    cid = compute_cubeid (element, i);
     id |= ((t8_linearidx_t) t8_dtri_type_cid_to_Iloc[type_temp][cid]) << exponent;
     exponent += T8_DTRI_DIM; /* multiply with 4 (2d) resp. 8  (3d) */
     type_temp = t8_dtri_cid_type_to_parenttype[cid][type_temp];
@@ -1449,7 +1451,7 @@ t8_dtri_linear_id (const t8_dtri_t *t, int level)
 }
 
 void
-t8_dtri_init_linear_id_with_level (t8_dtri_t *t, t8_linearidx_t id, const int start_level, const int end_level,
+t8_dtri_init_linear_id_with_level (t8_dtri_t *element, t8_linearidx_t id, const int start_level, const int end_level,
                                    t8_dtri_type_t parenttype)
 {
   int i;
@@ -1460,10 +1462,10 @@ t8_dtri_init_linear_id_with_level (t8_dtri_t *t, t8_linearidx_t id, const int st
   t8_dtri_type_t type;
   T8_ASSERT (id <= ((t8_linearidx_t) 1) << (T8_DTRI_DIM * end_level));
   /*Ensure, that the function is called with a valid element */
-  T8_ASSERT (t->level == start_level);
-  T8_ASSERT (t8_dtri_is_valid (t));
+  T8_ASSERT (element->level == start_level);
+  T8_ASSERT (t8_dtri_is_valid (element));
 
-  t->level = end_level;
+  element->level = end_level;
 
   type = parenttype; /* This is the type of the parent triangle */
   for (i = start_level; i <= end_level; i++) {
@@ -1474,17 +1476,17 @@ t8_dtri_init_linear_id_with_level (t8_dtri_t *t, t8_linearidx_t id, const int st
     /* Get the type and cube-id of T's ancestor on level i */
     cid = t8_dtri_parenttype_Iloc_to_cid[type][local_index];
     type = t8_dtri_parenttype_Iloc_to_type[type][local_index];
-    t->x |= (cid & 1) ? 1 << offset_coords : 0;
-    t->y |= (cid & 2) ? 1 << offset_coords : 0;
+    element->x |= (cid & 1) ? 1 << offset_coords : 0;
+    element->y |= (cid & 2) ? 1 << offset_coords : 0;
 #ifdef T8_DTRI_TO_DTET
-    t->z |= (cid & 4) ? 1 << offset_coords : 0;
+    element->z |= (cid & 4) ? 1 << offset_coords : 0;
 #endif
   }
-  t->type = type;
+  element->type = type;
 }
 
 void
-t8_dtri_init_linear_id (t8_dtri_t *t, t8_linearidx_t id, int level)
+t8_dtri_init_linear_id (t8_dtri_t *element, t8_linearidx_t id, int level)
 {
   int i;
   int offset_coords, offset_index;
@@ -1494,11 +1496,11 @@ t8_dtri_init_linear_id (t8_dtri_t *t, t8_linearidx_t id, int level)
   t8_dtri_type_t type;
   T8_ASSERT (id <= ((t8_linearidx_t) 1) << (T8_DTRI_DIM * level));
 
-  t->level = level;
-  t->x = 0;
-  t->y = 0;
+  element->level = level;
+  element->x = 0;
+  element->y = 0;
 #ifdef T8_DTRI_TO_DTET
-  t->z = 0;
+  element->z = 0;
 #endif
   type = 0; /* This is the type of the root triangle */
   for (i = 1; i <= level; i++) {
@@ -1509,24 +1511,24 @@ t8_dtri_init_linear_id (t8_dtri_t *t, t8_linearidx_t id, int level)
     /* Get the type and cube-id of T's ancestor on level i */
     cid = t8_dtri_parenttype_Iloc_to_cid[type][local_index];
     type = t8_dtri_parenttype_Iloc_to_type[type][local_index];
-    t->x |= (cid & 1) ? 1 << offset_coords : 0;
-    t->y |= (cid & 2) ? 1 << offset_coords : 0;
+    element->x |= (cid & 1) ? 1 << offset_coords : 0;
+    element->y |= (cid & 2) ? 1 << offset_coords : 0;
 #ifdef T8_DTRI_TO_DTET
-    t->z |= (cid & 4) ? 1 << offset_coords : 0;
+    element->z |= (cid & 4) ? 1 << offset_coords : 0;
 #endif
   }
-  t->type = type;
+  element->type = type;
 }
 
 void
-t8_dtri_init_root (t8_dtri_t *t)
+t8_dtri_init_root (t8_dtri_t *element)
 {
-  t->level = 0;
-  t->type = 0;
-  t->x = 0;
-  t->y = 0;
+  element->level = 0;
+  element->type = 0;
+  element->x = 0;
+  element->y = 0;
 #ifdef T8_DTRI_TO_DTET
-  t->z = 0;
+  element->z = 0;
 #endif
 }
 
@@ -1535,7 +1537,7 @@ t8_dtri_init_root (t8_dtri_t *t)
  * 'increment' must be greater than -4 (-8) and smaller than +4 (+8).
  * Before calling this function s should store the same entries as t. */
 static void
-t8_dtri_succ_pred_recursion (const t8_dtri_t *t, t8_dtri_t *s, int level, int increment)
+t8_dtri_succ_pred_recursion (const t8_dtri_t *element, t8_dtri_t *s, int level, int increment)
 {
   t8_dtri_type_t type_level, type_level_p1;
   t8_dtri_cube_id_t cid;
@@ -1544,20 +1546,20 @@ t8_dtri_succ_pred_recursion (const t8_dtri_t *t, t8_dtri_t *s, int level, int in
 
   /* We exclude the case level = 0, because the root triangle does
    * not have a successor. */
-  T8_ASSERT (1 <= level && level <= t->level);
+  T8_ASSERT (1 <= level && level <= element->level);
   T8_ASSERT (-T8_DTRI_CHILDREN < increment && increment < T8_DTRI_CHILDREN);
 
   if (increment == 0) {
-    t8_dtri_copy (t, s);
+    t8_dtri_copy (element, s);
     return;
   }
-  cid = compute_cubeid (t, level);
-  type_level = compute_type (t, level);
+  cid = compute_cubeid (element, level);
+  type_level = compute_type (element, level);
   local_index = t8_dtri_type_cid_to_Iloc[type_level][cid];
   local_index = (local_index + T8_DTRI_CHILDREN + increment) % T8_DTRI_CHILDREN;
   if (local_index == 0) {
     sign = increment < 0 ? -1 : increment > 0;
-    t8_dtri_succ_pred_recursion (t, s, level - 1, sign);
+    t8_dtri_succ_pred_recursion (element, s, level - 1, sign);
     type_level_p1 = s->type; /* We stored the type of s at level-1 in s->type */
   }
   else {
@@ -1577,47 +1579,47 @@ t8_dtri_succ_pred_recursion (const t8_dtri_t *t, t8_dtri_t *s, int level, int in
 }
 
 void
-t8_dtri_successor (const t8_dtri_t *t, t8_dtri_t *s, int level)
+t8_dtri_successor (const t8_dtri_t *element, t8_dtri_t *s, int level)
 {
-  t8_dtri_copy (t, s);
-  t8_dtri_succ_pred_recursion (t, s, level, 1);
+  t8_dtri_copy (element, s);
+  t8_dtri_succ_pred_recursion (element, s, level, 1);
 }
 
 void
-t8_dtri_first_descendant (const t8_dtri_t *t, t8_dtri_t *s, int level)
+t8_dtri_first_descendant (const t8_dtri_t *element, t8_dtri_t *s, int level)
 {
   t8_linearidx_t id;
 
-  T8_ASSERT (level >= t->level);
+  T8_ASSERT (level >= element->level);
   /* Compute the linear id of the first descendant */
-  id = t8_dtri_linear_id_first_desc (t, level);
+  id = t8_dtri_linear_id_first_desc (element, level);
   /* The first descendant has exactly this id */
   t8_dtri_init_linear_id (s, id, level);
 }
 
 void
-t8_dtri_last_descendant (const t8_dtri_t *t, t8_dtri_t *s, int level)
+t8_dtri_last_descendant (const t8_dtri_t *element, t8_dtri_t *s, int level)
 {
   t8_linearidx_t id;
 
-  T8_ASSERT (level >= t->level);
+  T8_ASSERT (level >= element->level);
   /* Compute the linear id of t's last descendant */
-  id = t8_dtri_linear_id_last_desc (t, level);
+  id = t8_dtri_linear_id_last_desc (element, level);
   /* Set s to math this linear id */
   t8_dtri_init_linear_id (s, id, level);
 }
 
 void
-t8_dtri_corner_descendant (const t8_dtri_t *t, t8_dtri_t *s, int corner, int level)
+t8_dtri_corner_descendant (const t8_dtri_t *element, t8_dtri_t *s, int corner, int level)
 {
   t8_linearidx_t id;
-  T8_ASSERT (t->level <= level && level <= T8_DTRI_MAXLEVEL);
+  T8_ASSERT (element->level <= level && level <= T8_DTRI_MAXLEVEL);
   T8_ASSERT (0 <= corner && corner < T8_DTRI_CORNERS);
 
   switch (corner) {
   case 0:
     /* The 0-the corner descendant is just the first descendant */
-    t8_dtri_first_descendant (t, s, level);
+    t8_dtri_first_descendant (element, s, level);
     break;
   case 1:
 #ifdef T8_DTRI_TO_DTET /* In 3D corner 1 and 2 are handled the same */
@@ -1625,12 +1627,12 @@ t8_dtri_corner_descendant (const t8_dtri_t *t, t8_dtri_t *s, int corner, int lev
 #endif
     /* Compute the linear id of the descendant and construct a triangle with
      * this id */
-    id = t8_dtri_linear_id_corner_desc (t, corner, level);
+    id = t8_dtri_linear_id_corner_desc (element, corner, level);
     t8_dtri_init_linear_id (s, id, level);
     break;
   case T8_DTRI_DIM:
     /* The 2nd corner (2D) or 3rd corner (3D) descendant is just the last descendant */
-    t8_dtri_last_descendant (t, s, level);
+    t8_dtri_last_descendant (element, s, level);
     break;
   default:
     SC_ABORT_NOT_REACHED ();
@@ -1638,40 +1640,40 @@ t8_dtri_corner_descendant (const t8_dtri_t *t, t8_dtri_t *s, int corner, int lev
 }
 
 void
-t8_dtri_predecessor (const t8_dtri_t *t, t8_dtri_t *s, int level)
+t8_dtri_predecessor (const t8_dtri_t *element, t8_dtri_t *s, int level)
 {
-  t8_dtri_copy (t, s);
-  t8_dtri_succ_pred_recursion (t, s, level, -1);
+  t8_dtri_copy (element, s);
+  t8_dtri_succ_pred_recursion (element, s, level, -1);
 }
 
 int
-t8_dtri_ancestor_id (const t8_dtri_t *t, int level)
+t8_dtri_ancestor_id (const t8_dtri_t *element, int level)
 {
   t8_dtri_cube_id_t cid;
   t8_dtri_type_t type;
 
   T8_ASSERT (0 <= level && level <= T8_DTRI_MAXLEVEL);
-  T8_ASSERT (level <= t->level);
+  T8_ASSERT (level <= element->level);
 
-  cid = compute_cubeid (t, level);
-  type = compute_type (t, level);
+  cid = compute_cubeid (element, level);
+  type = compute_type (element, level);
   return t8_dtri_type_cid_to_Iloc[type][cid];
 }
 
 int
-t8_dtri_child_id (const t8_dtri_t *t)
+t8_dtri_child_id (const t8_dtri_t *element)
 {
-  return t8_dtri_type_cid_to_Iloc[t->type][compute_cubeid (t, t->level)];
+  return t8_dtri_type_cid_to_Iloc[element->type][compute_cubeid (element, element->level)];
 }
 
 int
-t8_dtri_get_level (const t8_dtri_t *t)
+t8_dtri_get_level (const t8_dtri_t *element)
 {
-  return t->level;
+  return element->level;
 }
 
 int
-t8_dtri_is_valid (const t8_dtri_t *t)
+t8_dtri_is_valid (const t8_dtri_t *element)
 {
   int is_valid;
   t8_dtri_coord_t max_coord;
@@ -1681,26 +1683,26 @@ t8_dtri_is_valid (const t8_dtri_t *t)
 
   /* A triangle/tet is valid if: */
   /* The level is in the valid range */
-  is_valid = 0 <= t->level && t->level <= T8_DTRI_MAXLEVEL;
+  is_valid = 0 <= element->level && element->level <= T8_DTRI_MAXLEVEL;
   /* The coordinates are in valid ranges, we allow the x,y,z coordinates
    * to lie in the 3x3 neighborhood of the root cube. */
   max_coord = ((int64_t) 2 * T8_DTRI_ROOT_LEN) - 1;
-  is_valid = is_valid && -T8_DTRI_ROOT_LEN <= t->x && t->x <= max_coord;
-  is_valid = is_valid && -T8_DTRI_ROOT_LEN <= t->y && t->y <= max_coord;
+  is_valid = is_valid && -T8_DTRI_ROOT_LEN <= element->x && element->x <= max_coord;
+  is_valid = is_valid && -T8_DTRI_ROOT_LEN <= element->y && element->y <= max_coord;
 #ifdef T8_DTRI_TO_DTET
-  is_valid = is_valid && -T8_DTRI_ROOT_LEN <= t->z && t->z <= max_coord;
+  is_valid = is_valid && -T8_DTRI_ROOT_LEN <= element->z && element->z <= max_coord;
 #endif
   /* Its type is in the valid range */
-  is_valid = is_valid && 0 <= t->type && t->type < T8_DTRI_NUM_TYPES;
+  is_valid = is_valid && 0 <= element->type && element->type < T8_DTRI_NUM_TYPES;
 
   return is_valid;
 }
 
 void
-t8_dtri_init (t8_dtri_t *t)
+t8_dtri_init (t8_dtri_t *element)
 {
   /* Set all values to zero */
-  memset (t, 0, sizeof (*t));
+  memset (element, 0, sizeof (*element));
 }
 
 /* triangles (tets) are packed as x,y (,z) coordinates, type and level */

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
@@ -33,67 +33,67 @@
 T8_EXTERN_C_BEGIN ();
 
 /** Copy the values of one triangle to another.
- * \param [in] t Triangle whose values will be copied.
+ * \param [in] element Triangle whose values will be copied.
  * \param [in,out] dest Existing triangle whose data will be
- *                      filled with the data of \a t. *
+ *                      filled with the data of \a element.
  */
 void
-t8_dtri_copy (const t8_dtri_t *t, t8_dtri_t *dest);
+t8_dtri_copy (const t8_dtri_t *element, t8_dtri_t *dest);
 
 /** Compare two triangle in their linear order.
- * \param [in] t1 Triangle one.
- * \param [in] t2 Triangle two.
- * \return        Returns negative if t1 < t2, zero if t1 = t2, positive if t1 > t2
+ * \param [in] element1 Triangle one.
+ * \param [in] element2 Triangle two.
+ * \return        Returns negative if tri1 < tri2, zero if tri1 = tri2, positive if tri1 > tri2
  */
 int
-t8_dtri_compare (const t8_dtri_t *t1, const t8_dtri_t *t2);
+t8_dtri_compare (const t8_dtri_t *element1, const t8_dtri_t *element2);
 
 /** Check if two elements are equal.
-* \param [in] elem1  The first element.
-* \param [in] elem2  The second element.
+* \param [in] element1  The first element.
+* \param [in] element2  The second element.
 * \return            1 if the elements are equal, 0 if they are not equal
 */
 int
-t8_dtri_equal (const t8_dtri_t *elem1, const t8_dtri_t *elem2);
+t8_dtri_equal (const t8_dtri_t *element1, const t8_dtri_t *element2);
 
 /** Compute the parent of a triangle.
- * \param [in]  t Input triangle.
+ * \param [in]  element Input triangle.
  * \param [in,out] parent Existing triangle whose data will be filled with the data of elem's parent.
- * \note \a t may point to the same triangle as \a parent.
+ * \note \a element may point to the same triangle as \a parent.
  */
 void
-t8_dtri_parent (const t8_dtri_t *t, t8_dtri_t *parent);
+t8_dtri_parent (const t8_dtri_t *element, t8_dtri_t *parent);
 
 /** Compute the ancestor of a triangle at a given level.
- * \param [in]  t   Input triangle.
- * \param [in]  level A smaller level than \a t.
- * \param [in,out] ancestor Existing triangle whose data will be filled with the data of \a t's ancestor on level 
+ * \param [in]  element   Input triangle.
+ * \param [in]  level A smaller level than \a element.
+ * \param [in,out] ancestor Existing triangle whose data will be filled with the data of \a element's ancestor on level 
  *                 \a level.
- * \note The triangle \a ancestor may point to the same triangle as \a t.
+ * \note The triangle \a ancestor may point to the same triangle as \a element.
  */
 void
-t8_dtri_ancestor (const t8_dtri_t *t, int level, t8_dtri_t *ancestor);
+t8_dtri_ancestor (const t8_dtri_t *element, int level, t8_dtri_t *ancestor);
 
 /** Compute the coordinates of a vertex of a triangle.
- * \param [in] elem         Input triangle.
+ * \param [in] element         Input triangle.
  * \param [in] vertex       The number of the vertex.
  * \param [out] coordinates An array of 2 t8_dtri_coord_t that will be filled with the coordinates of the vertex.
  */
 void
-t8_dtri_compute_integer_coords (const t8_dtri_t *elem, const int vertex, t8_dtri_coord_t coordinates[2]);
+t8_dtri_compute_integer_coords (const t8_dtri_t *element, const int vertex, t8_dtri_coord_t coordinates[2]);
 
 /** Compute the reference coordinates of a vertex of a triangle when the 
  * tree (level 0 triangle) is embedded in \f$ [0,1]^2 \f$.
- * \param [in] elem         Input triangle.
+ * \param [in] element         Input triangle.
  * \param [in] vertex       The number of the vertex.
  * \param [out] coordinates An array of 2 double that will be filled with the reference coordinates of the vertex.
  */
 void
-t8_dtri_compute_vertex_ref_coords (const t8_dtri_t *elem, const int vertex, double coordinates[2]);
+t8_dtri_compute_vertex_ref_coords (const t8_dtri_t *element, const int vertex, double coordinates[2]);
 
 /** Convert points in the reference space of a tri element to points in the
  *  reference space of the tree (level 0) embedded in \f$ [0,1]^2 \f$.
- * \param [in]  elem       Input triangle.
+ * \param [in]  element       Input triangle.
  * \param [in]  ref_coords The reference coordinates in the triangle
  *                         (\a num_coords times \f$ [0,1]^2 \f$)
  * \param [in]  num_coords Number of coordinates to evaluate
@@ -106,30 +106,30 @@ t8_dtri_compute_vertex_ref_coords (const t8_dtri_t *elem, const int vertex, doub
  *                         of the points on the triangle.
  */
 void
-t8_dtri_compute_reference_coords (const t8_dtri_t *elem, const double *ref_coords, const size_t num_coords,
+t8_dtri_compute_reference_coords (const t8_dtri_t *element, const double *ref_coords, const size_t num_coords,
                                   const size_t skip_coords, double *out_coords);
 
 /** Compute the coordinates of the four vertices of a triangle.
- * \param [in] elem         Input triangle.
+ * \param [in] element         Input triangle.
  * \param [out] coordinates An array of 4x3 t8_dtri_coord_t that will be filled with the coordinates of t's vertices.
  */
 void
-t8_dtri_compute_all_coords (const t8_dtri_t *elem, t8_dtri_coord_t coordinates[3][2]);
+t8_dtri_compute_all_coords (const t8_dtri_t *element, t8_dtri_coord_t coordinates[3][2]);
 
 /** Compute the childid-th child in Morton order of a triangle.
- * \param [in] t    Input triangle.
+ * \param [in] element    Input triangle.
  * \param [in,out] childid The id of the child, 0..7 in Morton order.
  * \param [out] child  Existing triangle whose data will be filled with the date of t's childid-th child.
  */
 void
-t8_dtri_child (const t8_dtri_t *t, int childid, t8_dtri_t *child);
+t8_dtri_child (const t8_dtri_t *element, int childid, t8_dtri_t *child);
 
 /** Compute the 4 children of a triangle, array version.
- * \param [in]     t  Input triangle.
- * \param [in,out] c  Pointers to the 4 computed children in Morton order. t may point to the same quadrant as c[0].
+ * \param [in]     element  Input triangle.
+ * \param [in,out] children  Pointers to the 4 computed children in Morton order. t may point to the same quadrant as c[0].
  */
 void
-t8_dtri_childrenpv (const t8_dtri_t *t, t8_dtri_t *c[T8_DTRI_CHILDREN]);
+t8_dtri_childrenpv (const t8_dtri_t *element, t8_dtri_t *children[T8_DTRI_CHILDREN]);
 
 /** Check whether a collection of eight triangles is a family in Morton order.
  * \param [in]     f  An array of eight triangles.
@@ -139,43 +139,44 @@ int
 t8_dtri_is_familypv (const t8_dtri_t *f[]);
 
 /** Compute a specific sibling of a triangle.
- * \param [in]     elem  Input triangle.
- * \param [in,out] sibling  Existing triangle whose data will be filled with the data of sibling no. sibling_id of 
- *                          elem.
+ * \param [in]     element  Input triangle.
  * \param [in]     sibid The id of the sibling computed, 0..7 in Bey order.
+ * \param [in,out] sibling  Existing triangle whose data will be filled with the data of sibling no. sibling_id of 
+ *                          \a element.
  */
 void
-t8_dtri_sibling (const t8_dtri_t *elem, int sibid, t8_dtri_t *sibling);
+t8_dtri_sibling (const t8_dtri_t *element, int sibid, t8_dtri_t *sibling);
 
 /** Compute the face neighbor of a triangle.
- * \param [in]     t      Input triangle.
+ * \param [in]     element      Input triangle.
  * \param [in]     face   The face across which to generate the neighbor.
- * \param [in,out] n      Existing triangle whose data will be filled.
- * \note \a t may point to the same triangle as \a n.
+ * \param [in,out] neigh      Existing triangle whose data will be filled.
+ * \note \a element may point to the same triangle as \a neigh.
  */
 int
-t8_dtri_face_neighbour (const t8_dtri_t *t, int face, t8_dtri_t *n);
+t8_dtri_face_neighbour (const t8_dtri_t *element, int face, t8_dtri_t *neigh);
 
 /** Computes the nearest common ancestor of two triangles in the same tree.
- * \param [in]     t1 First input triangle.
- * \param [in]     t2 Second input triangle.
- * \param [in,out] r Existing triangle whose data will be filled.
- * \note \a t1, \a t2, \a r may point to the same quadrant.
+ * \param [in]     element1 First input triangle.
+ * \param [in]     element2 Second input triangle.
+ * \param [in,out] nca Existing triangle whose data will be filled.
+ * \note \a element1, \a element2, \a nca may point to the same quadrant.
  */
 void
-t8_dtri_nearest_common_ancestor (const t8_dtri_t *t1, const t8_dtri_t *t2, t8_dtri_t *r);
+t8_dtri_nearest_common_ancestor (const t8_dtri_t *element1, const t8_dtri_t *element2, t8_dtri_t *nca);
 
 /** Given a triangle and a face of the triangle, compute all children of the triangle that touch the face.
- * \param [in] tri      The triangle.
- * \param [in] face     A face of \a tri.
- * \param [in,out] children Allocated triangles, in which the children of \a tri that share a face with \a face are 
+ * \param [in] element      The triangle.
+ * \param [in] face     A face of \a element.
+ * \param [in,out] children Allocated triangles, in which the children of \a element that share a face with \a face are 
  *                      stored. They will be stored in order of their child_id.
  * \param [in] num_children The number of triangles in \a children. Must match the number of children that touch 
  *                      \a face.
  * \param [in,out] child_indices The indices of the children in \a children. Only filled if this is null previously.
  */
 void
-t8_dtri_children_at_face (const t8_dtri_t *tri, int face, t8_dtri_t *children[], int num_children, int *child_indices);
+t8_dtri_children_at_face (const t8_dtri_t *element, int face, t8_dtri_t *children[], int num_children,
+                          int *child_indices);
 
 /** Given a face of a triangle and a child number of a child of that face, return the face number of the child of the 
  * triangle that matches the child face.
@@ -199,25 +200,25 @@ t8_dtri_face_parent_face (const t8_dtri_t *triangle, int face);
 
 /** Given a triangle and a face of this triangle. If the face lies on the tree boundary, return the face number of the 
  * tree face. If not the return value is arbitrary.
- * \param [in] t        The triangle.
- * \param [in] face     The index of a face of \a t.
+ * \param [in] element        The triangle.
+ * \param [in] face     The index of a face of \a element.
  * \return The index of the tree face that \a face is a subface of, if \a face is on a tree boundary. Any arbitrary 
- *         integer if \a t is not at a tree boundary.
+ *         integer if \a element is not at a tree boundary.
  * \note For boundary triangles, this function is the inverse of \ref t8_dtri_root_face_to_face
  */
 int
-t8_dtri_tree_face (t8_dtri_t *t, int face);
+t8_dtri_tree_face (t8_dtri_t *element, int face);
 
 /** Given a triangle and a face of the root triangle. If the triangle lies on the tree boundary, return the 
  * corresponding face number of the triangle. If not the return value is arbitrary.
- * \param [in] t        The triangle.
+ * \param [in] element        The triangle.
  * \param [in] root_face     The index of a face of the root element.
- * \return The index of the face of \a t that is a subface of \a root_face, if \a t is on the tree boundary.
- *         Any arbitrary integer if \a t is not at a tree boundary.
+ * \return The index of the face of \a element that is a subface of \a root_face, if \a element is on the tree boundary.
+ *         Any arbitrary integer if \a element is not at a tree boundary.
  * \note For boundary triangles, this function is the inverse of \ref t8_dtri_tree_face
  */
 int
-t8_dtri_root_face_to_face (t8_dtri_t *t, int root_face);
+t8_dtri_root_face_to_face (t8_dtri_t *element, int root_face);
 
 /** Suppose we have two trees that share a common triangle f. Given a triangle e that is a subface of f in one of the 
  * trees and given the orientation of the tree connection, construct the face triangle of the respective tree neighbor 
@@ -239,170 +240,170 @@ t8_dtri_transform_face (const t8_dtri_t *trianglein, t8_dtri_t *triangle2, int o
                         int is_smaller_face);
 
 /** Test if a triangle lies inside of the root triangle, that is the triangle of level 0, anchor node (0,0) and type 0.
- *  \param [in]     t Input triangle.
- *  \return true    If \a t lies inside of the root triangle.
+ *  \param [in]     element Input triangle.
+ *  \return true    If \a element lies inside of the root triangle.
  */
 int
-t8_dtri_is_inside_root (t8_dtri_t *t);
+t8_dtri_is_inside_root (t8_dtri_t *element);
 
 /** Compute whether a given triangle shares a given face with its root tree.
- * \param [in] t        The input triangle.
- * \param [in] face     A face of \a t.
+ * \param [in] element        The input triangle.
+ * \param [in] face     A face of \a element.
  * \return              True if \a face is a subface of the triangle's root element.
  */
 int
-t8_dtri_is_root_boundary (const t8_dtri_t *t, int face);
+t8_dtri_is_root_boundary (const t8_dtri_t *element, int face);
 
 /** Test if two triangles have the same coordinates, type and level.
- * \return true if \a t1 describes the same triangle as \a t2.
+ * \return true if \a element1 describes the same triangle as \a element2.
  */
 int
-t8_dtri_is_equal (const t8_dtri_t *t1, const t8_dtri_t *t2);
+t8_dtri_is_equal (const t8_dtri_t *element1, const t8_dtri_t *element2);
 
 /** Test if two triangles are siblings.
- * \param [in] t1 First triangle to be tested.
- * \param [in] t2 Second triangle to be tested.
- * \return true if \a t1 is equal to or a sibling of \a t2. *
+ * \param [in] element1 First triangle to be tested.
+ * \param [in] element2 Second triangle to be tested.
+ * \return true if \a element1 is equal to or a sibling of \a element2.
  */
 int
-t8_dtri_is_sibling (const t8_dtri_t *t1, const t8_dtri_t *t2);
+t8_dtri_is_sibling (const t8_dtri_t *element1, const t8_dtri_t *element2);
 
 /** Test if a triangle is the parent of another triangle.
- * \param [in] t triangle to be tested.
- * \param [in] c Possible child triangle.
- * \return true if \a t is the parent of \a c.
+ * \param [in] element triangle to be tested.
+ * \param [in] child Possible child triangle.
+ * \return true if \a element is the parent of \a child.
  */
 int
-t8_dtri_is_parent (const t8_dtri_t *t, const t8_dtri_t *c);
+t8_dtri_is_parent (const t8_dtri_t *element, const t8_dtri_t *child);
 
 /** Test if a triangle is an ancestor of another triangle.
- * \param [in] t triangle to be tested.
- * \param [in] c Descendent triangle.
- * \return true if \a t is equal to or an ancestor of \a c.
+ * \param [in] element triangle to be tested.
+ * \param [in] child Descendent triangle.
+ * \return true if \a element is equal to or an ancestor of \a child.
  */
 int
-t8_dtri_is_ancestor (const t8_dtri_t *t, const t8_dtri_t *c);
+t8_dtri_is_ancestor (const t8_dtri_t *element, const t8_dtri_t *child);
 
 /** Computes the linear position of a triangle in a uniform grid.
- * \param [in] t  triangle whose id will be computed.
+ * \param [in] element  triangle whose id will be computed.
  * \param [in] level level of uniform grid to be considered.
  * \return Returns the linear position of this triangle on a grid of level \a level.
  * \note This id is not the Morton index.
  */
 t8_linearidx_t
-t8_dtri_linear_id (const t8_dtri_t *t, int level);
+t8_dtri_linear_id (const t8_dtri_t *element, int level);
 
 /**
  * Same as init_linear_id, but we only consider the subtree. Used for computing the index of a tetrahedron lying in a 
  * pyramid
- * \param [in, out] t   Existing triangle whose data will be filled
+ * \param [in, out] element   Existing triangle whose data will be filled
  * \param [in] id            Index to be considered
  * \param [in] start_level   The level of the root of the subtree
  * \param [in] end_level     Level of uniform grid to be considered
  * \param [in] parenttype    The type of the parent.
  */
 void
-t8_dtri_init_linear_id_with_level (t8_dtri_t *t, t8_linearidx_t id, const int start_level, const int end_level,
+t8_dtri_init_linear_id_with_level (t8_dtri_t *element, t8_linearidx_t id, const int start_level, const int end_level,
                                    t8_dtri_type_t parenttype);
 
 /** Initialize a triangle as the triangle with a given global id in a uniform refinement of a given level. *
- * \param [in,out] t  Existing triangle whose data will be filled.
+ * \param [in,out] element  Existing triangle whose data will be filled.
  * \param [in] id     Index to be considered.
  * \param [in] level  level of uniform grid to be considered.
  */
 void
-t8_dtri_init_linear_id (t8_dtri_t *t, t8_linearidx_t id, int level);
+t8_dtri_init_linear_id (t8_dtri_t *element, t8_linearidx_t id, int level);
 
 /** Initialize a triangle as the root triangle (type 0 at level 0)
- * \param [in,out] t Existing triangle whose data will be filled.
+ * \param [in,out] element Existing triangle whose data will be filled.
  */
 void
-t8_dtri_init_root (t8_dtri_t *t);
+t8_dtri_init_root (t8_dtri_t *element);
 
 /** Computes the successor of a triangle in a uniform grid of level \a level.
- * \param [in] t  triangle whose id will be computed.
+ * \param [in] element  triangle whose id will be computed.
  * \param [in,out] s Existing triangle whose data will be filled with the
  *                data of t's successor on level \a level.
  * \param [in] level level of uniform grid to be considered.
  */
 void
-t8_dtri_successor (const t8_dtri_t *t, t8_dtri_t *s, int level);
+t8_dtri_successor (const t8_dtri_t *element, t8_dtri_t *s, int level);
 
 /** Compute the first descendant of a triangle at a given level. This is the descendant of
  * the triangle in a uniform maxlevel refinement that has the smaller id.
- * \param [in] t        Triangle whose descendant is computed.
- * \param [in] level    A given level. Must be grater or equal to \a t's level.
+ * \param [in] element        Triangle whose descendant is computed.
+ * \param [in] level    A given level. Must be grater or equal to \a element's level.
  * \param [out] s       Existing triangle whose data will be filled with the data
  *                      of t's first descendant.
  */
 void
-t8_dtri_first_descendant (const t8_dtri_t *t, t8_dtri_t *s, int level);
+t8_dtri_first_descendant (const t8_dtri_t *element, t8_dtri_t *s, int level);
 
 /** Compute the last descendant of a triangle at a given level. This is the descendant of
  * the triangle in a uniform maxlevel refinement that has the biggest id.
- * \param [in] t        Triangle whose descendant is computed.
- * \param [in] level    A given level. Must be grater or equal to \a t's level.
+ * \param [in] element        Triangle whose descendant is computed.
+ * \param [in] level    A given level. Must be grater or equal to \a element's level.
  * \param [out] s       Existing triangle whose data will be filled with the data
  *                      of t's last descendant.
  */
 void
-t8_dtri_last_descendant (const t8_dtri_t *t, t8_dtri_t *s, int level);
+t8_dtri_last_descendant (const t8_dtri_t *element, t8_dtri_t *s, int level);
 
 /** Compute the descendant of a triangle in a given corner.
- * \param [in] t        Triangle whose descendant is computed.
+ * \param [in] element       Triangle whose descendant is computed.
  * \param [out] s       Existing triangle whose data will be filled with the data
  *                      of t's descendant in \a corner.
  * \param [in]  corner  The corner in which the descendant should lie.
  * \param [in]  level   The refinement level of the descendant. Must be greater or
- *                      equal to \a t's level.
+ *                      equal to \a element's level.
  */
 void
-t8_dtri_corner_descendant (const t8_dtri_t *t, t8_dtri_t *s, int corner, int level);
+t8_dtri_corner_descendant (const t8_dtri_t *element, t8_dtri_t *s, int corner, int level);
 
 /** Computes the predecessor of a triangle in a uniform grid of level \a level.
- * \param [in] t  triangle whose id will be computed.
+ * \param [in] element  triangle whose id will be computed.
  * \param [in,out] s Existing triangle whose data will be filled with the
- *                data of t's predecessor on level \a level.
+ *                data of \a element's predecessor on level \a level.
  * \param [in] level level of uniform grid to be considered.
  */
 void
-t8_dtri_predecessor (const t8_dtri_t *t, t8_dtri_t *s, int level);
+t8_dtri_predecessor (const t8_dtri_t *element, t8_dtri_t *s, int level);
 
 /** Compute the position of the ancestor of this child at level \a level within its siblings.
- * \param [in] t  triangle to be considered.
+ * \param [in] element  triangle to be considered.
  * \param [in] level level to be considered.
  * \return Returns its child id in 0..3
  */
 int
-t8_dtri_ancestor_id (const t8_dtri_t *t, int level);
+t8_dtri_ancestor_id (const t8_dtri_t *element, int level);
 
 /** Compute the position of the ancestor of this child at level \a level within its siblings.
- * \param [in] t  triangle to be considered.
+ * \param [in] element  triangle to be considered.
  * \return Returns its child id in 0..3
  */
 int
-t8_dtri_child_id (const t8_dtri_t *t);
+t8_dtri_child_id (const t8_dtri_t *element);
 
 /** Return the level of a triangle.
- * \param [in] t  triangle to be considered.
- * \return        The level of \a t.
+ * \param [in] element  triangle to be considered.
+ * \return        The level of \a element.
  */
 int
-t8_dtri_get_level (const t8_dtri_t *t);
+t8_dtri_get_level (const t8_dtri_t *element);
 
 /** Query whether all entries of a triangle are in valid ranges.
- * \param [in] t  triangle to be considered.
- * \return        True, if \a t is a valid triangle and it is safe to call any function on \a t. False otherwise.
+ * \param [in] element  triangle to be considered.
+ * \return        True, if \a element is a valid triangle and it is safe to call any function on \a element. False otherwise.
  */
 int
-t8_dtri_is_valid (const t8_dtri_t *t);
+t8_dtri_is_valid (const t8_dtri_t *element);
 
 #if T8_ENABLE_DEBUG
 /** Set sensible default values for a triangle.
- * \param [in,out] t A triangle.
+ * \param [in,out] element A triangle.
  */
 void
-t8_dtri_init (t8_dtri_t *t);
+t8_dtri_init (t8_dtri_t *element);
 #endif
 
 /** Packs an array of triangle elements into contiguous memory. 

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
@@ -310,11 +310,11 @@ t8_default_scheme_vertex::element_get_reference_coords ([[maybe_unused]] const t
 
 #if T8_ENABLE_DEBUG
 int
-t8_default_scheme_vertex::element_is_valid ([[maybe_unused]] const t8_element_t *elem)
+t8_default_scheme_vertex::element_is_valid ([[maybe_unused]] const t8_element_t *element)
 
 {
   /* Check maxlevel, nothing else is saved in a vertex. */
-  const t8_dvertex_t *vertex = (t8_dvertex_t *) elem;
+  const t8_dvertex_t *vertex = (t8_dvertex_t *) element;
   return vertex->level <= T8_DVERTEX_MAXLEVEL;
 }
 

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.hxx
@@ -605,8 +605,8 @@ class t8_default_scheme_vertex: public t8_default_scheme_common<t8_default_schem
 #if T8_ENABLE_DEBUG
   /** Query whether a given element can be considered as 'valid' and it is
    *  safe to perform any of the above algorithms on it.
-   * \param [in]      t  The element to be checked.
-   * \return          True if \a t is safe to use. False otherwise.
+   * \param [in]      element  The element to be checked.
+   * \return          True if \a element is safe to use. False otherwise.
    * \note            An element that is constructed with \ref element_new
    *                  must pass this test.
    * \note            An element for which \ref element_init was called must pass
@@ -618,7 +618,7 @@ class t8_default_scheme_vertex: public t8_default_scheme_common<t8_default_schem
    *                  in the implementation of each of the functions in this file.
    */
   static int
-  element_is_valid (const t8_element_t *t);
+  element_is_valid (const t8_element_t *element);
 
   /**
   * Print a given element. For a example for a triangle print the coordinates


### PR DESCRIPTION
**_Describe your changes here:_**
Closes #1861
Rename variables from t to element in t8 scheme default. Additionally, this makes the variable naming of some functions in the .hxx and .cxx files consistent.
Hope that i catched all t's.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).