### PR TITLE
Other: Remove netcdf-cmake code

### DIFF
--- a/.github/workflows/test_preparation.yml
+++ b/.github/workflows/test_preparation.yml
@@ -98,6 +98,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: |
+          ${{ env.SC_BUILD }}
           ${{ env.SC_DEBUG }}
           ${{ env.SC_RELEASE }}
         # You can increase the counter at the end to force a new key and hence recomputing the cache
@@ -160,6 +161,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: |
+          ${{ env.P4EST_BUILD }}s
           ${{ env.P4EST_DEBUG }}
           ${{ env.P4EST_RELEASE }}
         # You can increase the counter at the end to force a new key and hence recomputing the cache

--- a/.github/workflows/test_preparation.yml
+++ b/.github/workflows/test_preparation.yml
@@ -161,7 +161,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: |
-          ${{ env.P4EST_BUILD }}s
+          ${{ env.P4EST_BUILD }}
           ${{ env.P4EST_DEBUG }}
           ${{ env.P4EST_RELEASE }}
         # You can increase the counter at the end to force a new key and hence recomputing the cache

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -120,7 +120,7 @@ jobs:
     with:
       MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
       IGNORE_CACHE: false # Use this to force a new installation of sc and p4est for this specific workflow run
-      CACHE_COUNTER: 5 # Increase this number to force a new installation of sc and p4est and to update the cache once
+      CACHE_COUNTER: 6 # Increase this number to force a new installation of sc and p4est and to update the cache once
       MPI: ${{ matrix.MPI }}
 
   # Run parallel tests for sc and p4est with and without MPI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,15 +218,6 @@ if( T8CODE_ENABLE_OCC )
     endif (OpenCASCADE_FOUND)
 endif( T8CODE_ENABLE_OCC )
 
-if( T8CODE_ENABLE_NETCDF )
-    find_package( NetCDF REQUIRED )
-    if(NetCDF_FOUND)
-        message("Found NetCDF")
-        include(cmake/CheckNetCDFPar.cmake)
-    endif (NetCDF_FOUND)
-endif( T8CODE_ENABLE_NETCDF )
-
-
 # Override default for this libsc option
 set( BUILD_SHARED_LIBS ON CACHE BOOL "Build libsc as a shared library" )
 


### PR DESCRIPTION
Closes #2288

The FetchContent PR added CMake code that was removed for the deprecated optional netcdf-dependency. 
This PR fixes it. 


**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).