### PR TITLE
Feature: Reintroduce FetchContent

### DIFF
--- a/.github/workflows/test_preparation.yml
+++ b/.github/workflows/test_preparation.yml
@@ -65,10 +65,10 @@ jobs:
         fetch-depth: 0
     - name: Update packages
       run: sudo apt-get update && sudo apt-get upgrade -y
-      # This seems to be necessary because of the docker container
-      # Install the command line processor jq to read the dependencies.json file
     - name: Install jq
       run: sudo apt-get install -y jq
+      # This seems to be necessary because of the docker container
+      # Install the command line processor jq to read the dependencies.json file
     - name: disable ownership checks
       run: git config --global --add safe.directory '*'
     - name: Get input vars
@@ -84,7 +84,8 @@ jobs:
 #       SC installation
 #
     - name: store sc folders in var
-      run: echo SC_BUILD=$PWD/sc/build >> $GITHUB_ENV
+      run: echo SC_SOURCE=$PWD/sc >> $GITHUB_ENV
+        && echo SC_BUILD=$PWD/sc/build >> $GITHUB_ENV
         && echo SC_DEBUG=$PWD/sc/build/Debug >> $GITHUB_ENV
         && echo SC_RELEASE=$PWD/sc/build/Release >> $GITHUB_ENV
     - name: Get sc commit hash  and url from dependencies.json
@@ -113,31 +114,33 @@ jobs:
       # The true at the end is to ignore errors that i.e. occur when the folders do not exist
       run: rm -r $SC_BUILD || true
     - name: make folders
