### PR TITLE
add post-installation test (answer issue #2361)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,17 @@ endif()
 
 if ( T8CODE_BUILD_TUTORIALS )
     add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/tutorials )
+    if ( CMAKE_SYSTEM_NAME MATCHES "Linux" ) # post-install tests currently limited to our main development OS
+        add_custom_target(post_install_tests # notice that add_test() would not be appropriate for this test
+            COMMAND rm -fR post_install_tests_dir # we perform the test out of this cmake tree
+            COMMAND mkdir post_install_tests_dir
+            COMMAND cd post_install_tests_dir && cmake ${CMAKE_INSTALL_PREFIX}/share/doc/T8CODE/cmake_examples/ && make VERBOSE=1 && make VERBOSE=1 tests
+            COMMAND rm -fR post_install_tests_dir
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+            VERBATIM
+            COMMENT "Post-install tests' target. It creates, uses, and deletes temporary directory 'post_install_tests_dir'. It assumes running under Linux."
+        )
+    endif()
 endif()
 
 if ( T8CODE_BUILD_EXAMPLES )

--- a/doc/author_martone.txt
+++ b/doc/author_martone.txt
@@ -1,0 +1,1 @@
+I place my contributions to t8code under the FreeBSD license. Michele Martone <michelemartone@users.sourceforge.net>

--- a/doc/cmake_examples/CMakeLists.txt.in
+++ b/doc/cmake_examples/CMakeLists.txt.in
@@ -1,0 +1,37 @@
+#  This file is part of t8code.
+#  t8code is a C library to manage a collection (a forest) of multiple
+#  connected adaptive space-trees of general element types in parallel.
+#
+#  Copyright (C) 2026 the developers
+#
+#  t8code is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  t8code is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with t8code; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+cmake_minimum_required( VERSION 3.2 )
+project(
+    T8CODE_DOC_CMAKE_EXAMPLES
+    DESCRIPTION "A CMakeLists.txt file to test installed CMakeLists.txt example files (which can be ran independently anyways). The idea is to use this after installing T8CODE."
+)
+
+# The two following lines stem from the user-provided installation directories.
+# You can test the subdirectories individually by specifying them yourself via -D...
+set(T8TEST_ROOT       @CMAKE_INSTALL_PREFIX@)
+set(CMAKE_PREFIX_PATH @CMAKE_INSTALL_PREFIX@)
+
+file(GLOB T8CODE_CMAKE_EXAMPLES RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "${CMAKE_CURRENT_LIST_DIR}/?") # for each single-character directory; notice there's no explicit listing here
+add_custom_target(tests)
+foreach(_dir IN LISTS T8CODE_CMAKE_EXAMPLES)
+    add_subdirectory( ${CMAKE_CURRENT_LIST_DIR}/${_dir} )
+    add_dependencies( tests tests_${_dir} )
+endforeach()

--- a/doc/cmake_examples/a/CMakeLists.txt
+++ b/doc/cmake_examples/a/CMakeLists.txt
@@ -1,0 +1,29 @@
+#  This file is part of t8code.
+#  t8code is a C library to manage a collection (a forest) of multiple
+#  connected adaptive space-trees of general element types in parallel.
+#
+#  Copyright (C) 2026 the developers
+#
+#  t8code is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  t8code is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with t8code; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+# A CMakeLists.txt example file showing a way of detecting an installed instance of T8CODE and using it in program test.cxx.
+# This example relies on what is being declared in files installed by T8CODE.
+
+cmake_minimum_required(VERSION 3.22.0)
+project(t8test DESCRIPTION "t8code test program (requires CMAKE_PREFIX_PATH to point to T8CODE's package files are)" LANGUAGES CXX)
+find_package(T8CODE)
+add_executable(test_a test.cxx)
+target_link_libraries(test_a PRIVATE T8CODE::T8)
+add_custom_target(tests_a COMMAND ./test_a)

