### PR TITLE
Bugfix: t8indent extraction of clang-format version number

### DIFF
--- a/scripts/t8indent.sh
+++ b/scripts/t8indent.sh
@@ -51,7 +51,8 @@ fi
 # Get indentation script version and split it into major, minor, patch
 CLANG_VERSION_STRING=`$FORMAT --version`
 
-VERSION=`echo $CLANG_VERSION_STRING | cut -d " " -f 3`
+[[ $CLANG_VERSION_STRING =~ version[[:space:]]+([^[:space:]]+) ]] &&
+VERSION="${BASH_REMATCH[1]}"
 MAJOR=`echo $VERSION | cut -d. -f1`
 MINOR=`echo $VERSION | cut -d. -f2`
 PATCH=`echo $VERSION | cut -d. -f3`


### PR DESCRIPTION
**_Describe your changes here:_**
Closes #2136

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [x] The reviewer executed the new code features at least once and checked the results manually.
- [x] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [x] New source/header files are properly added to the CMake files.
- [x] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [x] The code is covered in an existing or new test case using Google Test.
- [x] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [x] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [x] Should this use case be added to the github action?
  - [x] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [x] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [x] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).