-      run: mkdir -p $SC_DEBUG $SC_RELEASE $SC_BUILD
+      run: mkdir -p $SC_DEBUG $SC_RELEASE
       if: ${{ steps.sc_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
     - name: install sc
       run: echo "Install sc"
       if: ${{ steps.sc_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
-      ## sc debug
     - name: get sc source
+      ## minimal amount of history and fetches
       run: |
-        cd $SC_BUILD
-        if [ ! -d sc ]; then
-          git clone ${{ env.sc_url }} sc
+        if [ ! -d $SC_SOURCE ]; then
+          git init $SC_SOURCE
+          cd $SC_SOURCE
+          git remote add origin ${{ env.sc_url }}
         fi
-        cd sc
-        git fetch
+        cd $SC_SOURCE
+        git fetch --depth 1 origin ${{ env.sc_commit }}
         git checkout ${{ env.sc_commit }}
       if: ${{ steps.sc_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
+      ## sc debug build
     - name: sc cmake debug
-      run: cd $SC_DEBUG && cmake $SC_BUILD/sc -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$SC_DEBUG/install -Dmpi=$MPI -GNinja
+      run: cd $SC_DEBUG && cmake $SC_SOURCE -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$SC_DEBUG/install -Dmpi=$MPI -GNinja
       if: ${{ steps.sc_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
     - name: sc build debug
       run: cd $SC_DEBUG && ninja $MAKEFLAGS && ninja $MAKEFLAGS install
       if: ${{ steps.sc_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
-      ## sc release
+      ## sc release build
     - name: sc cmake release
-      run: cd $SC_RELEASE && cmake $SC_BUILD/sc -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$SC_RELEASE/install -Dmpi=$MPI -GNinja
+      run: cd $SC_RELEASE && cmake $SC_SOURCE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$SC_RELEASE/install -Dmpi=$MPI -GNinja
       if: ${{ steps.sc_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
     - name: sc build release
       run: cd $SC_RELEASE && ninja $MAKEFLAGS && ninja $MAKEFLAGS install
@@ -146,7 +149,8 @@ jobs:
 # P4EST
 #
     - name: store p4est folders in var
-      run: echo P4EST_BUILD=$PWD/p4est/build >> $GITHUB_ENV
+      run: echo P4EST_SOURCE=$PWD/p4est >> $GITHUB_ENV
+        && echo P4EST_BUILD=$PWD/p4est/build >> $GITHUB_ENV
         && echo P4EST_DEBUG=$PWD/p4est/build/Debug >> $GITHUB_ENV
         && echo P4EST_RELEASE=$PWD/p4est/build/Release >> $GITHUB_ENV
     - name: Get p4est commit hash and url from dependencies.json
@@ -176,29 +180,31 @@ jobs:
       run: rm -r $P4EST_BUILD || true
     - name: make folders
       if: ${{ steps.p4est_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
-      run: mkdir -p $P4EST_DEBUG $P4EST_RELEASE $P4EST_BUILD
+      run: mkdir -p $P4EST_DEBUG $P4EST_RELEASE
     - name: install p4est
       run: echo "Install p4est"
       if: ${{ steps.p4est_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
     - name: get p4est source
+      ## minimal amount of history and fetches
       run: |
-        cd $P4EST_BUILD
-        if [ ! -d p4est ]; then
-          git clone ${{ env.p4est_url }} p4est
+        if [ ! -d $P4EST_SOURCE ]; then
+          git init $P4EST_SOURCE
+          cd $P4EST_SOURCE
+          git remote add origin ${{ env.p4est_url }}
         fi
-        cd p4est
-        git fetch
+        cd $P4EST_SOURCE
+        git fetch --depth 1 origin ${{ env.p4est_commit }}
         git checkout ${{ env.p4est_commit }}
-    ## p4est debug
+    ## p4est debug build
     - name: p4est cmake debug
-      run: cd $P4EST_DEBUG && cmake $P4EST_BUILD/p4est -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$P4EST_DEBUG/install -DP4EST_USE_SYSTEM_SC=ON -DSC_DIR=$SC_DEBUG/install/cmake -DP4EST_ENABLE_MPI=$MPI -GNinja
+      run: cd $P4EST_DEBUG && cmake $P4EST_SOURCE -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$P4EST_DEBUG/install -DP4EST_USE_SYSTEM_SC=ON -DSC_DIR=$SC_DEBUG/install/cmake -DP4EST_ENABLE_MPI=$MPI -GNinja
       if: ${{ steps.p4est_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
     - name: p4est build debug
       run: cd $P4EST_DEBUG && ninja $MAKEFLAGS && ninja $MAKEFLAGS install
       if: ${{ steps.p4est_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
-    ## p4est release
+    ## p4est release build
     - name: p4est cmake release
-      run: cd $P4EST_RELEASE && cmake $P4EST_BUILD/p4est -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$P4EST_RELEASE/install -DP4EST_USE_SYSTEM_SC=ON -DSC_DIR=$SC_RELEASE/install/cmake -DP4EST_ENABLE_MPI=$MPI -GNinja
+      run: cd $P4EST_RELEASE && cmake $P4EST_SOURCE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$P4EST_RELEASE/install -DP4EST_USE_SYSTEM_SC=ON -DSC_DIR=$SC_RELEASE/install/cmake -DP4EST_ENABLE_MPI=$MPI -GNinja
       if: ${{ steps.p4est_cmake_cache.outputs.cache-hit != 'true' || inputs.IGNORE_CACHE == 1 }}
     - name: p4est build release
       run: cd $P4EST_RELEASE && ninja $MAKEFLAGS && ninja $MAKEFLAGS install

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -120,7 +120,7 @@ jobs:
     with:
       MAKEFLAGS: ${{ matrix.MAKEFLAGS }}
       IGNORE_CACHE: false # Use this to force a new installation of sc and p4est for this specific workflow run
-      CACHE_COUNTER: 5 # Increase this number to force a new installation of sc and p4est and to update the cache once
+      CACHE_COUNTER: 6 # Increase this number to force a new installation of sc and p4est and to update the cache once
       MPI: ${{ matrix.MPI }}
 
   # Run parallel tests for sc and p4est with and without MPI


### PR DESCRIPTION
**_Describe your changes here:_**
Reintroduces FetchContent after its remocal in #2289

Improvements in this PR:
- MakeAvailable was called multiple times for each target
- Renamed dependencies to thirdparty, because not all libs in fetchcontent are mandatory
- Combined fixes for SC and GTest
- Fixed Gtest fix for Windows systems
- Fixed CI

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).