--- a/doc/cmake_examples/b/CMakeLists.txt
+++ b/doc/cmake_examples/b/CMakeLists.txt
@@ -1,0 +1,43 @@
+#  This file is part of t8code.
+#  t8code is a C library to manage a collection (a forest) of multiple
+#  connected adaptive space-trees of general element types in parallel.
+#
+#  Copyright (C) 2026 the developers
+#
+#  t8code is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  t8code is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with t8code; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+# A CMakeLists.txt file showing a way of detecting an installed instance of T8CODE for use in program test.cxx.
+# This example does not rely on what is being declared in files installed by T8CODE.
+
+cmake_minimum_required(VERSION 3.22)
+include(CheckIncludeFileCXX)
+include(CheckLibraryExists)
+project(t8test DESCRIPTION "t8code test program (needs T8TEST_ROOT to contain relevant include and lib directories and CMAKE_PREFIX_PATH to point to T8CODE's package files are.)" LANGUAGES CXX)
+option(T8TEST_ROOT "Custom directory containing t8code's include, lib, ..." "")
+find_library(T8CODE_LIBRARY t8 REQUIRED) # one may have done this in the if conditional construct after check_library_exists
+CHECK_LIBRARY_EXISTS(t8 t8_init "${T8TEST_ROOT}/lib" HAVE_T8) # check_library_exists looks for a library and sets one variable accordingly
+if(NOT HAVE_T8)
+    message(FATAL_ERROR "no t8 library found!")
+else()
+    message("t8 library found in ${T8TEST_ROOT}/lib")
+endif()
+find_path(SC_INCLUDE_DIR sc.h REQUIRED)
+find_path(T8CODE_INCLUDE_DIR t8.h REQUIRED)
+add_executable(test_b test.cxx)
+target_include_directories(test_b PUBLIC "${SC_INCLUDE_DIR}" )
+target_include_directories(test_b PUBLIC "${T8CODE_INCLUDE_DIR}" )
+target_link_directories(test_b PUBLIC "${T8TEST_ROOT}/lib" )
+target_link_libraries(test_b PRIVATE t8 sc)
+add_custom_target(tests_b COMMAND ./test_b)

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -46,6 +46,7 @@ function( add_t8_tutorial )
     endif( T8CODE_EXPORT_COMPILE_COMMANDS )
 
     install( TARGETS ${ADD_T8_TUTORIAL_NAME} RUNTIME )
+    install( FILES ${ADD_T8_TUTORIAL_SOURCES} DESTINATION ${CMAKE_INSTALL_DOCDIR}/tutorials/general/ )
 endfunction()
 
 function( add_mesh_handle_tutorial )
@@ -80,6 +81,15 @@ copy_tutorial_file (features/t8_features_curved_meshes_generate_cmesh_hex.geo)
 copy_tutorial_file (features/t8_features_curved_meshes_generate_cmesh_quad.geo)
 copy_tutorial_file (features/t8_features_curved_meshes_generate_cmesh_tet.geo)
 copy_tutorial_file (features/t8_features_curved_meshes_generate_cmesh_tri.geo)
+
+# notice that in the following, we install files from doc/ and tutorials/ together:
+file(GLOB T8CODE_CMAKE_EXAMPLES RELATIVE "${PROJECT_SOURCE_DIR}/doc/cmake_examples/" "${PROJECT_SOURCE_DIR}/doc/cmake_examples/?") # for each single-character directory; notice there's no explicit listing here
+configure_file( ${PROJECT_SOURCE_DIR}/doc/cmake_examples/CMakeLists.txt.in ${CMAKE_BINARY_DIR}/doc/cmake_examples/CMakeLists.txt @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/doc/cmake_examples/CMakeLists.txt DESTINATION ${CMAKE_INSTALL_DOCDIR}/cmake_examples/ RENAME CMakeLists.txt) # reminder that we may want to name this differently (yet, no necessity for .in)
+foreach(_dir IN LISTS T8CODE_CMAKE_EXAMPLES)
+     install(DIRECTORY ${PROJECT_SOURCE_DIR}/doc/cmake_examples/${_dir} DESTINATION ${CMAKE_INSTALL_DOCDIR}/cmake_examples/) # notice we take directories from doc...
+     install(FILES ${PROJECT_SOURCE_DIR}/tutorials/general/t8_step0_helloworld.cxx DESTINATION ${CMAKE_INSTALL_DOCDIR}/cmake_examples/${_dir}/ RENAME test.cxx) #... and add the same sample tutorial program as a test
+endforeach()
 
 if( T8CODE_BUILD_MESH_HANDLE )
     add_mesh_handle_tutorial( NAME t8_mesh_element_data SOURCES mesh_handle/t8_mesh_element_data.cxx )


### PR DESCRIPTION
Closes #2363

Address issue #2361 by adding a post-installation test goal (`post_install_tests`).

This works by:
 - generating a top-level CMakeLists.txt file with hardcoded paths reflecting the installation directories and installing it in a directory with documentation
 - installing two simple CMakeLists.txt files meant as t8code use examples; the two are located in respective sub-directories, both containing the same sample t8code program (the first tutorial program actually)
 - ensuring that the top-level CMakeLists.txt file is be usable from anywhere without further configuration, and uses the two CMakeLists.txt files to build two executables and run them (via the `tests` target)
 - having a `post_install_tests` target, to build the above two programs in the temporary `post_install_tests_dir` directory for test purposes
 - assuming the `post_install_tests` target to only work after `install`
 - keeping the test to be basic - the goal is to have detection of the t8code library to work, as well as build and execution of the two test programs

Current shortcomings:
 - test limited to Linux
 - not documented anywhere ( ideal would be in this files' tree, but current t8code practice uses t8code.wiki, which is separate )
 - it may assume that the two MPI-enabled executables can be ran straight-ahead
 - installation happens in a documentation directory, but to be enabled, this feature relies on T8CODE_BUILD_TUTORIALS, not T8CODE_BUILD_DOCUMENTATION

p.s.: Since this is my first contribution to t8code, I'm including my
      authorization to treat this contribution under the "FreeBSD License"
      and I'm signing (at least) this commit with my usual GPG key.

**_Describe your changes here:_**


**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] README.md files are updated if necessary.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).