### PR TITLE
Improvement: Add test for t8_types/t8_vec

### DIFF
--- a/src/t8_types/t8_vec.hxx
+++ b/src/t8_types/t8_vec.hxx
@@ -74,7 +74,8 @@ template <T8InputRange TVec>
 static inline double
 t8_norm (const TVec &vec)
 {
-  return std::sqrt (std::inner_product (vec.begin (), vec.end (), vec.begin (), 0.0));
+  return std::sqrt (
+    std::inner_product (std::ranges::begin (vec), std::ranges::end (vec), std::ranges::begin (vec), 0.0));
 }
 
 /** Normalize a vector.
@@ -86,7 +87,7 @@ t8_normalize (TVec &vec)
 {
   const double norm = t8_norm (vec);
   T8_ASSERT (norm != 0);
-  std::ranges::transform (vec, vec.begin (), [norm] (double v) { return v / norm; });
+  std::ranges::transform (vec, std::ranges::begin (vec), [norm] (double v) { return v / norm; });
 }
 
 /** Copy a dimensional object.
@@ -97,7 +98,7 @@ template <T8InputRange TVec1, T8InputRange TVec2>
 constexpr void
 t8_copy (const TVec1 &src, TVec2 &dest)
 {
-  std::ranges::copy (src, dest.begin ());
+  std::ranges::copy (src, std::ranges::begin (dest));
 }
 
 /** Euclidean distance of X and Y.
@@ -110,8 +111,9 @@ template <T8InputRange TPointX, T8InputRange TPointY>
 constexpr double
 t8_dist (const TPointX &point_x, const TPointY &point_y)
 {
-  double dist = std::inner_product (point_x.begin (), point_x.end (), point_y.begin (), 0.0, std::plus<double> (),
-                                    [] (double x, double y) { return (x - y) * (x - y); });
+  double dist
+    = std::inner_product (std::ranges::begin (point_x), std::ranges::end (point_x), std::ranges::begin (point_y), 0.0,
+                          std::plus<double> (), [] (double x, double y) { return (x - y) * (x - y); });
   return std::sqrt (dist);
 }
 
@@ -123,7 +125,7 @@ template <T8InputRange TVec>
 constexpr void
 t8_ax (TVec &vec_x, const double alpha)
 {
-  std::ranges::transform (vec_x, vec_x.begin (), [alpha] (double v) { return v * alpha; });
+  std::ranges::transform (vec_x, std::ranges::begin (vec_x), [alpha] (double v) { return v * alpha; });
 }
 
 /** Compute Y = alpha * X
@@ -135,7 +137,7 @@ template <T8InputRange TVecX, T8InputRange TVecY>
 constexpr void
 t8_axy (const TVecX &vec_x, TVecY &vec_y, const double alpha)
 {
-  std::ranges::transform (vec_x, vec_y.begin (), [alpha] (double v) { return v * alpha; });
+  std::ranges::transform (vec_x, std::ranges::begin (vec_y), [alpha] (double v) { return v * alpha; });
 }
 
 /** Y = alpha * X + b
@@ -149,7 +151,7 @@ template <T8InputRange TVecX, T8InputRange TVecY>
 constexpr void
 t8_axb (const TVecX &vec_x, TVecY &vec_y, const double alpha, const double b)
 {
-  std::ranges::transform (vec_x, vec_y.begin (), [alpha, b] (double v) { return alpha * v + b; });
+  std::ranges::transform (vec_x, std::ranges::begin (vec_y), [alpha, b] (double v) { return alpha * v + b; });
 }
 
 /** Y = Y + alpha * X
@@ -162,7 +164,8 @@ template <T8InputRange TVecX, T8InputRange TVecY>
 constexpr void
 t8_axpy (const TVecX &vec_x, TVecY &vec_y, const double alpha)
 {
-  std::ranges::transform (vec_x, vec_y, vec_y.begin (), [alpha] (double x, double y) { return y + alpha * x; });
+  std::ranges::transform (vec_x, vec_y, std::ranges::begin (vec_y),
+                          [alpha] (double x, double y) { return y + alpha * x; });
 }
 
 /** Z = Y + alpha * X
@@ -175,7 +178,8 @@ template <T8InputRange TVecX, T8InputRange TVecY, T8InputRange TVecZ>
 constexpr void
 t8_axpyz (const TVecX &vec_x, const TVecY &vec_y, TVecZ &vec_z, const double alpha)
 {
-  std::ranges::transform (vec_x, vec_y, vec_z.begin (), [alpha] (double x, double y) { return y + alpha * x; });
+  std::ranges::transform (vec_x, vec_y, std::ranges::begin (vec_z),
+                          [alpha] (double x, double y) { return y + alpha * x; });
 }
 
 /** Dot product of X and Y.
@@ -187,7 +191,7 @@ template <T8InputRange TVecX, T8InputRange TVecY>
 constexpr double
 t8_dot (const TVecX &vec_x, const TVecY &vec_y)
 {
-  return std::inner_product (vec_x.begin (), vec_x.end (), vec_y.begin (), 0.0);
+  return std::inner_product (std::ranges::begin (vec_x), std::ranges::end (vec_x), std::ranges::begin (vec_y), 0.0);
 }
 
 /** Cross product of X and Y
@@ -229,7 +233,7 @@ constexpr void
 t8_diff (const TVecX &vec_x, const TVecY &vec_y, TVecDiff &diff)
 {
   T8_ASSERT (std::ranges::distance (vec_x) == std::ranges::distance (vec_y));
-  std::ranges::transform (vec_x, vec_y, diff.begin (), std::minus {});
+  std::ranges::transform (vec_x, vec_y, std::ranges::begin (diff), std::minus {});
 }
 
 /**
@@ -274,8 +278,8 @@ t8_normal_of_tri (const TVecP1 &p1, const TVecP2 &p2, const TVecP3 &p3, TVecNorm
   t8_3D_vec a;
   t8_3D_vec b;
 
-  std::ranges::transform (p2, p1, a.begin (), std::minus {});
-  std::ranges::transform (p3, p1, b.begin (), std::minus {});
+  std::ranges::transform (p2, p1, std::ranges::begin (a), std::minus {});
+  std::ranges::transform (p3, p1, std::ranges::begin (b), std::minus {});
 
   t8_cross_3D (a, b, normal);
 }

--- a/src/t8_types/t8_vec.hxx
+++ b/src/t8_types/t8_vec.hxx
@@ -291,11 +291,13 @@ t8_orthogonal_tripod (const TVecV1 &v1, TVecV2 &v2, TVecV3 &v3)
 {
   T8_ASSERT ((std::ranges::distance (v1) >= 3) && (std::ranges::distance (v2) >= 3)
              && (std::ranges::distance (v3) >= 3));
+  T8_ASSERT (t8_dot (v1, v1) != 0);
+
   v2[0] = v1[1];
   v2[1] = v1[2];
   v2[2] = -v1[0];
 
-  t8_axpy (v1, v2, -t8_dot (v1, v2));
+  t8_axpy (v1, v2, -t8_dot (v1, v2) / t8_dot (v1, v1));
   t8_cross_3D (v1, v2, v3);
 
   t8_normalize (v2);

--- a/test/t8_types/t8_gtest_vec.cxx
+++ b/test/t8_types/t8_gtest_vec.cxx
@@ -46,6 +46,33 @@ TEST (t8_gtest_vec, norm)
   EXPECT_NEAR (t8_norm (arbitrary), normarbitrary, T8_PRECISION_SQRT_EPS);
 }
 
+/* Test the t8_normalize function and t8_copy. */
+TEST (t8_gtest_vec, normalize)
+{
+  t8_3D_vec onetwothree ({ 1, 2, 3 });
+  t8_3D_vec arbitrary ({ -.05, 3.14159, 42 });
+
+  // Copy vectors for comparison later on.
+  t8_3D_vec onetwothreecopy;
+  t8_copy (onetwothree, onetwothreecopy);
+  t8_3D_vec arbitrarycopy;
+  t8_copy (arbitrary, arbitrarycopy);
+
+  // Normalize and check if norm is one as expected.
+  t8_normalize (onetwothree);
+  t8_normalize (arbitrary);
+  EXPECT_NEAR (t8_norm (onetwothree), 1, T8_PRECISION_SQRT_EPS);
+  EXPECT_NEAR (t8_norm (arbitrary), 1, T8_PRECISION_SQRT_EPS);
+
+  // Compare to vector that is normalized with the t8_ax function.
+  const double normonetwothree = sqrt (1 + 4 + 9);
+  t8_ax (onetwothreecopy, 1 / normonetwothree);
+  EXPECT_VEC_EQ (onetwothree, onetwothreecopy, T8_PRECISION_SQRT_EPS);
+  const double normarbitrary = 42.117360883;
+  t8_ax (arbitrarycopy, 1 / normarbitrary);
+  EXPECT_VEC_EQ (arbitrary, arbitrarycopy, T8_PRECISION_SQRT_EPS);
+}
+
 /* test the t8_dist function */
 TEST (t8_gtest_vec, dist)
 {
@@ -295,4 +322,62 @@ TEST (t8_gtest_vec, check_less_or_equal)
     { 1.0 - T8_PRECISION_SQRT_EPS, 1.0 - T8_PRECISION_SQRT_EPS, 1.0 - T8_PRECISION_SQRT_EPS });
 
   EXPECT_VEC_EQ (one, one_minus_eps, T8_PRECISION_SQRT_EPS);
