### PR TITLE
Bugfix: Geometry access of cad shapes

### DIFF
--- a/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.hxx
+++ b/src/t8_geometry/t8_geometry_implementations/t8_geometry_cad.hxx
@@ -209,16 +209,28 @@ struct t8_geometry_cad: public t8_geometry_with_vertices
   t8_geom_evaluate_cad_prism (t8_cmesh_t cmesh, t8_gloidx_t gtreeid, const double *ref_coords, const size_t num_coords,
                               double *out_coords) const;
 
+  /**
+   * Evaluate a point on a CAD curve.
+   * \param [in] edge_index The index of the curve in the CAD shape.
+   * \param [in] param      The parameter on the curve to evaluate.
+   * \return The point on the curve.
+   */
+  gp_Pnt
+  process_curve (const int curve_index, const double param) const;
+
+  /**
+   * Evaluate a point on a CAD surface.
+   * \param [in] surface_index The index of the surface in the CAD shape.
+   * \param [in] param      The parameter on the surface to evaluate.
+   * \return The point on the surface.
+   */
+  gp_Pnt
+  process_surface (const int surface_index, const double *params) const;
+
   const int *edges; /**< The linked edges of the currently active tree. */
   const int *faces; /**< The linked faces of the currently active tree. */
 
   std::shared_ptr<t8_cad> cad_manager; /**< The CAD manager of the geometry. */
-
-  gp_Pnt
-  process_curve (const int edge_index, const double interpolated_curve_param) const;
-
-  gp_Pnt
-  process_surface (const int face_index, const double *interpolated_surface_params, const int offset) const;
 };
 
 #endif /* !T8_GEOMETRY_CAD_HXX */


### PR DESCRIPTION
Closes #1879

**_Describe your changes here:_**
During the last geometry update, the access for cad shapes got mangled. This PR fixes that.
It also introduces clearer names for parameters. Can be verified by running the cad tutorials

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).