### PR TITLE
Enhancement: Reduce output from pre-commit script

### DIFF
--- a/scripts/internal/check_macros.sh
+++ b/scripts/internal/check_macros.sh
@@ -27,8 +27,6 @@ fi
 
 file_path=$1
 
-echo "$file_path"
-
 if [[ "$file_path" -ef "src/t8_misc/t8_with_macro_error.h" ]]
 then
   echo The file \"src/t8_misc/t8_with_macro_error.h\" will be ignored by the check_macros.sh script.

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -65,6 +65,8 @@ exec 1>&2
 
 nocontinue=0
 
+echo "Pre-commit script is checking added files, this may take a moment."
+
 for file in `git diff --cached --name-only`
 do
   # only indent existing files, this is necessary since if we rename or delete
@@ -90,7 +92,6 @@ do
   FILE_ENDING="${file##*.}"
   if [ $FILE_ENDING = "c" -o $FILE_ENDING = "h" -o $FILE_ENDING = "cxx" -o $FILE_ENDING = "hxx" ]
   then
-    echo "Checking file $file"
     $CHECK_INDENT $file > /dev/null 2>&1
     status=$?
     if test $status -ne 0


### PR DESCRIPTION
Closes #2345

**_Describe your changes here:_**
The pre-commit script outputs 2-3 lines per checked file, which can become very much and the output gets hard to filter visually. This PR reduces the output and only keeps the relevant stuff, so when something is not in order.

