### PR TITLE
Bugfix: 1922 Non-initialized variable caused "jump based on uninitialized value" in t8_cmesh_uniform_bounds_from_unpartioned

### DIFF
--- a/src/t8_cmesh/t8_cmesh.cxx
+++ b/src/t8_cmesh/t8_cmesh.cxx
@@ -1636,6 +1636,7 @@ t8_cmesh_uniform_bounds_from_unpartioned (const t8_cmesh_t cmesh, const t8_gloid
     T8_ASSERT (first_child_next_non_empty < last_child_next_non_empty);
     // Loop over trees to find the one containing first_child_next_non_empty, which gives us the first and last local tree.
     t8_gloidx_t current_tree_element_offset = 0;
+    *last_local_tree = -1;  // Initialize for the case of num_trees <= 0
     for (t8_gloidx_t igtree = 0; igtree < num_trees; ++igtree) {
       const t8_eclass_t tree_class = t8_cmesh_get_tree_class (cmesh, (t8_locidx_t) igtree);
       const t8_gloidx_t num_leaf_elems_in_tree = scheme->count_leaves_from_root (tree_class, level);


### PR DESCRIPTION
**_Describe your changes here:_**

Closes #1922 

The last_local_tree in t8_cmesh_uniform_bounds_from_unpartioned was not set in some specific cases.
For example in `mpirun -np 3 ./test/t8_cmesh/t8_gtest_cmesh_partition_parallel --gtest_filter=*t8_cmesh_new_from_class_Vertex_sc_MPI_COMM_WORLD_default`

Only single line but would be great to have a review from @Davknapp  since you wrote the t8_cmesh_uniform_bounds_from_unpartioned  function.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).