### PR TITLE
Improvement: Add concept for mesh handle 

### DIFF
--- a/mesh_handle/concepts.hxx
+++ b/mesh_handle/concepts.hxx
@@ -30,7 +30,7 @@
 
 namespace t8_mesh_handle
 {
-/** Concept to restrict types to \ref mesh class instantiations.
+/** Concept to restrict types to \ref t8_mesh_handle::mesh class instantiations.
  * \tparam TType Type that should be checked.
  */
 template <typename TType>

--- a/mesh_handle/concepts.hxx
+++ b/mesh_handle/concepts.hxx
@@ -1,0 +1,45 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2026 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file concepts.hxx
+ * Concepts related to the mesh handle.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace t8_mesh_handle
+{
+/** Concept to restrict types to \ref mesh class instantiations.
+ * \tparam TType Type that should be checked.
+ */
+template <typename TType>
+concept T8MeshType = requires { typename TType::mesh_tag; };
+
+/** Concept to ensure that a type is MPI safe.
+ * \tparam TType Type that should be checked to be MPI safe.
+ */
+template <typename TType>
+concept T8MPISafeType
+  = std::is_void_v<TType> || (std::is_trivially_copyable_v<TType> && std::is_standard_layout_v<TType>);
+}  // namespace t8_mesh_handle

--- a/mesh_handle/constructor_wrappers.hxx
+++ b/mesh_handle/constructor_wrappers.hxx
@@ -34,6 +34,7 @@
 #include <t8_cmesh/t8_cmesh.h>
 #include <t8_schemes/t8_default/t8_default.hxx>
 #include <t8_cmesh/t8_cmesh_examples.h>
+#include "concepts.hxx"
 #include <memory>
 
 namespace t8_mesh_handle
@@ -45,16 +46,16 @@ namespace t8_mesh_handle
  * \param [in] level         An initial uniform refinement level.
  * \param [in] comm          MPI communicator to use.
  * \param [in] do_face_ghost If true, a layer of ghost elements is created.
- * \tparam TMesh             The mesh handle class.
+ * \tparam TMeshClass             The mesh handle class.
  * \return Unique pointer to a uniformly refined mesh handle with coarse mesh \a cmesh and refinement level \a level.
  */
-template <typename TMesh>
-std::unique_ptr<TMesh>
+template <T8MeshType TMeshClass>
+std::unique_ptr<TMeshClass>
 handle_new_uniform (const t8_cmesh_t cmesh, const t8_scheme *scheme, const int level, const sc_MPI_Comm comm,
                     const bool do_face_ghost = false)
 {
   t8_forest_t forest = t8_forest_new_uniform (cmesh, scheme, level, do_face_ghost, comm);
-  return std::make_unique<TMesh> (forest);
+  return std::make_unique<TMeshClass> (forest);
 }
 
 /** Build a uniformly refined mesh handle on a coarse mesh using a default scheme.
@@ -62,15 +63,15 @@ handle_new_uniform (const t8_cmesh_t cmesh, const t8_scheme *scheme, const int l
  * \param [in] level         An initial uniform refinement level.
  * \param [in] comm          MPI communicator to use.
  * \param [in] do_face_ghost If true, a layer of ghost elements is created.
- * \tparam TMesh             The mesh handle class.
+ * \tparam TMeshClass             The mesh handle class.
  * \return Unique pointer to a uniformly refined mesh handle with coarse mesh \a cmesh and refinement level \a level.
  */
-template <typename TMesh>
-std::unique_ptr<TMesh>
+template <T8MeshType TMeshClass>
+std::unique_ptr<TMeshClass>
 handle_new_uniform_default (const t8_cmesh_t cmesh, const int level, const sc_MPI_Comm comm,
                             const bool do_face_ghost = false)
 {
-  return handle_new_uniform<TMesh> (cmesh, t8_scheme_new_default (), level, comm, do_face_ghost);
+  return handle_new_uniform<TMeshClass> (cmesh, t8_scheme_new_default (), level, comm, do_face_ghost);
 }
 
 // --- A very small fraction of example coarse meshes is wrapped here for easy access and for the use in tests. ---
@@ -80,17 +81,17 @@ handle_new_uniform_default (const t8_cmesh_t cmesh, const int level, const sc_MP
  * \param [in] do_partition  If non-zero create a partitioned cmesh.
  * \param [in] do_face_ghost If true, a layer of ghost elements is created.
  * \param [in] periodic      If non-zero create a periodic cmesh in each direction.
- * \tparam TMesh             The mesh handle class.
+ * \tparam TMeshClass             The mesh handle class.
  * \return Unique pointer to a uniformly refined mesh handle initially consisting of 6 Tets, 6 prism and 4 hex.
  *         Together, they form a cube.
 */
-template <typename TMesh>
-std::unique_ptr<TMesh>
+template <T8MeshType TMeshClass>
+std::unique_ptr<TMeshClass>
 handle_hypercube_hybrid_uniform_default (const int level, const sc_MPI_Comm comm, const bool do_partition = false,
                                          const bool do_face_ghost = false, const bool periodic = false)
 {
   t8_cmesh_t cmesh = t8_cmesh_new_hypercube_hybrid (comm, do_partition, periodic);
-  return handle_new_uniform_default<TMesh> (cmesh, level, comm, do_face_ghost);
+  return handle_new_uniform_default<TMeshClass> (cmesh, level, comm, do_face_ghost);
 }
 
 /** Construct hybercube from one primitive tree class. Refined uniformly to given level using the default scheme.
@@ -100,18 +101,18 @@ handle_hypercube_hybrid_uniform_default (const int level, const sc_MPI_Comm comm
  * \param [in] do_partition  If non-zero create a partitioned cmesh.
  * \param [in] do_face_ghost If true, a layer of ghost elements is created.
  * \param [in] periodic      If non-zero create a periodic cmesh in each direction. Not possible with \a eclass pyramid.
- * \tparam TMesh             The mesh handle class.
+ * \tparam TMeshClass             The mesh handle class.
  * \return Unique pointer to a uniformly refined mesh handle hypercube.
 */
-template <typename TMesh>
-std::unique_ptr<TMesh>
+template <T8MeshType TMeshClass>
+std::unique_ptr<TMeshClass>
 handle_hypercube_uniform_default (t8_eclass_t eclass, const int level, const sc_MPI_Comm comm,
                                   const bool do_partition = false, const bool do_face_ghost = false,
                                   const bool periodic = false)
 {
   // Broadcast option is hidden from the user.
   t8_cmesh_t cmesh = t8_cmesh_new_hypercube (eclass, comm, 0, do_partition, periodic);
-  return handle_new_uniform_default<TMesh> (cmesh, level, comm, do_face_ghost);
+  return handle_new_uniform_default<TMeshClass> (cmesh, level, comm, do_face_ghost);
 }
 
 }  // namespace t8_mesh_handle

--- a/mesh_handle/constructor_wrappers.hxx
+++ b/mesh_handle/constructor_wrappers.hxx
@@ -46,7 +46,7 @@ namespace t8_mesh_handle
  * \param [in] level         An initial uniform refinement level.
  * \param [in] comm          MPI communicator to use.
  * \param [in] do_face_ghost If true, a layer of ghost elements is created.
- * \tparam TMeshClass             The mesh handle class.
+ * \tparam TMeshClass        The mesh handle class.
  * \return Unique pointer to a uniformly refined mesh handle with coarse mesh \a cmesh and refinement level \a level.
  */
 template <T8MeshType TMeshClass>
@@ -63,7 +63,7 @@ handle_new_uniform (const t8_cmesh_t cmesh, const t8_scheme *scheme, const int l
  * \param [in] level         An initial uniform refinement level.
  * \param [in] comm          MPI communicator to use.
  * \param [in] do_face_ghost If true, a layer of ghost elements is created.
- * \tparam TMeshClass             The mesh handle class.
+ * \tparam TMeshClass        The mesh handle class.
  * \return Unique pointer to a uniformly refined mesh handle with coarse mesh \a cmesh and refinement level \a level.
  */
 template <T8MeshType TMeshClass>
@@ -81,7 +81,7 @@ handle_new_uniform_default (const t8_cmesh_t cmesh, const int level, const sc_MP
  * \param [in] do_partition  If non-zero create a partitioned cmesh.
  * \param [in] do_face_ghost If true, a layer of ghost elements is created.
  * \param [in] periodic      If non-zero create a periodic cmesh in each direction.
- * \tparam TMeshClass             The mesh handle class.
+ * \tparam TMeshClass        The mesh handle class.
  * \return Unique pointer to a uniformly refined mesh handle initially consisting of 6 Tets, 6 prism and 4 hex.
  *         Together, they form a cube.
 */
@@ -101,7 +101,7 @@ handle_hypercube_hybrid_uniform_default (const int level, const sc_MPI_Comm comm
  * \param [in] do_partition  If non-zero create a partitioned cmesh.
  * \param [in] do_face_ghost If true, a layer of ghost elements is created.
  * \param [in] periodic      If non-zero create a periodic cmesh in each direction. Not possible with \a eclass pyramid.
- * \tparam TMeshClass             The mesh handle class.
+ * \tparam TMeshClass        The mesh handle class.
  * \return Unique pointer to a uniformly refined mesh handle hypercube.
 */
 template <T8MeshType TMeshClass>

--- a/mesh_handle/internal/adapt.hxx
+++ b/mesh_handle/internal/adapt.hxx
@@ -66,16 +66,16 @@ struct mesh_adapt_context_base
 
 /** Templated mesh adaptation context holding the mesh handle and the user defined callback.
  * Struct inherits from \ref mesh_adapt_context_base and implements the virtual adapt callback using the mesh and the callback.
- * \tparam TMesh The mesh handle class.
+ * \tparam TMeshClass The mesh handle class.
  */
-template <typename TMesh>
+template <typename TMeshClass>
 struct mesh_adapt_context final: mesh_adapt_context_base
 {
   /** Constructor of the context with the mesh handle and the user defined callback.
    * \param [in] mesh_handle      The mesh handle to adapt.
    * \param [in] adapt_callback   The adapt callback.
    */
-  mesh_adapt_context (TMesh& mesh_handle, typename TMesh::adapt_callback_type adapt_callback)
+  mesh_adapt_context (TMeshClass& mesh_handle, typename TMeshClass::adapt_callback_type adapt_callback)
     : m_mesh_handle (mesh_handle), m_adapt_callback (std::move (adapt_callback))
   {
   }
@@ -93,13 +93,13 @@ struct mesh_adapt_context final: mesh_adapt_context_base
   {
     // Check if adapt callback is set and call it using the correct mesh handle function arguments.
     T8_ASSERTF (m_adapt_callback, "No adapt callback set.");
-    std::span<const typename TMesh::element_class> element_view (&m_mesh_handle[lelement_handle_id], num_elements);
+    std::span<const typename TMeshClass::element_class> element_view (&m_mesh_handle[lelement_handle_id], num_elements);
     return m_adapt_callback (m_mesh_handle, element_view);
   }
 
  private:
-  TMesh& m_mesh_handle;                                 /**< The mesh handle to adapt. */
-  typename TMesh::adapt_callback_type m_adapt_callback; /**< The adapt callback. */
+  TMeshClass& m_mesh_handle;                                 /**< The mesh handle to adapt. */
+  typename TMeshClass::adapt_callback_type m_adapt_callback; /**< The adapt callback. */
 };
 
 /** Registry pattern is used to register contexts, which provides access to the adapt callback and the mesh handle.

--- a/mesh_handle/mesh.hxx
+++ b/mesh_handle/mesh.hxx
@@ -30,25 +30,18 @@
 #include "element.hxx"
 #include "competence_pack.hxx"
 #include "internal/adapt.hxx"
+#include "concepts.hxx"
 #include "t8_forest/t8_forest_balance.h"
 #include "t8_forest/t8_forest_types.h"
 #include <t8_forest/t8_forest_general.h>
 #include <t8_forest/t8_forest_ghost.h>
 #include <vector>
-#include <type_traits>
 #include <functional>
 #include <memory>
 #include <span>
 
 namespace t8_mesh_handle
 {
-
-/** Concept to ensure that a type is MPI safe.
- */
-template <typename TType>
-concept T8MPISafeType
-  = std::is_void_v<TType> || (std::is_trivially_copyable_v<TType> && std::is_standard_layout_v<TType>);
-
 /**
  * Wrapper for a forest that enables it to be handled as a simple mesh object.
  * \tparam TCompetencePack The competences you want to add to the default functionality of the mesh.
@@ -61,6 +54,7 @@ concept T8MPISafeType
 template <typename TCompetencePack = competence_pack<>, T8MPISafeType TElementDataType = void>
 class mesh {
  public:
+  using mesh_tag = void; /**< Mesh tag for identification in concept. */
   using SelfType
     = mesh<TCompetencePack, TElementDataType>; /**< Type of the current class with all template parameters specified. */
   using ElementDataType = TElementDataType;    /**< Make Type of the element data accessible. */

--- a/mesh_handle/mesh_io.hxx
+++ b/mesh_handle/mesh_io.hxx
@@ -26,6 +26,7 @@
 
 #pragma once
 #include <t8_forest/t8_forest_io.h>
+#include "concepts.hxx"
 
 namespace t8_mesh_handle
 {
@@ -58,7 +59,7 @@ namespace t8_mesh_handle
  * \param [in] do_not_use_API   If true, do not use the VTK API, even if linked and available.
  * \return  True if successful, false if not (process local).
  */
-template <typename TMeshClass>
+template <T8MeshType TMeshClass>
 int
 write_mesh_to_vtk_ext (TMeshClass &mesh, const char *fileprefix, const int num_data, t8_vtk_data_field_t *data,
                        bool write_treeid = false, bool write_mpirank = true, bool write_level = true,
@@ -82,7 +83,7 @@ write_mesh_to_vtk_ext (TMeshClass &mesh, const char *fileprefix, const int num_d
  *             The master file is then fileprefix.pvtu and the process with rank r writes in the file fileprefix_r.vtu.
  * \return  True if successful, false if not (process local).
  */
-template <typename TMeshClass>
+template <T8MeshType TMeshClass>
 int
 write_mesh_to_vtk (TMeshClass &mesh, const char *fileprefix)
 {

--- a/test/mesh_handle/t8_gtest_adapt_partition_balance.cxx
+++ b/test/mesh_handle/t8_gtest_adapt_partition_balance.cxx
@@ -29,6 +29,7 @@ along with t8code; if not, write to the Free Software Foundation, Inc.,
 #include <t8.h>
 
 #include <mesh_handle/mesh.hxx>
+#include <mesh_handle/concepts.hxx>
 #include <mesh_handle/competence_pack.hxx>
 #include <t8_cmesh/t8_cmesh.h>
 #include <t8_cmesh/t8_cmesh_examples.h>
@@ -57,7 +58,7 @@ struct dummy_user_data
  *        -1 if the family \a elements shall be coarsened,
  *         0 else.
  */
-template <typename TMeshClass>
+template <t8_mesh_handle::T8MeshType TMeshClass>
 int
 adapt_callback_test ([[maybe_unused]] const TMeshClass &mesh,
                      std::span<const typename TMeshClass::element_class> elements, const dummy_user_data &user_data)
@@ -108,7 +109,7 @@ forest_adapt_callback_example (t8_forest_t forest, t8_forest_t forest_from, t8_l
  *        -1 if the family \a elements shall be coarsened,
  *         0 else.
  */
-template <typename TMeshClass>
+template <t8_mesh_handle::T8MeshType TMeshClass>
 int
 mesh_adapt_callback_test_refine_second ([[maybe_unused]] const TMeshClass &mesh,
                                         std::span<const typename TMeshClass::element_class> elements)

--- a/tutorials/mesh_handle/t8_mesh_element_data.cxx
+++ b/tutorials/mesh_handle/t8_mesh_element_data.cxx
@@ -31,6 +31,7 @@
 #include <mesh_handle/competence_pack.hxx>
 #include <mesh_handle/constructor_wrappers.hxx>
 #include <mesh_handle/mesh_io.hxx>
+#include <mesh_handle/concepts.hxx>
 #include <t8_types/t8_vec.hxx>
 #include <memory>
 #include <span>
@@ -61,7 +62,7 @@ struct user_data
  *        -1 if the family \a elements shall be coarsened,
  *         0 else.
  */
-template <typename TMeshClass>
+template <t8_mesh_handle::T8MeshType TMeshClass>
 int
 adapt_callback ([[maybe_unused]] const TMeshClass &mesh, std::span<const typename TMeshClass::element_class> elements,
                 const user_data &user_data)
@@ -85,7 +86,7 @@ adapt_callback ([[maybe_unused]] const TMeshClass &mesh, std::span<const typenam
  * \param [in] level Initial refinement level.
  * \return Unique pointer to the mesh created.
  */
-template <typename TMeshClass>
+template <t8_mesh_handle::T8MeshType TMeshClass>
 std::unique_ptr<TMeshClass>
 build_mesh (sc_MPI_Comm comm, int level)
 {
@@ -109,7 +110,7 @@ build_mesh (sc_MPI_Comm comm, int level)
  * \tparam TMeshClass    The mesh handle class.
  * \param [in, out] mesh  The mesh handle.
  */
-template <typename TMeshClass>
+template <t8_mesh_handle::T8MeshType TMeshClass>
 void
 set_element_data_mesh (TMeshClass &mesh)
 {
@@ -122,7 +123,7 @@ set_element_data_mesh (TMeshClass &mesh)
  * \tparam TMeshClass    The mesh handle class.
  * \param [in, out] mesh  The mesh handle.
  */
-template <typename TMeshClass>
+template <t8_mesh_handle::T8MeshType TMeshClass>
 void
 exchange_ghost_data_mesh (TMeshClass &mesh)
 {
@@ -140,7 +141,7 @@ exchange_ghost_data_mesh (TMeshClass &mesh)
  * \param [in] fileprefix The prefix of the files where the vtk will be stored.
  *             The master file is then fileprefix.pvtu and the process with rank r writes in the file fileprefix_r.vtu
  */
-template <typename TMeshClass>
+template <t8_mesh_handle::T8MeshType TMeshClass>
 static void
 output_data_to_vtu (const TMeshClass &mesh, const char *prefix)
 {


### PR DESCRIPTION
Closes #2269

**_Describe your changes here:_**
Added concept to restrict template parameters to specifications of the mesh class. 
This is convenient when writing applications using the mesh handle.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).