### PR TITLE
Bugfix: VTK Output of empty partitions

### DIFF
--- a/src/t8_vtk/t8_vtk_writer.hxx
+++ b/src/t8_vtk/t8_vtk_writer.hxx
@@ -382,8 +382,8 @@ class vtk_writer {
     T8_ASSERT (cellTypes != NULL);
 
     /* Get the local bounds of the forest or cmesh */
+    double bounds[6] = { 0 };
     if (num_cells > 0) {
-      double bounds[6];
       // This function expects a non-empty partition, so we only call it
       // if we have cells.
       grid_get_local_bounds (grid, bounds);


### PR DESCRIPTION
**_Describe your changes here:_**

Fixes #1953 
We were not able to write empty partitions any more due to this call in the VTK writer:

```
grid_get_local_bounds (grid, bounds);
```
For an empty partition (i.e. no cells to write in VTK), the cmesh function `t8_cmesh_get_local_bounding_box` is called anyways and raises the assertion ` T8_ASSERT (num_local_trees > 0);`

Fixed it by wrapping the line in an `if (num_cells > 0)`.

This was a minimal fix, since i felt like not touching the rest of the writer code.

However, it seems like VTK is smart and does not even write a file for the empty processes.
Thus, we could also go a step further and skip all of the remaining code in the writer function if the partition is empty.
What do you think @Davknapp?

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).