### PR TITLE
Improvement: clearer error message when creating a distributed cmesh

### DIFF
--- a/src/t8_cmesh/t8_cmesh_commit.cxx
+++ b/src/t8_cmesh/t8_cmesh_commit.cxx
@@ -549,7 +549,10 @@ t8_cmesh_commit (t8_cmesh_t cmesh, sc_MPI_Comm comm)
   T8_ASSERT (comm != sc_MPI_COMM_NULL);
   T8_ASSERT (!cmesh->committed);
   SC_CHECK_ABORT (0 <= cmesh->dimension && cmesh->dimension <= T8_ECLASS_MAX_DIM,
-                  "Dimension of the cmesh is not set properly.\n");
+                  "Dimension of the cmesh is not set properly. This error may be "
+                  "caused by empty cmesh partitions whose dimension can't be "
+                  "inferred from the element types. Try setting the dimension "
+                  "explicitly using t8_cmesh_set_dimension\n");
 
   /* If profiling is enabled, we measure the runtime of  commit. */
   if (cmesh->profile != NULL) {


### PR DESCRIPTION
**_Describe your changes here:_**
This PR adds a hint to fix the problem of creating distributed meshes with empty partitions, following a discussion with @holke. This problem could also be eliminated completely by performing an `MPI_[All]gather` and using that information to both propagate the information to the eventual empty partitions, as well as checking that all the partitions agree on the dimension. This robustness enhancement would definitely cost some CPU cycles though, but I don't have enough context to evaluate if this would be an acceptable tradeoff.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).