### PR TITLE
Improvement: Add const begin and end to mesh handle

### DIFF
--- a/mesh_handle/mesh.hxx
+++ b/mesh_handle/mesh.hxx
@@ -221,6 +221,26 @@ class mesh {
   }
 
   /**
+   * Returns a constant iterator to the first (local) mesh element.
+   * \return Constant iterator to the first (local) mesh element.
+   */
+  mesh_const_iterator
+  begin () const
+  {
+    return this->cbegin ();
+  }
+
+  /**
+   * Returns a constant iterator to a mesh element following the last (local) element of the mesh.
+   * \return Constant iterator to the mesh element following the last (local) element of the mesh.
+   */
+  mesh_const_iterator
+  end () const
+  {
+    return this->cend ();
+  }
+
+  /**
    * Getter for an element given its local index. This could be a (local) mesh element or 
    *  a ghost element. 
    * The indices 0, 1, ... num_local_el - 1 refer to local mesh elements and 

--- a/test/mesh_handle/t8_gtest_cache_competence.cxx
+++ b/test/mesh_handle/t8_gtest_cache_competence.cxx
@@ -147,21 +147,22 @@ TEST (t8_gtest_cache_competence, cache_volume)
   const int level = 1;
   using mesh_class = t8_mesh_handle::mesh<t8_mesh_handle::competence_pack<cache_volume_overwrite>>;
   using element_class = typename mesh_class::element_class;
-  const auto mesh = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<mesh_class> (level, sc_MPI_COMM_WORLD);
+  const auto mesh
+    = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<const mesh_class> (level, sc_MPI_COMM_WORLD);
   EXPECT_TRUE (element_class::has_volume_cache ());
 
   double unrealistic_volume = -3000;
-  for (auto it = mesh->cbegin (); it != mesh->cend (); ++it) {
+  for (const auto &elem : *mesh) {
     // Check that cache is empty at the beginning.
-    EXPECT_FALSE (it->volume_cache_filled ());
+    EXPECT_FALSE (elem.volume_cache_filled ());
     // Fill cache and check that volume is valid.
-    EXPECT_GE (it->get_volume (), 0);
+    EXPECT_GE (elem.get_volume (), 0);
     // Check that cache is set.
-    EXPECT_TRUE (it->volume_cache_filled ());
+    EXPECT_TRUE (elem.volume_cache_filled ());
     // Overwrite the cache with unrealistic values.
-    it->overwrite_cache (unrealistic_volume);
+    elem.overwrite_cache (unrealistic_volume);
     // Check that the cache is actually used.
-    EXPECT_EQ (it->get_volume (), unrealistic_volume);
+    EXPECT_EQ (elem.get_volume (), unrealistic_volume);
   }
 }
 
@@ -174,16 +175,17 @@ TEST (t8_gtest_cache_competence, cache_diameter)
   const int level = 1;
   using mesh_class = t8_mesh_handle::mesh<t8_mesh_handle::competence_pack<cache_diameter_overwrite>>;
   using element_class = typename mesh_class::element_class;
-  auto mesh = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<mesh_class> (level, sc_MPI_COMM_WORLD);
+  const auto mesh
+    = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<const mesh_class> (level, sc_MPI_COMM_WORLD);
   EXPECT_TRUE (element_class::has_diameter_cache ());
 
   double unrealistic_diameter = -3000.0;
-  for (auto it = mesh->cbegin (); it != mesh->cend (); ++it) {
-    EXPECT_FALSE (it->diameter_cache_filled ());
-    EXPECT_GE (it->get_diameter (), 0);
-    EXPECT_TRUE (it->diameter_cache_filled ());
-    it->overwrite_cache (unrealistic_diameter);
-    EXPECT_EQ (it->get_diameter (), unrealistic_diameter);
+  for (const auto &elem : *mesh) {
+    EXPECT_FALSE (elem.diameter_cache_filled ());
+    EXPECT_GE (elem.get_diameter (), 0);
+    EXPECT_TRUE (elem.diameter_cache_filled ());
+    elem.overwrite_cache (unrealistic_diameter);
+    EXPECT_EQ (elem.get_diameter (), unrealistic_diameter);
   }
 }
 
@@ -196,20 +198,21 @@ TEST (t8_gtest_cache_competence, cache_vertex_coordinates)
   const int level = 1;
   using mesh_class = t8_mesh_handle::mesh<t8_mesh_handle::competence_pack<cache_vertex_coordinates_overwrite>>;
   using element_class = typename mesh_class::element_class;
-  const auto mesh = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<mesh_class> (level, sc_MPI_COMM_WORLD);
+  const auto mesh
+    = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<const mesh_class> (level, sc_MPI_COMM_WORLD);
   EXPECT_TRUE (element_class::has_vertex_cache ());
 
   std::vector<t8_3D_vec> unrealistic_vertex = { t8_3D_vec ({ 41, 42, 43 }), t8_3D_vec ({ 99, 100, 101 }) };
-  for (auto it = mesh->cbegin (); it != mesh->cend (); ++it) {
-    EXPECT_FALSE (it->vertex_cache_filled ());
-    for (int ivertex = 0; ivertex < it->get_num_vertices (); ++ivertex) {
-      for (const auto &coordinate : it->get_vertex_coordinates (ivertex)) {
+  for (const auto &elem : *mesh) {
+    EXPECT_FALSE (elem.vertex_cache_filled ());
+    for (int ivertex = 0; ivertex < elem.get_num_vertices (); ++ivertex) {
+      for (const auto &coordinate : elem.get_vertex_coordinates (ivertex)) {
         EXPECT_TRUE (coordinate >= 0.0 && coordinate <= 1.0);
       }
     }
-    EXPECT_TRUE (it->vertex_cache_filled ());
-    it->overwrite_cache (unrealistic_vertex);
-    EXPECT_EQ (it->get_vertex_coordinates (), unrealistic_vertex);
+    EXPECT_TRUE (elem.vertex_cache_filled ());
+    elem.overwrite_cache (unrealistic_vertex);
+    EXPECT_EQ (elem.get_vertex_coordinates (), unrealistic_vertex);
   }
 }
 
@@ -222,18 +225,19 @@ TEST (t8_gtest_cache_competence, cache_centroid)
   const int level = 1;
   using mesh_class = t8_mesh_handle::mesh<t8_mesh_handle::competence_pack<cache_centroid_overwrite>>;
   using element_class = typename mesh_class::element_class;
-  const auto mesh = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<mesh_class> (level, sc_MPI_COMM_WORLD);
+  const auto mesh
+    = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<const mesh_class> (level, sc_MPI_COMM_WORLD);
   EXPECT_TRUE (element_class::has_centroid_cache ());
 
   t8_3D_vec unrealistic_centroid ({ 999.0, 1000.0, 998.0 });
-  for (auto it = mesh->cbegin (); it != mesh->cend (); ++it) {
-    EXPECT_FALSE (it->centroid_cache_filled ());
-    for (const auto &coordinate : it->get_centroid ()) {
+  for (const auto &elem : *mesh) {
+    EXPECT_FALSE (elem.centroid_cache_filled ());
+    for (const auto &coordinate : elem.get_centroid ()) {
       EXPECT_TRUE (coordinate >= 0.0 && coordinate <= 1.0);
     }
-    EXPECT_TRUE (it->centroid_cache_filled ());
-    it->overwrite_cache (unrealistic_centroid);
-    EXPECT_EQ (it->get_centroid (), unrealistic_centroid);
+    EXPECT_TRUE (elem.centroid_cache_filled ());
+    elem.overwrite_cache (unrealistic_centroid);
+    EXPECT_EQ (elem.get_centroid (), unrealistic_centroid);
   }
 }
 
@@ -247,18 +251,19 @@ TEST (t8_gtest_cache_competence, cache_face_areas)
   const int level = 1;
   using mesh_class = t8_mesh_handle::mesh<t8_mesh_handle::competence_pack<cache_face_areas_overwrite>>;
   using element_class = typename mesh_class::element_class;
-  auto mesh = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<mesh_class> (level, sc_MPI_COMM_WORLD);
+  const auto mesh
+    = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<const mesh_class> (level, sc_MPI_COMM_WORLD);
   EXPECT_TRUE (element_class::has_face_areas_cache ());
 
   double unrealistic_face_area = 41.1;
-  for (auto it = mesh->cbegin (); it != mesh->cend (); ++it) {
-    for (int iface = 0; iface < it->get_num_faces (); ++iface) {
-      EXPECT_FALSE (it->face_area_cache_filled (iface));
-      auto face_area = it->get_face_area (iface);
+  for (const auto &elem : *mesh) {
+    for (int iface = 0; iface < elem.get_num_faces (); ++iface) {
+      EXPECT_FALSE (elem.face_area_cache_filled (iface));
+      auto face_area = elem.get_face_area (iface);
       EXPECT_LE (0, face_area);
-      EXPECT_TRUE (it->face_area_cache_filled (iface));
-      it->overwrite_cache (iface, unrealistic_face_area + iface);
-      EXPECT_EQ (it->get_face_area (iface), unrealistic_face_area + iface);
+      EXPECT_TRUE (elem.face_area_cache_filled (iface));
+      elem.overwrite_cache (iface, unrealistic_face_area + iface);
+      EXPECT_EQ (elem.get_face_area (iface), unrealistic_face_area + iface);
     }
   }
 }
@@ -272,19 +277,20 @@ TEST (t8_gtest_cache_competence, cache_face_centroids)
   const int level = 1;
   using mesh_class = t8_mesh_handle::mesh<t8_mesh_handle::competence_pack<cache_face_centroids_overwrite>>;
   using element_class = typename mesh_class::element_class;
-  auto mesh = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<mesh_class> (level, sc_MPI_COMM_WORLD);
+  const auto mesh
+    = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<const mesh_class> (level, sc_MPI_COMM_WORLD);
   EXPECT_TRUE (element_class::has_face_centroids_cache ());
 
   t8_3D_vec unrealistic_face_centroid ({ 999.0, 1000.0, 998.0 });
-  for (auto it = mesh->cbegin (); it != mesh->cend (); ++it) {
-    for (int iface = 0; iface < it->get_num_faces (); ++iface) {
-      EXPECT_FALSE (it->face_centroid_cache_filled (iface));
-      for (const auto &coordinate : it->get_face_centroid (iface)) {
+  for (const auto &elem : *mesh) {
+    for (int iface = 0; iface < elem.get_num_faces (); ++iface) {
+      EXPECT_FALSE (elem.face_centroid_cache_filled (iface));
+      for (const auto &coordinate : elem.get_face_centroid (iface)) {
         EXPECT_TRUE (coordinate >= 0.0 && coordinate <= 1.0);
       }
-      EXPECT_TRUE (it->face_centroid_cache_filled (iface));
-      it->overwrite_cache (iface, unrealistic_face_centroid);
-      EXPECT_EQ (it->get_face_centroid (iface), unrealistic_face_centroid);
+      EXPECT_TRUE (elem.face_centroid_cache_filled (iface));
+      elem.overwrite_cache (iface, unrealistic_face_centroid);
+      EXPECT_EQ (elem.get_face_centroid (iface), unrealistic_face_centroid);
     }
   }
 }
@@ -298,19 +304,20 @@ TEST (t8_gtest_cache_competence, cache_face_normals)
   const int level = 1;
   using mesh_class = t8_mesh_handle::mesh<t8_mesh_handle::competence_pack<cache_face_normals_overwrite>>;
   using element_class = typename mesh_class::element_class;
-  auto mesh = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<mesh_class> (level, sc_MPI_COMM_WORLD);
+  const auto mesh
+    = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<const mesh_class> (level, sc_MPI_COMM_WORLD);
   EXPECT_TRUE (element_class::has_face_normals_cache ());
 
   t8_3D_vec unrealistic_face_normal ({ 41.1, 42.0, 43.0 });
-  for (auto it = mesh->cbegin (); it != mesh->cend (); ++it) {
-    for (int iface = 0; iface < it->get_num_faces (); ++iface) {
-      EXPECT_FALSE (it->face_normal_cache_filled (iface));
-      for (const auto &coordinate : it->get_face_normal (iface)) {
+  for (const auto &elem : *mesh) {
+    for (int iface = 0; iface < elem.get_num_faces (); ++iface) {
+      EXPECT_FALSE (elem.face_normal_cache_filled (iface));
+      for (const auto &coordinate : elem.get_face_normal (iface)) {
         EXPECT_TRUE (coordinate >= -1 && coordinate <= 1);
       }
-      EXPECT_TRUE (it->face_normal_cache_filled (iface));
-      it->overwrite_cache (iface, unrealistic_face_normal);
-      EXPECT_EQ (it->get_face_normal (iface), unrealistic_face_normal);
+      EXPECT_TRUE (elem.face_normal_cache_filled (iface));
+      elem.overwrite_cache (iface, unrealistic_face_normal);
+      EXPECT_EQ (elem.get_face_normal (iface), unrealistic_face_normal);
     }
   }
 }

--- a/test/mesh_handle/t8_gtest_custom_competence.cxx
+++ b/test/mesh_handle/t8_gtest_custom_competence.cxx
@@ -85,7 +85,7 @@ TEST (t8_gtest_custom_competence, custom_competence)
   // Check mesh with custom defined competence.
   using mesh_class_custom = t8_mesh_handle::mesh<t8_mesh_handle::competence_pack<dummy_get_level>>;
   const auto mesh
-    = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<mesh_class_custom> (level, sc_MPI_COMM_WORLD);
+    = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<const mesh_class_custom> (level, sc_MPI_COMM_WORLD);
 
   for (auto it = mesh->cbegin (); it != mesh->cend (); ++it) {
     EXPECT_EQ (it->get_level (), it->get_level_dummy ());
@@ -95,16 +95,15 @@ TEST (t8_gtest_custom_competence, custom_competence)
   // Test with two custom competences and a predefined competence.
   using competences = t8_mesh_handle::competence_pack<dummy_get_level, dummy_trivial, t8_mesh_handle::cache_centroid>;
   using mesh_class = t8_mesh_handle::mesh<competences>;
-  auto mesh_more_competences
-    = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<mesh_class> (level, sc_MPI_COMM_WORLD);
-
-  for (auto it = mesh_more_competences->cbegin (); it != mesh_more_competences->cend (); ++it) {
-    EXPECT_EQ (it->get_level (), it->get_level_dummy ());
-    EXPECT_EQ (it->get_value_dummy (), 1);
-    EXPECT_FALSE (it->centroid_cache_filled ());
-    for (const auto &coordinate : it->get_centroid ()) {
+  const auto mesh_more_competences
+    = t8_mesh_handle::handle_hypercube_hybrid_uniform_default<const mesh_class> (level, sc_MPI_COMM_WORLD);
+  for (const auto &elem : *mesh_more_competences) {
+    EXPECT_EQ (elem.get_level (), elem.get_level_dummy ());
+    EXPECT_EQ (elem.get_value_dummy (), 1);
+    EXPECT_FALSE (elem.centroid_cache_filled ());
+    for (const auto &coordinate : elem.get_centroid ()) {
       EXPECT_TRUE (coordinate >= 0.0 && coordinate <= 1.0);
     }
-    EXPECT_TRUE (it->centroid_cache_filled ());
+    EXPECT_TRUE (elem.centroid_cache_filled ());
   }
 }

--- a/test/mesh_handle/t8_gtest_ghost.cxx
+++ b/test/mesh_handle/t8_gtest_ghost.cxx
@@ -196,8 +196,8 @@ TEST_P (t8_mesh_ghost_test, cache_neighbors)
 {
   using mesh_class = t8_mesh_handle::mesh<t8_mesh_handle::competence_pack<cache_neighbors_overwrite>>;
   using element_class = typename mesh_class::element_class;
-  const auto mesh = t8_mesh_handle::handle_hypercube_uniform_default<mesh_class> (eclass, level, sc_MPI_COMM_WORLD,
-                                                                                  true, true, false);
+  const auto mesh = t8_mesh_handle::handle_hypercube_uniform_default<const mesh_class> (
+    eclass, level, sc_MPI_COMM_WORLD, true, true, false);
   EXPECT_TRUE (element_class::has_face_neighbor_cache ());
 
   if (mesh->get_num_local_elements () == 0) {
@@ -206,18 +206,18 @@ TEST_P (t8_mesh_ghost_test, cache_neighbors)
   const std::vector<const element_class*> unrealistic_neighbors
     = { &((*mesh)[0]), &((*mesh)[mesh->get_num_local_elements () - 1]) };
   const std::vector<int> unrealistic_dual_faces = { 100, 1012000 };
-  for (auto it = mesh->cbegin (); it != mesh->cend (); ++it) {
+  for (const auto& elem : *mesh) {
     // Check that cache is empty at the beginning.
-    EXPECT_FALSE (it->neighbor_cache_filled_any ());
-    it->fill_face_neighbor_cache ();
-    for (int iface = 0; iface < it->get_num_faces (); iface++) {
-      EXPECT_TRUE (it->neighbor_cache_filled (iface));
+    EXPECT_FALSE (elem.neighbor_cache_filled_any ());
+    elem.fill_face_neighbor_cache ();
+    for (int iface = 0; iface < elem.get_num_faces (); iface++) {
+      EXPECT_TRUE (elem.neighbor_cache_filled (iface));
       std::vector<int> dual_faces;
-      auto neighbors = it->get_face_neighbors (iface, dual_faces);
+      auto neighbors = elem.get_face_neighbors (iface, dual_faces);
       // Overwrite cache with unrealistic values.
-      it->overwrite_cache (iface, unrealistic_neighbors, unrealistic_dual_faces);
-      EXPECT_TRUE (it->neighbor_cache_filled (iface));
-      neighbors = it->get_face_neighbors (iface, dual_faces);
+      elem.overwrite_cache (iface, unrealistic_neighbors, unrealistic_dual_faces);
+      EXPECT_TRUE (elem.neighbor_cache_filled (iface));
+      neighbors = elem.get_face_neighbors (iface, dual_faces);
       // --- Compare results. ---
       EXPECT_EQ (neighbors, unrealistic_neighbors);
       EXPECT_EQ (dual_faces, unrealistic_dual_faces);

--- a/test/mesh_handle/t8_gtest_handle_data.cxx
+++ b/test/mesh_handle/t8_gtest_handle_data.cxx
@@ -80,7 +80,7 @@ TEST (t8_gtest_handle_data, set_and_get_element_data)
     }
   }
   mesh->exchange_ghost_data ();
-  for (auto &elem : *mesh) {
+  for (const auto &elem : *mesh) {
     if (t8_forest_global_tree_id (forest, elem.get_local_tree_id ()) < barrier) {
       EXPECT_EQ (elem.get_element_data ().level, newlevel);
       EXPECT_EQ (elem.get_element_data ().volume, newvolume);

--- a/test/mesh_handle/t8_gtest_mesh_handle.cxx
+++ b/test/mesh_handle/t8_gtest_mesh_handle.cxx
@@ -54,8 +54,8 @@ TEST_P (t8_mesh_handle_test, test_default_mesh_handle)
 {
   using mesh_class = t8_mesh_handle::mesh<>;
   using element_class = typename mesh_class::element_class;
-  auto mesh = t8_mesh_handle::handle_hypercube_uniform_default<mesh_class> (eclass, level, sc_MPI_COMM_WORLD, true,
-                                                                            true, false);
+  const auto mesh = t8_mesh_handle::handle_hypercube_uniform_default<const mesh_class> (
+    eclass, level, sc_MPI_COMM_WORLD, true, true, false);
   EXPECT_FALSE (element_class::has_vertex_cache ());
   EXPECT_FALSE (element_class::has_centroid_cache ());
 
@@ -88,8 +88,8 @@ TEST_P (t8_mesh_handle_test, test_all_cache_competence)
   // --- Use predefined competences to use all available caching competences. ---
   using mesh_class = t8_mesh_handle::mesh<t8_mesh_handle::all_cache_competences>;
   using element_class = typename mesh_class::element_class;
-  auto mesh = t8_mesh_handle::handle_hypercube_uniform_default<mesh_class> (eclass, level, sc_MPI_COMM_WORLD, true,
-                                                                            true, false);
+  const auto mesh = t8_mesh_handle::handle_hypercube_uniform_default<const mesh_class> (
+    eclass, level, sc_MPI_COMM_WORLD, true, true, false);
   EXPECT_TRUE (element_class::has_volume_cache ());
   EXPECT_TRUE (element_class::has_diameter_cache ());
   EXPECT_TRUE (element_class::has_vertex_cache ());
@@ -116,17 +116,17 @@ TEST_P (t8_mesh_handle_test, test_all_cache_competence)
     }
   }
   // Check if caches are set. If caches are accessed correctly is checked in another test.
-  for (auto it = mesh->cbegin (); it != mesh->cend (); ++it) {
-    EXPECT_TRUE (it->volume_cache_filled ());
-    EXPECT_TRUE (it->centroid_cache_filled ());
-    EXPECT_TRUE (it->vertex_cache_filled ());
-    EXPECT_FALSE (it->diameter_cache_filled ());
-    if (it->get_num_faces () > 0) {
-      EXPECT_FALSE (it->face_area_cache_filled (0));
-      EXPECT_FALSE (it->face_centroid_cache_filled (0));
-      EXPECT_FALSE (it->face_normal_cache_filled (0));
+  for (const auto& elem : *mesh) {
+    EXPECT_TRUE (elem.volume_cache_filled ());
+    EXPECT_TRUE (elem.centroid_cache_filled ());
+    EXPECT_TRUE (elem.vertex_cache_filled ());
+    EXPECT_FALSE (elem.diameter_cache_filled ());
+    if (elem.get_num_faces () > 0) {
+      EXPECT_FALSE (elem.face_area_cache_filled (0));
+      EXPECT_FALSE (elem.face_centroid_cache_filled (0));
+      EXPECT_FALSE (elem.face_normal_cache_filled (0));
     }
-    EXPECT_FALSE (it->neighbor_cache_filled_any ());
+    EXPECT_FALSE (elem.neighbor_cache_filled_any ());
   }
 }
 
@@ -135,8 +135,8 @@ TEST_P (t8_mesh_handle_test, test_cache_face_competences)
 {
   using mesh_class = t8_mesh_handle::mesh<t8_mesh_handle::cache_face_competences>;
   using element_class = typename mesh_class::element_class;
-  auto mesh = t8_mesh_handle::handle_hypercube_uniform_default<mesh_class> (eclass, level, sc_MPI_COMM_WORLD, true,
-                                                                            true, false);
+  const auto mesh = t8_mesh_handle::handle_hypercube_uniform_default<const mesh_class> (
+    eclass, level, sc_MPI_COMM_WORLD, true, true, false);
   EXPECT_FALSE (element_class::has_volume_cache ());
   EXPECT_FALSE (element_class::has_diameter_cache ());
   EXPECT_FALSE (element_class::has_vertex_cache ());


### PR DESCRIPTION
Closes #2267

**_Describe your changes here:_**
I had the problem that the range based for does not work for const meshes because begin and end is called and not cbegin and cend. begin and end has to be overloaded for this. cbegin and cend is still needed to be able to call them explicitly.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).