### PR TITLE
Improvement: Change location of CodeCoverage include in cmake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,14 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     "Debug" "Release" "RelWithDebInfo")
 endif()
 
+if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
+  # Option to generate code coverage target.
+  option( T8CODE_CODE_COVERAGE "Enable code coverage reporting" OFF)
+  if(T8CODE_CODE_COVERAGE)
+    include(./cmake/CodeCoverage.cmake)
+  endif()
+endif()
+
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 if( T8CODE_BUILD_FORTRAN_INTERFACE )

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -13,8 +13,8 @@
 # Adds compiler flags necessary to be able to collect coverage information.
 # 
 function(append_coverage_compiler_flags)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g --coverage" PARENT_SCOPE)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g --coverage" PARENT_SCOPE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g --coverage -O0" PARENT_SCOPE)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g --coverage -O0" PARENT_SCOPE)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage" PARENT_SCOPE)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage" PARENT_SCOPE)
 endfunction() # append_coverage_compiler_flags
@@ -79,8 +79,6 @@ function(setup_target_for_coverage)
 
     # Generate HTML file using genhtml.
     COMMAND ${GENHTML_PATH} -o ${Coverage_NAME} ${Coverage_NAME}.info
-    # Show result in terminal.
-    COMMAND ${LCOV_PATH} --list ${Coverage_NAME}.info
 
     BYPRODUCTS
       ${Coverage_NAME}.base
@@ -98,6 +96,6 @@ endfunction() # setup_target_for_coverage
 append_coverage_compiler_flags()
 setup_target_for_coverage(
   NAME coverage
-  EXCLUDE "${CMAKE_SOURCE_DIR}/sc*"
-  LCOV_ARGS "--no-external"
+  EXCLUDE "${CMAKE_SOURCE_DIR}/sc*" "${CMAKE_SOURCE_DIR}/p4est*" "${CMAKE_SOURCE_DIR}/test*" "${CMAKE_SOURCE_DIR}/thirdparty*" "${CMAKE_SOURCE_DIR}/tutorials*" "${CMAKE_SOURCE_DIR}/example*" "${CMAKE_SOURCE_DIR}/benchmarks*"
+  LCOV_ARGS --no-external --ignore-errors gcov,mismatch --demangle-cpp
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,12 +41,6 @@ if( CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" )
 endif()
 
 if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
-  # Option to generate code coverage target.
-  option( T8CODE_CODE_COVERAGE "Enable code coverage reporting" OFF)
-  if(T8CODE_CODE_COVERAGE)
-    include(CodeCoverage)
-  endif()
-
   set (T8_CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}")
   set (T8_CFLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_DEBUG}")
 


### PR DESCRIPTION
**_Describe your changes here:_**
The current location of the CodeCoverage.cmake include in the src cmake means that only the src folder is taken into account and coverage information is only collected for this folder. This causes problems when using templates, as no code is created here if the class is only used in tests, etc. Accordingly, we now also compile the remaining files with the --coverage option, which means that templated code is better taken into account. The test files and other files are, of course, excluded again for the creation of the codecoverage report.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).