### PR TITLE
Bugfix: cmake: move setting of rpath in front of third party handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,30 @@ else()
     set( gtest_disable_mpi ON CACHE INTERNAL "disable gtest mpi support" FORCE)
 endif()
 
+# Rpath options necessary for shared library install to work correctly in user projects.
+# Compute the relative Rpath for proper library installation
+set(libPath ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}) # Library directory)
+cmake_path(RELATIVE_PATH libPath
+    BASE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR} # Binary directory
+    OUTPUT_VARIABLE relativeRpath
+)
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
+
+if(APPLE)
+    set(CMAKE_MACOSX_RPATH true)
+    set(CMAKE_INSTALL_RPATH @loader_path @loader_path/${relativeRpath})
+elseif(UNIX)
+    set(CMAKE_INSTALL_RPATH $ORIGIN $ORIGIN/${relativeRpath})
+endif()
+
 ############################################ ThirdParty ############################################
+
+# Override default for this libsc option
+set( BUILD_SHARED_LIBS ON CACHE BOOL "Build libsc as a shared library" )
+
+# Prevent `libsc` and `p4est` from overwriting the default install prefix.
+set(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT FALSE)
 
 # Set some variables for the thirdparty libraries
 set( gtest_force_shared_crt ON CACHE INTERNAL "" FORCE )
@@ -204,29 +227,6 @@ if( T8CODE_ENABLE_OCC )
         message("Found OpenCASCADE")
     endif (OpenCASCADE_FOUND)
 endif( T8CODE_ENABLE_OCC )
-
-# Override default for this libsc option
-set( BUILD_SHARED_LIBS ON CACHE BOOL "Build libsc as a shared library" )
-
-# Prevent `libsc` and `p4est` from overwriting the default install prefix.
-set(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT FALSE)
-
-# Rpath options necessary for shared library install to work correctly in user projects.
-# Compute the relative Rpath for proper library installation
-set(libPath ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}) # Library directory)
-cmake_path(RELATIVE_PATH libPath
-    BASE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR} # Binary directory
-    OUTPUT_VARIABLE relativeRpath
-)
-
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
-
-if(APPLE)
-    set(CMAKE_MACOSX_RPATH true)
-    set(CMAKE_INSTALL_RPATH @loader_path @loader_path/${relativeRpath})
-elseif(UNIX)
-    set(CMAKE_INSTALL_RPATH $ORIGIN $ORIGIN/${relativeRpath})
-endif()
 
 if ( T8CODE_USE_SYSTEM_SC )
     find_package( SC REQUIRED )


### PR DESCRIPTION
**_Describe your changes here:_**

When building and installing t8code's current June release, dynamic linking of `libp4est.so.4.0.0` fails because `libsc.so.4.0.0` cannot be found. This is caused by a missing rpath setting. In fact, when running `make install` we see

```
-- Set non-toolchain portion of runtime path of "/home/bene/install/t8code-current-debug/lib/libp4est.so.4.0.0" to ""
``` 

The reason seems to be the order in which the rpaths are set up within CMakeLists.txt. Before introducing FetchContent for third party sources (#2303), it happened before sc and p4est were added, now it is done after.

Resolves #2334 

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] README.md files are updated if necessary.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).