Output example (you can try to check, if this commit was valid or not):
```
(base) elsw_sa@SC-030292:~/source/t8code$ git commit -m "draw cmesh init out of generators"
Checking file api/t8_fortran_interface/t8_fortran_interface.c
api/t8_fortran_interface/t8_fortran_interface.c
Checking file benchmarks/t8_time_forest_partition.cxx
benchmarks/t8_time_forest_partition.cxx
Checking file benchmarks/t8_time_fractal.cxx
benchmarks/t8_time_fractal.cxx
Checking file benchmarks/t8_time_new_refine.c
benchmarks/t8_time_new_refine.c
Checking file benchmarks/t8_time_partition.cxx
benchmarks/t8_time_partition.cxx
Checking file benchmarks/t8_time_prism_adapt.cxx
benchmarks/t8_time_prism_adapt.cxx
Checking file benchmarks/t8_time_set_join_by_vertices.cxx
benchmarks/t8_time_set_join_by_vertices.cxx
Checking file example/IO/cmesh/deprecated_t8_cmesh_load_save.cxx
example/IO/cmesh/deprecated_t8_cmesh_load_save.cxx
Checking file example/IO/cmesh/gmsh/t8_load_and_refine_square_w_hole.cxx
example/IO/cmesh/gmsh/t8_load_and_refine_square_w_hole.cxx
Checking file example/IO/cmesh/gmsh/t8_read_msh_file.cxx
example/IO/cmesh/gmsh/t8_read_msh_file.cxx
Checking file example/IO/forest/gmsh/t8_gmsh_to_vtk.cxx
example/IO/forest/gmsh/t8_gmsh_to_vtk.cxx
Checking file example/advect/t8_advection.cxx
example/advect/t8_advection.cxx
Checking file example/cmesh/t8_cmesh_geometry_examples.cxx
File example/cmesh/t8_cmesh_geometry_examples.cxx is not indented.
example/cmesh/t8_cmesh_geometry_examples.cxx
Checking file example/cmesh/t8_cmesh_hypercube_pad.cxx
example/cmesh/t8_cmesh_hypercube_pad.cxx
Checking file example/cmesh/t8_cmesh_mesh_deformation.cxx
example/cmesh/t8_cmesh_mesh_deformation.cxx
Checking file example/cmesh/t8_cmesh_partition.cxx
example/cmesh/t8_cmesh_partition.cxx
Checking file example/cmesh/t8_cmesh_set_join_by_vertices.cxx
example/cmesh/t8_cmesh_set_join_by_vertices.cxx
Checking file example/forest/t8_test_face_iterate.cxx
example/forest/t8_test_face_iterate.cxx
Checking file example/forest/t8_test_ghost.cxx
example/forest/t8_test_ghost.cxx
Checking file example/forest/t8_test_ghost_large_level_diff.cxx
example/forest/t8_test_ghost_large_level_diff.cxx
Checking file example/geometry/t8_example_geometries.cxx
example/geometry/t8_example_geometries.cxx
Checking file example/remove/t8_example_empty_trees.cxx
File example/remove/t8_example_empty_trees.cxx is not indented.
example/remove/t8_example_empty_trees.cxx
Checking file example/remove/t8_example_gauss_blob.cxx
example/remove/t8_example_gauss_blob.cxx
Checking file example/remove/t8_example_spheres.cxx
example/remove/t8_example_spheres.cxx
Checking file mesh_handle/constructor_wrappers.hxx
mesh_handle/constructor_wrappers.hxx
Checking file src/t8_cmesh/t8_cmesh_cad.cxx
src/t8_cmesh/t8_cmesh_cad.cxx
Checking file src/t8_cmesh/t8_cmesh_cad.hxx
src/t8_cmesh/t8_cmesh_cad.hxx
Checking file src/t8_cmesh/t8_cmesh_examples.cxx
File src/t8_cmesh/t8_cmesh_examples.cxx is not indented.
src/t8_cmesh/t8_cmesh_examples.cxx
Checking file src/t8_cmesh/t8_cmesh_examples.h
File src/t8_cmesh/t8_cmesh_examples.h is not indented.
src/t8_cmesh/t8_cmesh_examples.h
Checking file src/t8_cmesh/t8_cmesh_io/t8_cmesh_readmshfile.cxx
File src/t8_cmesh/t8_cmesh_io/t8_cmesh_readmshfile.cxx is not indented.
src/t8_cmesh/t8_cmesh_io/t8_cmesh_readmshfile.cxx
Checking file src/t8_cmesh/t8_cmesh_io/t8_cmesh_readmshfile.h
File src/t8_cmesh/t8_cmesh_io/t8_cmesh_readmshfile.h is not indented.
src/t8_cmesh/t8_cmesh_io/t8_cmesh_readmshfile.h
Checking file test/mesh_handle/t8_gtest_adapt_partition_balance.cxx
test/mesh_handle/t8_gtest_adapt_partition_balance.cxx
Checking file test/mesh_handle/t8_gtest_compare_handle_to_forest.cxx
test/mesh_handle/t8_gtest_compare_handle_to_forest.cxx
Checking file test/mesh_handle/t8_gtest_ghost.cxx
test/mesh_handle/t8_gtest_ghost.cxx
Checking file test/t8_IO/t8_gtest_cmesh_readmshfile.cxx
test/t8_IO/t8_gtest_cmesh_readmshfile.cxx
Checking file test/t8_IO/t8_gtest_vtk_writer.cxx
test/t8_IO/t8_gtest_vtk_writer.cxx
Checking file test/t8_cmesh/t8_gtest_bcast.cxx
test/t8_cmesh/t8_gtest_bcast.cxx
Checking file test/t8_cmesh/t8_gtest_cmesh_bounding_box.cxx
File test/t8_cmesh/t8_gtest_cmesh_bounding_box.cxx is not indented.
test/t8_cmesh/t8_gtest_cmesh_bounding_box.cxx
Checking file test/t8_cmesh/t8_gtest_cmesh_face_is_boundary.cxx
test/t8_cmesh/t8_gtest_cmesh_face_is_boundary.cxx
Checking file test/t8_cmesh/t8_gtest_cmesh_set_join_by_vertices.cxx
test/t8_cmesh/t8_gtest_cmesh_set_join_by_vertices.cxx
Checking file test/t8_cmesh/t8_gtest_hypercube.cxx
test/t8_cmesh/t8_gtest_hypercube.cxx
Checking file test/t8_cmesh/t8_gtest_multiple_attributes.cxx
File test/t8_cmesh/t8_gtest_multiple_attributes.cxx is not indented.
test/t8_cmesh/t8_gtest_multiple_attributes.cxx
Checking file test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_bigmesh_param.hxx
test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_bigmesh_param.hxx
Checking file test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_comm.hxx
test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_comm.hxx
Checking file test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_disjoint_bricks_param.hxx
test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_disjoint_bricks_param.hxx
Checking file test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_empty.hxx
test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_empty.hxx
Checking file test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_from_class_param.hxx
test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_from_class_param.hxx
Checking file test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_hypercube_pad.hxx
File test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_hypercube_pad.hxx is not indented.
test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_hypercube_pad.hxx
Checking file test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_hypercube_param.hxx
test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_hypercube_param.hxx
Checking file test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_periodic.hxx
test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_periodic.hxx
Checking file test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_prism_cake_param.hxx
test/t8_cmesh_generator/t8_cmesh_parameterized_examples/t8_cmesh_new_prism_cake_param.hxx
Checking file test/t8_forest/t8_gtest_balance.cxx
test/t8_forest/t8_gtest_balance.cxx
Checking file test/t8_forest/t8_gtest_bin_search.cxx
test/t8_forest/t8_gtest_bin_search.cxx
Checking file test/t8_forest/t8_gtest_element_volume.cxx
test/t8_forest/t8_gtest_element_volume.cxx
Checking file test/t8_forest/t8_gtest_find_owner.cxx
test/t8_forest/t8_gtest_find_owner.cxx
Checking file test/t8_forest/t8_gtest_forest_face_normal.cxx
test/t8_forest/t8_gtest_forest_face_normal.cxx
Checking file test/t8_forest/t8_gtest_ghost_delete.cxx
test/t8_forest/t8_gtest_ghost_delete.cxx
Checking file test/t8_forest/t8_gtest_half_neighbors.cxx
test/t8_forest/t8_gtest_half_neighbors.cxx
Checking file test/t8_forest/t8_gtest_leaf_face_neighbors.cxx
test/t8_forest/t8_gtest_leaf_face_neighbors.cxx
Checking file test/t8_forest/t8_gtest_partition_data.cxx
test/t8_forest/t8_gtest_partition_data.cxx
Checking file test/t8_forest/t8_gtest_search.cxx
test/t8_forest/t8_gtest_search.cxx
Checking file test/t8_forest/t8_gtest_transform.cxx
test/t8_forest/t8_gtest_transform.cxx
Checking file test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
test/t8_forest_incomplete/t8_gtest_empty_global_tree.cxx
Checking file test/t8_forest_incomplete/t8_gtest_empty_local_tree.cxx
test/t8_forest_incomplete/t8_gtest_empty_local_tree.cxx
Checking file test/t8_forest_incomplete/t8_gtest_permute_hole.cxx
test/t8_forest_incomplete/t8_gtest_permute_hole.cxx
Checking file test/t8_forest_incomplete/t8_gtest_recursive.cxx
test/t8_forest_incomplete/t8_gtest_recursive.cxx
Checking file test/t8_geometry/t8_geometry_implementations/t8_gtest_geometry_cad_component.cxx
test/t8_geometry/t8_geometry_implementations/t8_gtest_geometry_cad_component.cxx
Checking file test/t8_geometry/t8_gtest_point_inside.cxx
test/t8_geometry/t8_gtest_point_inside.cxx
Checking file test/t8_gtest_eclass.cxx
test/t8_gtest_eclass.cxx
Checking file test/t8_schemes/t8_gtest_element_ref_coords.cxx
test/t8_schemes/t8_gtest_element_ref_coords.cxx
Checking file test/t8_schemes/t8_gtest_get_linear_id.cxx
test/t8_schemes/t8_gtest_get_linear_id.cxx
Checking file tutorials/features/t8_features_curved_meshes.cxx
tutorials/features/t8_features_curved_meshes.cxx
Checking file tutorials/general/t8_step1_coarsemesh.cxx
tutorials/general/t8_step1_coarsemesh.cxx
Checking file tutorials/general/t8_step2_uniform_forest.cxx
tutorials/general/t8_step2_uniform_forest.cxx
Checking file tutorials/general/t8_step3_adapt_forest.cxx
tutorials/general/t8_step3_adapt_forest.cxx
Checking file tutorials/general/t8_step4_partition_balance_ghost.cxx
tutorials/general/t8_step4_partition_balance_ghost.cxx
Checking file tutorials/general/t8_step5_element_data.cxx
tutorials/general/t8_step5_element_data.cxx
Checking file tutorials/general/t8_step5_element_data_c_interface.c
tutorials/general/t8_step5_element_data_c_interface.c
Checking file tutorials/general/t8_step6_stencil.cxx
tutorials/general/t8_step6_stencil.cxx
Checking file tutorials/general/t8_step7_interpolation.cxx
tutorials/general/t8_step7_interpolation.cxx
Checking file tutorials/general/t8_tutorial_build_scheme.cxx
tutorials/general/t8_tutorial_build_scheme.cxx
Checking file tutorials/general/t8_tutorial_search.cxx
tutorials/general/t8_tutorial_search.cxx
Note: To correct typos and fix indentation, run ./scripts/spell_check_and_indent.sh
```

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] README.md files are updated if necessary.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).