+}
+
+/* Test the t8_rescale function. */
+TEST (t8_gtest_vec, rescale)
+{
+  t8_3D_vec onetwothree ({ 1, 2, 3 });
+  t8_3D_vec arbitrary ({ -.05, 3.14159, 42 });
+
+  const double normonetwothree = sqrt (1 + 4 + 9);
+  const double normarbitrary = 42.117360883;
+  const double newlength = 3.;
+
+  // Copy vectors for comparison later on.
+  t8_3D_vec onetwothreecopy;
+  t8_copy (onetwothree, onetwothreecopy);
+  t8_3D_vec arbitrarycopy;
+  t8_copy (arbitrary, arbitrarycopy);
+
+  // Compare rescaled vector with the one rescaled by hand.
+  t8_ax (onetwothree, newlength / normonetwothree);
+  t8_rescale (onetwothreecopy, newlength);
+  EXPECT_VEC_EQ (onetwothree, onetwothreecopy, T8_PRECISION_SQRT_EPS);
+  t8_ax (arbitrary, newlength / normarbitrary);
+  t8_rescale (arbitrarycopy, newlength);
+  EXPECT_VEC_EQ (arbitrary, arbitrarycopy, T8_PRECISION_SQRT_EPS);
+}
+
+/* Test the t8_normal_of_tri function. */
+TEST (t8_gtest_vec, normal_of_tri)
+{
+  // Define triangle points.
+  const t8_3D_vec p0 ({ 0, 0, 0 });
+  const t8_3D_vec p1 ({ 1, 0, 0 });
+  const t8_3D_vec p2 ({ 0, 1, 0 });
+  // Expected normal.
+  const t8_3D_vec expected_normal ({ 0, 0, 1 });
+
+  t8_3D_vec computed_normal;
+  t8_normal_of_tri (p0, p1, p2, computed_normal);
+  // Compare with expected.
+  EXPECT_VEC_EQ (expected_normal, computed_normal, T8_PRECISION_SQRT_EPS);
+}
+
+/* Test the t8_orthogonal_tripod function. */
+TEST (t8_gtest_vec, orthogonal_tripod)
+{
+  // Define triangle points.
+  t8_3D_vec onetwothree ({ 1, 2, 3 });
+  t8_3D_vec output1;
+  t8_3D_vec output2;
+
+  t8_orthogonal_tripod (onetwothree, output1, output2);
+  // Check if result is orthogonal and normalized.
+  EXPECT_NEAR (t8_dot (output1, onetwothree), 0, T8_PRECISION_SQRT_EPS);
+  EXPECT_NEAR (t8_dot (output2, onetwothree), 0, T8_PRECISION_SQRT_EPS);
+  EXPECT_NEAR (t8_dot (output1, output2), 0, T8_PRECISION_SQRT_EPS);
+  EXPECT_NEAR (t8_norm (output1), 1., T8_PRECISION_SQRT_EPS);
+  EXPECT_NEAR (t8_norm (output2), 1., T8_PRECISION_SQRT_EPS);
 }

