### PR TITLE
Feature: Destructor for mesh handle

### DIFF
--- a/mesh_handle/mesh.hxx
+++ b/mesh_handle/mesh.hxx
@@ -59,6 +59,16 @@ class mesh {
     update_elements ();
   }
 
+  /** 
+   * Destructor for a mesh of the handle. 
+   * The forest in use will be unreferenced. 
+   * Call \ref t8_forest_ref before if you want to keep it alive.
+   */
+  ~mesh ()
+  {
+    t8_forest_unref (&m_forest);
+  }
+
   /**
    * Getter for the number of local elements in the mesh.
    * \return Number of local elements in the mesh.

--- a/test/mesh_handle/t8_gtest_cache_competence.cxx
+++ b/test/mesh_handle/t8_gtest_cache_competence.cxx
@@ -82,7 +82,9 @@ class t8_gtest_cache_competence: public testing::Test {
   void
   TearDown () override
   {
-    t8_forest_unref (&forest);
+    if (forest->rc.refcount > 0) {
+      t8_forest_unref (&forest);
+    }
   }
 
   t8_forest_t forest;

--- a/test/mesh_handle/t8_gtest_compare_handle_to_forest.cxx
+++ b/test/mesh_handle/t8_gtest_compare_handle_to_forest.cxx
@@ -76,7 +76,4 @@ TEST (t8_gtest_compare_handle_to_forest, compare_handle_to_forest)
       mesh_iterator++;
     }
   }
-
-  // Unref the forest.
-  t8_forest_unref (&forest);
 }

--- a/test/mesh_handle/t8_gtest_custom_competence.cxx
+++ b/test/mesh_handle/t8_gtest_custom_competence.cxx
@@ -96,6 +96,7 @@ TEST (t8_gtest_custom_competence, custom_competence)
     EXPECT_EQ (level, it->get_level_dummy ());
   }
 
+  t8_forest_ref (forest);
   // Test with two custom competences and a predefined competence.
   using mesh_class = t8_mesh_handle::mesh<dummy_get_level, dummy_trivial, t8_mesh_handle::cache_centroid>;
   mesh_class mesh_more_competences = mesh_class (forest);
@@ -111,7 +112,4 @@ TEST (t8_gtest_custom_competence, custom_competence)
     }
     EXPECT_TRUE (it->centroid_cache_filled ());
   }
-
-  // Unref the forest.
-  t8_forest_unref (&forest);
 }

--- a/test/mesh_handle/t8_gtest_ghost.cxx
+++ b/test/mesh_handle/t8_gtest_ghost.cxx
@@ -54,7 +54,9 @@ class t8_mesh_ghost_test: public testing::TestWithParam<std::tuple<t8_eclass_t, 
   void
   TearDown () override
   {
-    t8_forest_unref (&forest);
+    if (forest->rc.refcount > 0) {
+      t8_forest_unref (&forest);
+    }
   }
   t8_forest_t forest;
   int level;

--- a/test/mesh_handle/t8_gtest_mesh_handle.cxx
+++ b/test/mesh_handle/t8_gtest_mesh_handle.cxx
@@ -51,7 +51,9 @@ class t8_mesh_handle_test: public testing::TestWithParam<std::tuple<t8_eclass_t,
   void
   TearDown () override
   {
-    t8_forest_unref (&forest);
+    if (forest->rc.refcount > 0) {
+      t8_forest_unref (&forest);
+    }
   }
 
   t8_forest_t forest;
@@ -133,6 +135,7 @@ TEST_P (t8_mesh_handle_test, test_competences)
   }
 
   // --- Version with cached centroid variable. ---
+  t8_forest_ref (forest);
   using mesh_class_centroid = t8_mesh_handle::mesh<t8_mesh_handle::cache_centroid>;
   using element_class_centroid = mesh_class_centroid::element_class;
   mesh_class_centroid mesh_centroid = mesh_class_centroid (forest);


### PR DESCRIPTION
Closes #2079

**_Describe your changes here:_**
The mesh handle gets a destructor. This is for convenience for the user but also nice to have in the adapt routine and constructor wrappers for the mesh handle where the user never sees a forest. 

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).