### PR TITLE
Add element print in release

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_common/t8_default_common.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common/t8_default_common.hxx
@@ -307,7 +307,19 @@ class t8_default_scheme_common: public t8_crtp_operator<TUnderlyingEclassScheme,
     const int dim = t8_eclass_to_dimension[eclass];
     return count_leaves_from_level (0, level, dim);
   }
-
+  /**
+   * Print a given element. For a example for a triangle print the coordinates
+   * and the level of the triangle. This function is only available in the
+   * debugging configuration. 
+   * \param [in]        elem  The element to print
+   */
+  inline void
+  element_print (const t8_element_t *elem) const
+  {
+    char debug_string[BUFSIZ];
+    this->underlying ().element_to_string (elem, debug_string, BUFSIZ);
+    t8_productionf ("%s\n", debug_string);
+  }
 #if T8_ENABLE_DEBUG
   /**
    * Print a given element. For a example for a triangle print the coordinates

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
@@ -639,6 +639,7 @@ t8_default_scheme_hex::element_is_valid (const t8_element_t *element) const
          && T8_QUAD_GET_TDIM ((const p8est_quadrant_t *) element) == 3;
 }
 
+#endif
 void
 t8_default_scheme_hex::element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const
 {
@@ -647,7 +648,6 @@ t8_default_scheme_hex::element_to_string (const t8_element_t *elem, char *debug_
   p8est_quadrant_t *hex = (p8est_quadrant_t *) elem;
   snprintf (debug_string, string_size, "x: %i, y: %i, z: %i, level: %i", hex->x, hex->y, hex->z, hex->level);
 }
-#endif
 
 void
 t8_default_scheme_hex::set_to_root (t8_element_t *elem) const

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.hxx
@@ -574,6 +574,7 @@ class t8_default_scheme_hex: public t8_default_scheme_common<t8_default_scheme_h
   int
   element_is_valid (const t8_element_t *element) const;
 
+#endif
   /**
   * Print a given element. For a example for a triangle print the coordinates
   * and the level of the triangle. This function is only available in the
@@ -585,7 +586,6 @@ class t8_default_scheme_hex: public t8_default_scheme_common<t8_default_scheme_h
   */
   void
   element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
-#endif
 
   /** Fills an element with the root element.
  * \param [in,out] elem   The element to be filled with root.

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
@@ -405,6 +405,7 @@ t8_default_scheme_line::element_is_valid (const t8_element_t *element) const
 {
   return t8_dline_is_valid ((const t8_dline_t *) element);
 }
+#endif
 
 void
 t8_default_scheme_line::element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const
@@ -414,7 +415,6 @@ t8_default_scheme_line::element_to_string (const t8_element_t *elem, char *debug
   t8_dline_t *line = (t8_dline_t *) elem;
   snprintf (debug_string, string_size, "x: %i, level: %i", line->x, line->level);
 }
-#endif
 
 void
 t8_default_scheme_line::element_new (int length, t8_element_t **elem) const

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.hxx
@@ -585,6 +585,7 @@ class t8_default_scheme_line: public t8_default_scheme_common<t8_default_scheme_
   int
   element_is_valid (const t8_element_t *element) const;
 
+#endif
   /**
   * Print a given element. For a example for a triangle print the coordinates
   * and the level of the triangle. This function is only available in the
@@ -596,7 +597,6 @@ class t8_default_scheme_line: public t8_default_scheme_common<t8_default_scheme_
   */
   void
   element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
-#endif
   /** Fills an element with the root element.
  * \param [in,out] elem   The element to be filled with root.
  */

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
@@ -441,6 +441,7 @@ t8_default_scheme_prism::element_is_valid (const t8_element_t *element) const
   T8_ASSERT (element != NULL);
   return t8_dprism_is_valid ((const t8_dprism_t *) element);
 }
+#endif /* T8_ENABLE_DEBUG */
 
 void
 t8_default_scheme_prism::element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const
@@ -451,8 +452,6 @@ t8_default_scheme_prism::element_to_string (const t8_element_t *elem, char *debu
   snprintf (debug_string, string_size, "x: %i, y: %i, z: %i, type: %i, level: %i", prism->tri.x, prism->tri.y,
             prism->line.x, prism->tri.type, prism->tri.level);
 }
-
-#endif /* T8_ENABLE_DEBUG */
 
 void
 t8_default_scheme_prism::set_to_root (t8_element_t *elem) const

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.hxx
@@ -555,6 +555,7 @@ class t8_default_scheme_prism: public t8_default_scheme_common<t8_default_scheme
    */
   int
   element_is_valid (const t8_element_t *element) const;
+#endif
 
   /**
   * Print a given element. For a example for a triangle print the coordinates
@@ -567,7 +568,6 @@ class t8_default_scheme_prism: public t8_default_scheme_common<t8_default_scheme
   */
   void
   element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
