### PR TITLE
Bugfix: Fix face corner mapping in quad coplanarity check

### DIFF
--- a/doc/author_mishra.txt
+++ b/doc/author_mishra.txt
@@ -1,0 +1,1 @@
+I place my contributions to t8code under the FreeBSD license. Rishav Mishra (rishav.mishra@wmich.edu)

--- a/src/t8_forest/t8_forest.cxx
+++ b/src/t8_forest/t8_forest.cxx
@@ -1019,9 +1019,9 @@ t8_forest_element_face_normal (t8_forest_t forest, t8_locidx_t ltreeid, const t8
     {
       t8_3D_vec points[4];
       /* Compute the vertex coordinates of the quad */
-      for (int i = 0; i < 4; i++) {
-        const int corner = scheme->element_get_face_corner (tree_class, element, face, i);
-        t8_forest_element_coordinate (forest, ltreeid, element, corner, points[i].data ());
+      for (int ipoint = 0; ipoint < 4; ipoint++) {
+        const int corner = scheme->element_get_face_corner (tree_class, element, face, ipoint);
+        t8_forest_element_coordinate (forest, ltreeid, element, corner, points[ipoint].data ());
       }
       if (!t8_four_points_coplanar (points[0], points[1], points[2], points[3], T8_PRECISION_SQRT_EPS)) {
         t8_debugf ("WARNING: Computing normal to a quad that is not coplanar. This computation will be inaccurate.\n");

--- a/src/t8_forest/t8_forest.cxx
+++ b/src/t8_forest/t8_forest.cxx
@@ -1017,13 +1017,13 @@ t8_forest_element_face_normal (t8_forest_t forest, t8_locidx_t ltreeid, const t8
 #if T8_ENABLE_DEBUG
     /* Issue a warning if the points of the quad do not lie in the same plane */
     {
-      t8_3D_vec p_0, p_1, p_2, p_3;
+      t8_3D_vec points[4];
       /* Compute the vertex coordinates of the quad */
-      t8_forest_element_coordinate (forest, ltreeid, element, 0, p_0.data ());
-      t8_forest_element_coordinate (forest, ltreeid, element, 1, p_1.data ());
-      t8_forest_element_coordinate (forest, ltreeid, element, 2, p_2.data ());
-      t8_forest_element_coordinate (forest, ltreeid, element, 3, p_3.data ());
-      if (!t8_four_points_coplanar (p_0, p_1, p_2, p_3, T8_PRECISION_SQRT_EPS)) {
+      for (int i = 0; i < 4; i++) {
+        const int corner = scheme->element_get_face_corner (tree_class, element, face, i);
+        t8_forest_element_coordinate (forest, ltreeid, element, corner, points[i].data ());
+      }
+      if (!t8_four_points_coplanar (points[0], points[1], points[2], points[3], T8_PRECISION_SQRT_EPS)) {
         t8_debugf ("WARNING: Computing normal to a quad that is not coplanar. This computation will be inaccurate.\n");
       }
     }


### PR DESCRIPTION
**_Describe your changes here:_**

Closes #2337

This PR fixes the debug-only quadrilateral coplanarity check in `t8_forest_element_face_normal`.

Previously, the coplanarity check always used element corners `0`, `1`, `2`, and `3`. For volume elements, these are not necessarily the four corners of the selected face.

The normal computation already maps face-local corners correctly using `element_get_face_corner`. This PR applies the same face-local corner mapping to the coplanarity check before calling `t8_forest_element_coordinate`.

The change is intentionally small and only affects the debug warning logic. It does not change the actual face-normal computation.

Testing performed locally:

```bash
cmake --build build -j 4
ctest --test-dir build -R t8_gtest_forest_face_normal_serial --output-on-failure
```

Result:

```text
t8_gtest_forest_face_normal_serial ... Passed
100% tests passed, 0 tests failed out of 1
```

Since this is my first contribution to t8code, I added my BSD authorization statement in `doc/author_mishra.txt`.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [x] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] README.md files are updated if necessary.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [x] The author added a BSD statement to `doc/` (or already has one).