### PR TITLE
Bugfix: Make t8_vtk_writer.h C-safe

### DIFF
--- a/src/t8_vtk/t8_vtk_writer.cxx
+++ b/src/t8_vtk/t8_vtk_writer.cxx
@@ -156,6 +156,8 @@ t8_cmesh_vtk_write_file (const t8_cmesh_t cmesh, const char *fileprefix)
   return writer.write_ASCII (cmesh);
 }
 
+T8_EXTERN_C_END ();
+
 #if T8_ENABLE_VTK
 void
 t8_forest_to_vtkUnstructuredGrid (const t8_forest_t forest, vtkSmartPointer<vtkUnstructuredGrid> unstructuredGrid,
@@ -168,5 +170,3 @@ t8_forest_to_vtkUnstructuredGrid (const t8_forest_t forest, vtkSmartPointer<vtkU
   writer.grid_to_vtkUnstructuredGrid (forest, unstructuredGrid);
 }
 #endif
-
-T8_EXTERN_C_END ();

--- a/src/t8_vtk/t8_vtk_writer.h
+++ b/src/t8_vtk/t8_vtk_writer.h
@@ -32,37 +32,7 @@
 #include <t8_vtk/t8_vtk.h>
 #include <t8_forest/t8_forest_types.h>
 
-#if T8_ENABLE_VTK
-#include <vtkUnstructuredGrid.h>
-#endif
-
 T8_EXTERN_C_BEGIN ();
-
-#if T8_ENABLE_VTK
-/**
- * Translate a forest into a vtkUnstructuredGrid with respect to the given flags. 
- * This function uses the vtk library. t8code must be configured with
- * "-DT8CODE_ENABLE_VTK=ON" in order to use it.
- * \param [in]  forest    The forest.
- * \param[in, out] unstructuredGrid 
- * \param [in]  write_treeid If true, the global tree id is written for each element.
- * \param [in]  write_mpirank If true, the mpirank is written for each element.
- * \param [in]  write_level If true, the refinement level is written for each element.
- * \param [in]  write_element_id If true, the global element id is written for each element.
- * \param [in]  curved_flag If true, write the elements as curved element types from vtk.
- * \param [in]  write_ghosts If true, write out ghost elements as well.
- * \param [in]  num_data  Number of user defined double valued data fields to write.
- * \param [in]  data      Array of t8_vtk_data_field_t of length \a num_data
- *                        providing the user defined per element data.
- *                        If scalar and vector fields are used, all scalar fields
- *                        must come first in the array.
- */
-void
-t8_forest_to_vtkUnstructuredGrid (t8_forest_t forest, vtkSmartPointer<vtkUnstructuredGrid> unstructuredGrid,
-                                  const int write_treeid, const int write_mpirank, const int write_level,
-                                  const int write_element_id, const int write_ghosts, const int curved_flag,
-                                  const int num_data, t8_vtk_data_field_t *data);
-#endif
 
 /** Write the forest in .pvtu file format. Writes one .vtu file per
  * process and a meta .pvtu file.

--- a/src/t8_vtk/t8_vtk_writer.hxx
+++ b/src/t8_vtk/t8_vtk_writer.hxx
@@ -586,4 +586,30 @@ struct vtk_writer
   bool merge_points = true;
 };
 
+#if T8_ENABLE_VTK
+/**
+ * Translate a forest into a vtkUnstructuredGrid with respect to the given flags. 
+ * This function uses the vtk library. t8code must be configured with
+ * "-DT8CODE_ENABLE_VTK=ON" in order to use it.
+ * \param [in]  forest    The forest.
+ * \param[in, out] unstructuredGrid 
+ * \param [in]  write_treeid If true, the global tree id is written for each element.
+ * \param [in]  write_mpirank If true, the mpirank is written for each element.
+ * \param [in]  write_level If true, the refinement level is written for each element.
+ * \param [in]  write_element_id If true, the global element id is written for each element.
+ * \param [in]  curved_flag If true, write the elements as curved element types from vtk.
+ * \param [in]  write_ghosts If true, write out ghost elements as well.
+ * \param [in]  num_data  Number of user defined double valued data fields to write.
+ * \param [in]  data      Array of t8_vtk_data_field_t of length \a num_data
+ *                        providing the user defined per element data.
+ *                        If scalar and vector fields are used, all scalar fields
+ *                        must come first in the array.
+ */
+void
+t8_forest_to_vtkUnstructuredGrid (t8_forest_t forest, vtkSmartPointer<vtkUnstructuredGrid> unstructuredGrid,
+                                  const int write_treeid, const int write_mpirank, const int write_level,
+                                  const int write_element_id, const int write_ghosts, const int curved_flag,
+                                  const int num_data, t8_vtk_data_field_t *data);
+#endif
+
 #endif /* T8_VTK_WRITER_HXX */


### PR DESCRIPTION
**_Describe your changes here:_**

Closes #2171

This PR moves the function `t8_forest_to_vtkUnstructuredGrid` to the file `t8_vtk_writer.hxx`, because it requires `vtkUnstructuredGrid.h`, which in turn requires C++. Although the function is not called anywhere from t8code, I thought it might be a handy function so I suggest to keep it.

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] README.md files are updated if necessary.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).