### PR TITLE
Other: Removed #if 1 directive from benchmarks/time_partition.cxx

### DIFF
--- a/benchmarks/t8_time_partition.cxx
+++ b/benchmarks/t8_time_partition.cxx
@@ -61,7 +61,6 @@ t8_time_half (t8_cmesh_t cmesh, sc_MPI_Comm comm)
   t8_cmesh_destroy (&cmesh_partition);
 }
 
-#if 1
 /* add x*mpirank to all of the x-coordinates of a tree in cmesh.
  * This is useful to separate the disjoint parts visually. */
 void
@@ -138,7 +137,6 @@ t8_time_cmesh_partition_brick (int x, int y, int z, sc_MPI_Comm comm, int no_vtk
   /* memory clean-up */
   t8_cmesh_destroy (&cmesh_partition);
 }
-#endif
 
 int
 main (int argc, char *argv[])


### PR DESCRIPTION
Closes #690 

**_Describe your changes here:_**

It has been for this for 9 years and the code is used in main, so I removed unnecessary `#if 1 ... #endif` directive.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [x] The reviewer executed the new code features at least once and checked the results manually.
- [x] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [x] New source/header files are properly added to the CMake files.
- [x] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [x] The code is covered in an existing or new test case using Google Test.
- [x] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [x] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [x] Should this use case be added to the github action?
  - [x] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [x] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).