--- a/test/t8_types/t8_gtest_vec.cxx
+++ b/test/t8_types/t8_gtest_vec.cxx
@@ -24,6 +24,7 @@
 
 #include <gtest/gtest.h>
 #include <t8_types/t8_vec.h>
+#include <t8_types/t8_vec.hxx>
 #include <test/t8_gtest_custom_assertion.hxx>
 #include <test/t8_gtest_memory_macros.hxx>
 #include <t8_helper_functions/t8_unrolled_for.hxx>
@@ -48,11 +49,11 @@ TEST (t8_gtest_vec, norm)
 /* Test the t8_normalize function and t8_copy. */
 TEST (t8_gtest_vec, normalize)
 {
-  t8_3D_vec onetwothree ({ 1, 2, 3 });
+  double onetwothree[3] = { 1, 2, 3 };
   t8_3D_vec arbitrary ({ -.05, 3.14159, 42 });
 
   // Copy vectors for comparison later on.
-  t8_3D_vec onetwothreecopy;
+  double onetwothreecopy[3];
   t8_copy (onetwothree, onetwothreecopy);
   t8_3D_vec arbitrarycopy;
   t8_copy (arbitrary, arbitrarycopy);
@@ -65,10 +66,10 @@ TEST (t8_gtest_vec, normalize)
 
   // Compare to vector that is normalized with the t8_ax function.
   const double normonetwothree = sqrt (1 + 4 + 9);
-  t8_ax (onetwothreecopy, 1 / normonetwothree);
+  t8_ax (onetwothreecopy, 1. / normonetwothree);
   EXPECT_VEC_EQ (onetwothree, onetwothreecopy, T8_PRECISION_SQRT_EPS);
   const double normarbitrary = 42.117360883;
-  t8_ax (arbitrarycopy, 1 / normarbitrary);
+  t8_ax (arbitrarycopy, 1. / normarbitrary);
   EXPECT_VEC_EQ (arbitrary, arbitrarycopy, T8_PRECISION_SQRT_EPS);
 }
 
