### PR TITLE
Other: Move `main`s out off `T8_EXTERN_C` region

### DIFF
--- a/example/remove/t8_example_empty_trees.cxx
+++ b/example/remove/t8_example_empty_trees.cxx
@@ -29,8 +29,6 @@
 #include <sc_options.h>
 #include <string>
 
-T8_EXTERN_C_BEGIN ();
-
 /** Removes all elements of a local tree if they belong to the corresponding
  *  global trees which is given by the user_data. */
 static int
@@ -94,8 +92,6 @@ t8_strip_of_quads (t8_gloidx_t num_trees, t8_gloidx_t empty_tree, const char **v
   t8_forest_unref (&forest_adapt);
   t8_forest_unref (&forest);
 }
-
-T8_EXTERN_C_END ();
 
 int
 main (int argc, char **argv)

--- a/example/remove/t8_example_gauss_blob.cxx
+++ b/example/remove/t8_example_gauss_blob.cxx
@@ -27,8 +27,6 @@
 #include <t8_schemes/t8_default/t8_default.hxx>
 #include <sc_options.h>
 
-T8_EXTERN_C_BEGIN ();
-
 struct t8_adapt_data
 {
   const int remove_scope;
@@ -170,8 +168,6 @@ t8_construct_spheres (const int initial_level, const double radius_inner, const 
   T8_FREE (data);
   t8_forest_unref (&forest);
 }
-
-T8_EXTERN_C_END ();
 
 int
 main (int argc, char **argv)

--- a/example/remove/t8_example_spheres.cxx
+++ b/example/remove/t8_example_spheres.cxx
@@ -27,8 +27,6 @@
 #include <t8_schemes/t8_default/t8_default.hxx>
 #include <sc_options.h>
 
-T8_EXTERN_C_BEGIN ();
-
 struct t8_adapt_data
 {
   const int num_spheres;
@@ -124,8 +122,6 @@ t8_construct_spheres (const int initial_level, const double radius_inner, const 
 
   t8_forest_unref (&forest);
 }
-
-T8_EXTERN_C_END ();
 
 int
 main (int argc, char **argv)


### PR DESCRIPTION
**_Describe your changes here:_**

Noticed today while compiling t8code main using `gcc (GCC) 15.2.1 20260103`

```bash
[ 98%] Building CXX object example/CMakeFiles/t8_example_spheres.dir/remove/t8_example_spheres.cxx.o
/home/bene/adaptex/t8code/example/remove/t8_example_spheres.cxx:129:1: warning: cannot declare ‘::main’ with a linkage specification [-Wpedantic]
  129 | main (int argc, char **argv)
      | ^~~~
```

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).