### PR TITLE
Use internal data pointer instead of user data pointer in ghost

### DIFF
--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -642,7 +642,7 @@ t8_forest_ghost_search_boundary (t8_forest_t forest, t8_locidx_t ltreeid, const 
                                  const int is_leaf, [[maybe_unused]] const t8_element_array_t *leaves,
                                  const t8_locidx_t tree_leaf_index)
 {
-  t8_forest_ghost_boundary_data_t *data = (t8_forest_ghost_boundary_data_t *) t8_forest_get_user_data (forest);
+  t8_forest_ghost_boundary_data_t *data = (t8_forest_ghost_boundary_data_t *) forest->t8code_data;
   int num_faces, iface, faces_totally_owned, level;
   int parent_face;
   int lower, upper, *bounds, *new_bounds, parent_lower, parent_upper;
@@ -775,7 +775,7 @@ static void
 t8_forest_ghost_fill_remote_v3 (t8_forest_t forest)
 {
   t8_forest_ghost_boundary_data_t data;
-  void *store_user_data = nullptr;
+  void *store_t8code_data = nullptr;
 
   /* Start with invalid entries in the user data.
    * These are set in t8_forest_ghost_search_boundary each time a new tree is entered */
@@ -789,21 +789,19 @@ t8_forest_ghost_fill_remote_v3 (t8_forest_t forest)
   /* This is a dummy init, since we call sc_array_reset in ghost_search_boundary
    * and we should not call sc_array_reset on a non-initialized array */
   sc_array_init (&data.bounds_per_level, 1);
-  /* Store any user data that may reside on the forest */
-  store_user_data = t8_forest_get_user_data (forest);
-  /* Set the user data for the search routine */
-  t8_forest_set_user_data (forest, &data);
+  /* Store any previous internal data that may reside on the forest. */
+  store_t8code_data = forest->t8code_data;
+  /* Set the internal data for the search routine. */
+  forest->t8code_data = &data;
   /* Loop over the trees of the forest */
   t8_forest_search (forest, t8_forest_ghost_search_boundary, nullptr, nullptr);
 
-  /* Reset the user data from before search */
-  t8_forest_set_user_data (forest, store_user_data);
+  /* Reset the internal data from before the search. */
+  forest->t8code_data = store_t8code_data;
 
   /* Reset the data arrays */
   sc_array_reset (&data.face_owners);
   sc_array_reset (&data.bounds_per_level);
-#if T8_ENABLE_DEBUG
-#endif
 }
 
 /** 


### PR DESCRIPTION
**_Describe your changes here:_**

By utilizing the forest's internal data pointer instead of the user data pointer, this closes #92 
All other forest user_data-pointer usages in the code and have been checked.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] README.md files are updated if necessary.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).