-#endif
 
   /** Fills an element with the root element.
  * \param [in,out] elem   The element to be filled with root.

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
@@ -433,6 +433,7 @@ t8_default_scheme_pyramid::element_is_valid (const t8_element_t *element) const
   return t8_dpyramid_is_valid ((const t8_dpyramid_t *) element);
 }
 
+#endif
 void
 t8_default_scheme_pyramid::element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const
 {
@@ -443,7 +444,6 @@ t8_default_scheme_pyramid::element_to_string (const t8_element_t *elem, char *de
             pyra->pyramid.x, pyra->pyramid.y, pyra->pyramid.x, pyra->pyramid.type, pyra->pyramid.level,
             pyra->switch_shape_at_level);
 }
-#endif
 
 void
 t8_default_scheme_pyramid::set_to_root (t8_element_t *elem) const

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.hxx
@@ -575,6 +575,7 @@ class t8_default_scheme_pyramid: public t8_default_scheme_common<t8_default_sche
    */
   int
   element_is_valid (const t8_element_t *element) const;
+#endif
 
   /**
   * Print a given element. For a example for a triangle print the coordinates
@@ -587,7 +588,6 @@ class t8_default_scheme_pyramid: public t8_default_scheme_common<t8_default_sche
   */
   void
   element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
-#endif
 
   /** Fills an element with the root element.
  * \param [in,out] elem   The element to be filled with root.

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
@@ -751,6 +751,7 @@ t8_default_scheme_quad::element_is_valid (const t8_element_t *element) const
    */
   return p4est_quadrant_is_extended ((const p4est_quadrant_t *) element);
 }
+#endif
 
 void
 t8_default_scheme_quad::element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const
@@ -760,7 +761,6 @@ t8_default_scheme_quad::element_to_string (const t8_element_t *elem, char *debug
   p4est_quadrant_t *quad = (p4est_quadrant_t *) elem;
   snprintf (debug_string, string_size, "x: %i, y: %i, level: %i", quad->x, quad->y, quad->level);
 }
-#endif
 
 void
 t8_default_scheme_quad::set_to_root (t8_element_t *elem) const

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
@@ -604,6 +604,7 @@ class t8_default_scheme_quad: public t8_default_scheme_common<t8_default_scheme_
    */
   int
   element_is_valid (const t8_element_t *element) const;
+#endif
 
   /**
   * Print a given element. For a example for a triangle print the coordinates
@@ -616,7 +617,6 @@ class t8_default_scheme_quad: public t8_default_scheme_common<t8_default_scheme_
   */
   void
   element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
-#endif
 
   /** Fills an element with the root element.
  * \param [in,out] elem   The element to be filled with root.

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.cxx
@@ -495,6 +495,7 @@ t8_default_scheme_tet::element_is_valid (const t8_element_t *element) const
 {
   return t8_dtet_is_valid ((const t8_dtet_t *) element);
 }
+#endif
 
 void
 t8_default_scheme_tet::element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const
@@ -505,7 +506,6 @@ t8_default_scheme_tet::element_to_string (const t8_element_t *elem, char *debug_
   snprintf (debug_string, string_size, "x: %i, y: %i, z: %i, type: %i, level: %i", tet->x, tet->y, tet->z, tet->type,
             tet->level);
 }
-#endif
 
 void
 t8_default_scheme_tet::element_new (int length, t8_element_t **elem) const

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.hxx
@@ -524,6 +524,7 @@ class t8_default_scheme_tet: public t8_default_scheme_common<t8_default_scheme_t
    */
   int
   element_is_valid (const t8_element_t *element) const;
+#endif
 
   /**
   * Print a given element. For a example for a triangle print the coordinates
@@ -536,7 +537,6 @@ class t8_default_scheme_tet: public t8_default_scheme_common<t8_default_scheme_t
   */
   void
   element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
-#endif
 
   /** Fills an element with the root element.
  * \param [in,out] elem   The element to be filled with root.

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.cxx
@@ -507,6 +507,7 @@ t8_default_scheme_tri::element_is_valid (const t8_element_t *element) const
 {
   return t8_dtri_is_valid ((const t8_dtri_t *) element);
 }
+#endif
 
 void
 t8_default_scheme_tri::element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const
@@ -516,7 +517,6 @@ t8_default_scheme_tri::element_to_string (const t8_element_t *elem, char *debug_
   t8_dtri_t *tri = (t8_dtri_t *) elem;
   snprintf (debug_string, string_size, "x: %i, y: %i, type: %i, level: %i", tri->x, tri->y, tri->type, tri->level);
 }
-#endif
 
 void
 t8_default_scheme_tri::element_new (int length, t8_element_t **elem) const

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.hxx
@@ -516,6 +516,7 @@ class t8_default_scheme_tri: public t8_default_scheme_common<t8_default_scheme_t
    */
   int
   element_is_valid (const t8_element_t *element) const;
+#endif
 
   /**
   * Print a given element. For a example for a triangle print the coordinates
@@ -528,7 +529,6 @@ class t8_default_scheme_tri: public t8_default_scheme_common<t8_default_scheme_t
   */
   void
   element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
