### PR TITLE
Bugfix: array access in `t8_forest_leaf_face_neighbors_ext`

### DIFF
--- a/src/t8_forest/t8_forest.cxx
+++ b/src/t8_forest/t8_forest.cxx
@@ -1961,20 +1961,17 @@ t8_forest_leaf_face_neighbors_ext (const t8_forest_t forest, const t8_locidx_t l
           *pneighbor_leaves = T8_REALLOC (*pneighbor_leaves, const t8_element_t *, total_num_neighbors);
           T8_ASSERT (*pneighbor_leaves != NULL);
           // Copy the pointers to pneighbor_leaves
-          for (t8_locidx_t ielem = 0; ielem < num_neighbors_current_tree; ++ielem) {
-            (*pneighbor_leaves)[ielem] = user_data.neighbors.data ()[*num_neighbors + ielem];
-          }
+          std::copy_n (user_data.neighbors.begin (), num_neighbors_current_tree, *pneighbor_leaves + *num_neighbors);
         }
         // Copy element indices
         *pelement_indices = T8_REALLOC (*pelement_indices, t8_locidx_t, total_num_neighbors);
         T8_ASSERT (*pelement_indices != NULL);
-        memcpy (*pelement_indices + *num_neighbors, user_data.element_indices.data () + *num_neighbors,
-                num_neighbors_current_tree * sizeof (t8_locidx_t));
+        std::copy_n (user_data.element_indices.begin (), num_neighbors_current_tree,
+                     *pelement_indices + *num_neighbors);
         // Copy dual face
         *dual_faces = T8_REALLOC (*dual_faces, int, total_num_neighbors);
         T8_ASSERT (*dual_faces != NULL);
-        memcpy (*dual_faces + *num_neighbors, user_data.dual_faces.data () + *num_neighbors,
-                num_neighbors_current_tree * sizeof (int));
+        std::copy_n (user_data.dual_faces.begin (), num_neighbors_current_tree, *dual_faces + *num_neighbors);
         *num_neighbors = total_num_neighbors;
       }
     }  // End if neighbors exist (first_leaf_index > 0)


### PR DESCRIPTION
This PR closes #2323

- fix offsets when copying
- use `std::copy_n` instead of manual copying elements or using `memcpy` (C++ style, but presumably there is a more modern way to do it)


**_Describe your changes here:_**


**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [x] The reviewer executed the new code features at least once and checked the results manually.
- [x] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [x] New source/header files are properly added to the CMake files.
- [x] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [x] README.md files are updated if necessary.
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).