@@ -384,16 +385,16 @@ TEST (t8_gtest_vec, orthogonal_tripod)
 /* Test the t8_swap function. */
 TEST (t8_gtest_vec, swap)
 {
-  t8_3D_vec onetwothree ({ 1, 2, 3 });
-  t8_3D_vec arbitrary ({ -.05, 3.14159, 42 });
+  double onetwothree[3] = { 1, 2, 3 };
+  double arbitrary[3] = { -.05, 3.14159, 42 };
 
   // Copy vectors for comparison later on.
-  t8_3D_vec onetwothreecopy;
+  double onetwothreecopy[3];
   t8_copy (onetwothree, onetwothreecopy);
-  t8_3D_vec arbitrarycopy;
+  double arbitrarycopy[3];
   t8_copy (arbitrary, arbitrarycopy);
 
-  t8_swap (onetwothree.data (), arbitrary.data ());
+  t8_swap (onetwothree, arbitrary);
   EXPECT_VEC_EQ (onetwothreecopy, arbitrary, T8_PRECISION_SQRT_EPS);
   EXPECT_VEC_EQ (arbitrarycopy, onetwothree, T8_PRECISION_SQRT_EPS);
 }

--- a/test/t8_types/t8_gtest_vec.cxx
+++ b/test/t8_types/t8_gtest_vec.cxx
@@ -23,7 +23,6 @@
 /* In this file we collect tests for the routines in t8_vec.hxx */
 
 #include <gtest/gtest.h>
-#include <t8_types/t8_vec.hxx>
 #include <t8_types/t8_vec.h>
 #include <test/t8_gtest_custom_assertion.hxx>
 #include <test/t8_gtest_memory_macros.hxx>
@@ -380,4 +379,21 @@ TEST (t8_gtest_vec, orthogonal_tripod)
   EXPECT_NEAR (t8_dot (output1, output2), 0, T8_PRECISION_SQRT_EPS);
   EXPECT_NEAR (t8_norm (output1), 1., T8_PRECISION_SQRT_EPS);
   EXPECT_NEAR (t8_norm (output2), 1., T8_PRECISION_SQRT_EPS);
+}
+
+/* Test the t8_swap function. */
+TEST (t8_gtest_vec, swap)
+{
+  t8_3D_vec onetwothree ({ 1, 2, 3 });
+  t8_3D_vec arbitrary ({ -.05, 3.14159, 42 });
+
+  // Copy vectors for comparison later on.
+  t8_3D_vec onetwothreecopy;
+  t8_copy (onetwothree, onetwothreecopy);
+  t8_3D_vec arbitrarycopy;
+  t8_copy (arbitrary, arbitrarycopy);
+
+  t8_swap (onetwothree.data (), arbitrary.data ());
+  EXPECT_VEC_EQ (onetwothreecopy, arbitrary, T8_PRECISION_SQRT_EPS);
+  EXPECT_VEC_EQ (arbitrarycopy, onetwothree, T8_PRECISION_SQRT_EPS);
 }


### PR DESCRIPTION
**_Describe your changes here:_**
Closes #2270. 
Use ranges::begin instead of begin() such that also double [] is allowed which is also allowed with the concept used.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).