-#endif
 
   /** Fills an element with the root element.
  * \param [in,out] elem   The element to be filled with root.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
@@ -317,6 +317,7 @@ t8_default_scheme_vertex::element_is_valid ([[maybe_unused]] const t8_element_t 
   const t8_dvertex_t *vertex = (t8_dvertex_t *) element;
   return vertex->level <= T8_DVERTEX_MAXLEVEL;
 }
+#endif
 
 void
 t8_default_scheme_vertex::element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const
@@ -326,7 +327,6 @@ t8_default_scheme_vertex::element_to_string (const t8_element_t *elem, char *deb
   t8_dvertex_t *vertex = (t8_dvertex_t *) elem;
   snprintf (debug_string, string_size, "level: %i", vertex->level);
 }
-#endif
 
 int
 t8_default_scheme_vertex::refines_irregular () const

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.hxx
@@ -619,6 +619,7 @@ class t8_default_scheme_vertex: public t8_default_scheme_common<t8_default_schem
    */
   static int
   element_is_valid (const t8_element_t *element);
+#endif
 
   /**
   * Print a given element. For a example for a triangle print the coordinates
@@ -631,7 +632,6 @@ class t8_default_scheme_vertex: public t8_default_scheme_common<t8_default_schem
   */
   void
   element_to_string (const t8_element_t *elem, char *debug_string, const int string_size) const;
-#endif
 
   /** Fills an element with the root element.
  * \param [in,out] elem   The element to be filled with root.

--- a/src/t8_schemes/t8_scheme.cxx
+++ b/src/t8_schemes/t8_scheme.cxx
@@ -369,6 +369,7 @@ t8_element_debug_print (const t8_scheme_c *scheme, const t8_eclass_t tree_class,
 {
   return scheme->element_debug_print (tree_class, elem);
 }
+#endif
 
 void
 t8_element_to_string (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *elem,
@@ -378,7 +379,12 @@ t8_element_to_string (const t8_scheme_c *scheme, const t8_eclass_t tree_class, c
 
   return scheme->element_to_string (tree_class, elem, debug_string, string_size);
 }
-#endif
+
+void
+t8_element_print (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const t8_element_t *elem)
+{
+  return scheme->element_print (tree_class, elem);
+}
 
 void
 t8_element_new (const t8_scheme_c *scheme, const t8_eclass_t tree_class, const int length, t8_element_t **elems)

--- a/src/t8_schemes/t8_scheme.hxx
+++ b/src/t8_schemes/t8_scheme.hxx
@@ -984,6 +984,7 @@ class t8_scheme {
     return std::visit ([&] (auto &&scheme) { return scheme.element_debug_print (element); },
                        eclass_schemes[tree_class]);
   };
+#endif
 
   /**
  * Fill a string with readable information about the element
@@ -999,7 +1000,19 @@ class t8_scheme {
     return std::visit ([&] (auto &&scheme) { return scheme.element_to_string (element, debug_string, string_size); },
                        eclass_schemes[tree_class]);
   };
-#endif
+
+  /**
+ * Print a given element. For a example for a triangle print the coordinates
+ * and the level of the triangle. This function is only available in the
+ * debugging configuration.
+ * \param [in] tree_class    The eclass of the current tree. 
+ * \param [in] element  The element to print
+ */
+  inline void
+  element_print (const t8_eclass_t tree_class, const t8_element_t *element) const
+  {
+    return std::visit ([&] (auto &&scheme) { return scheme.element_print (element); }, eclass_schemes[tree_class]);
+  };
 
   /** Allocate memory for \a length many elements of a given class and initialize them,
    * and put pointers to the elements in the provided array.

--- a/src/t8_schemes/t8_standalone/t8_standalone_implementation.hxx
+++ b/src/t8_schemes/t8_standalone/t8_standalone_implementation.hxx
@@ -1734,7 +1734,7 @@ struct t8_standalone_scheme
       t8_debugf ("t_%i: %i \n", e_num, get_typebit (el->type, e_num));
     }
   }
-
+#endif
   /**
  * Fill a string with readable information about the element
  * \param[in] elem The element to translate into human-readable information
@@ -1752,7 +1752,20 @@ struct t8_standalone_scheme
     }
   }
 
-#endif
+  static constexpr void
+  element_print (const t8_element_t *elem) noexcept
+  {
+
+    const t8_standalone_element<TEclass> *el = (const t8_standalone_element<TEclass> *) elem;
+
+    t8_productionf ("level: %i\n", el->level);
+    for (int idim = 0; idim < T8_ELEMENT_DIM[TEclass]; idim++) {
+      t8_productionf ("x_%i: %i \n", idim, el->coords[idim]);
+    }
+    for (int e_num = 0; e_num < T8_ELEMENT_NUM_EQUATIONS[TEclass]; e_num++) {
+      t8_productionf ("t_%i: %i \n", e_num, get_typebit (el->type, e_num));
+    }
+  }
 
   // ################################################____MPI____################################################
 


### PR DESCRIPTION
Closes #1912

**_Describe your changes here:_**
Sometimes, weird stuff only happens in Release mode.
In order to manually find the error with print statements, this PR helps by introducing a print function that is available in release.

I am also open to just have one implementation, that works in both modes but only prints with DEBUG priority.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).