### PR TITLE
Set the caller's pointer to NULL in the destroy functions

### DIFF
--- a/doc/author_karpov.txt
+++ b/doc/author_karpov.txt
@@ -1,0 +1,1 @@
+I place my contributions to t8code under the FreeBSD license. Anton Karpov <karpovantonme@gmail.com>

--- a/src/t8_cmesh/t8_cmesh_internal/t8_cmesh_stash.c
+++ b/src/t8_cmesh/t8_cmesh_internal/t8_cmesh_stash.c
@@ -67,7 +67,7 @@ t8_stash_destroy (t8_stash_t *pstash)
   }
   sc_array_reset (&stash->attributes);
   T8_FREE (stash);
-  pstash = NULL;
+  *pstash = NULL;
 }
 
 void

--- a/src/t8_cmesh/t8_cmesh_internal/t8_cmesh_trees.cxx
+++ b/src/t8_cmesh/t8_cmesh_internal/t8_cmesh_trees.cxx
@@ -1292,5 +1292,5 @@ t8_cmesh_trees_destroy (t8_cmesh_trees_t *ptrees)
   sc_mempool_destroy (trees->global_local_mempool);
 
   T8_FREE (trees);
-  ptrees = nullptr;
+  *ptrees = nullptr;
 }


### PR DESCRIPTION
Closes #2387

`t8_stash_destroy` and `t8_cmesh_trees_destroy` both take a pointer to the caller's handle so that they can clear it after freeing, and both headers say so:

```c
/** Free all memory associated in a stash structure.
 * \param [in,out]  pstash  A pointer to the stash to be destroyed.
 *                  The pointer is set to NULL after the function call.
 */
```

```c
/** \param [in,out]  trees The tree structure to be destroyed. Set to NULL on output. */
```

Neither does it. Both assign to the parameter instead of dereferencing it:

```c
T8_FREE (stash);
pstash = NULL;      /* clears the local copy, not the caller's handle */
```

```cpp
T8_FREE (trees);
ptrees = nullptr;
```

So the caller is left holding a dangling pointer, and the whole reason for taking a double pointer is lost.

## Why this is not only cosmetic

The callers are written as if the contract held.

`t8_cmesh_commit.cxx:626` guards the destroy on the handle being non-NULL:

```cpp
if (cmesh->stash != nullptr) {
  t8_stash_destroy (&cmesh->stash);
}
```

and line 145 of the same file reads through the same guard:

```cpp
if (cmesh->stash != nullptr && cmesh->stash->classes.elem_count > 0) {
```

Since `cmesh->stash` is never set to NULL, that second check passes on a freed pointer and dereferences it. `t8_cmesh_helpers.cxx:263-264` and `t8_cmesh_readmshfile.cxx:1596` read `cmesh->stash->...` as well.

`t8_cmesh_bcast` (`t8_cmesh.cxx:792`) is the clearest case: it destroys the stash and sets `cmesh_out->committed = 1`, and the cmesh keeps living with a dangling `stash`.

In the teardown path (`t8_cmesh_destroy`) the dangling pointer is harmless, since the cmesh is freed right after. It is the commit and bcast paths that matter.

## The change

Two characters, one in each function: `pstash = NULL` becomes `*pstash = NULL`, `ptrees = nullptr` becomes `*ptrees = nullptr`. Nothing else touched.

I have not added a regression test. The natural one would assert that `cmesh->stash == NULL` after commit, but I did not want to guess where it belongs in your test layout. Happy to add it if you point me at the right file.

Found with a `cppcheck --enable=warning` sweep over `src/` (`uselessAssignmentPtrArg` at `t8_cmesh_stash.c:70` and `t8_cmesh_trees.cxx:1295`), then traced through the callers by hand.

Author file added as `doc/author_karpov.txt` per CONTRIBUTING, and both commits are signed off.