### PR TITLE
Improvement: Add missing const to elements_are_family arguments

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.cxx
@@ -197,7 +197,7 @@ t8_default_scheme_hex::element_get_ancestor_id (const t8_element_t *elem, const 
 }
 
 int
-t8_default_scheme_hex::elements_are_family (t8_element_t *const *fam) const
+t8_default_scheme_hex::elements_are_family (const t8_element_t *const *fam) const
 {
 #if T8_ENABLE_DEBUG
   {

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.hxx
@@ -259,7 +259,7 @@ struct t8_default_scheme_hex: public t8_default_scheme_common<T8_ECLASS_HEX, t8_
    * \note level 0 elements do not form a family.
    */
   int
-  elements_are_family (t8_element_t *const *fam) const;
+  elements_are_family (const t8_element_t *const *fam) const;
 
   /** Compute the nearest common ancestor of two elements. That is,
    * the element with highest level that still has both given elements as

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.cxx
@@ -381,7 +381,7 @@ t8_default_scheme_line::element_get_ancestor_id (const t8_element_t *elem, int l
 }
 
 int
-t8_default_scheme_line::elements_are_family (t8_element_t *const *fam) const
+t8_default_scheme_line::elements_are_family (const t8_element_t *const *fam) const
 {
 #if T8_ENABLE_DEBUG
   int i;

--- a/src/t8_schemes/t8_default/t8_default_line/t8_default_line.hxx
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_default_line.hxx
@@ -271,7 +271,7 @@ struct t8_default_scheme_line: public t8_default_scheme_common<T8_ECLASS_LINE, t
    * \note level 0 elements do not form a family.
    */
   int
-  elements_are_family (t8_element_t *const *fam) const;
+  elements_are_family (const t8_element_t *const *fam) const;
 
   /** Compute the nearest common ancestor of two elements. That is,
    * the element with highest level that still has both given elements as

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.cxx
@@ -251,7 +251,7 @@ t8_default_scheme_prism::element_extrude_face (const t8_element_t *face, t8_elem
 }
 
 int
-t8_default_scheme_prism::elements_are_family (t8_element_t *const *fam) const
+t8_default_scheme_prism::elements_are_family (const t8_element_t *const *fam) const
 {
 #if T8_ENABLE_DEBUG
   for (int i = 0; i < T8_DPRISM_CHILDREN; i++) {

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.hxx
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_default_prism.hxx
@@ -260,7 +260,7 @@ struct t8_default_scheme_prism: public t8_default_scheme_common<T8_ECLASS_PRISM,
    * \note level 0 elements do not form a family.
    */
   int
-  elements_are_family (t8_element_t *const *fam) const;
+  elements_are_family (const t8_element_t *const *fam) const;
 
   /** Compute the nearest common ancestor of two elements. That is, the element with highest level that still has
    * both given elements as descendants.

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.cxx
@@ -256,7 +256,7 @@ t8_default_scheme_pyramid::element_set_linear_id (t8_element_t *elem, int level,
 }
 
 int
-t8_default_scheme_pyramid::elements_are_family (t8_element_t *const *fam) const
+t8_default_scheme_pyramid::elements_are_family (const t8_element_t *const *fam) const
 {
 #if T8_ENABLE_DEBUG
   const int num_siblings = element_get_num_siblings (fam[0]);

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid.hxx
@@ -275,7 +275,7 @@ struct t8_default_scheme_pyramid: public t8_default_scheme_common<T8_ECLASS_PYRA
    * \note level 0 elements do not form a family.
    */
   int
-  elements_are_family (t8_element_t *const *fam) const;
+  elements_are_family (const t8_element_t *const *fam) const;
 
   /** Compute the nearest common ancestor of two elements. That is, the element with highest level that still has both
    * given elements as descendants.

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.cxx
@@ -235,7 +235,7 @@ t8_default_scheme_quad::element_get_ancestor_id (const t8_element_t *elem, int l
 }
 
 int
-t8_default_scheme_quad::elements_are_family (t8_element_t *const *fam) const
+t8_default_scheme_quad::elements_are_family (const t8_element_t *const *fam) const
 {
 #if T8_ENABLE_DEBUG
   for (int i = 0; i < P4EST_CHILDREN; i++) {

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.hxx
@@ -295,7 +295,7 @@ struct t8_default_scheme_quad: public t8_default_scheme_common<T8_ECLASS_QUAD, t
    * \note level 0 elements do not form a family.
    */
   int
-  elements_are_family (t8_element_t *const *fam) const;
+  elements_are_family (const t8_element_t *const *fam) const;
 
   /** Compute the nearest common ancestor of two elements. That is,
    * the element with highest level that still has both given elements as

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.cxx
@@ -169,7 +169,7 @@ t8_default_scheme_tet::element_get_ancestor_id (const t8_element_t *elem, int le
 }
 
 int
-t8_default_scheme_tet::elements_are_family (t8_element_t *const *fam) const
+t8_default_scheme_tet::elements_are_family (const t8_element_t *const *fam) const
 {
 #if T8_ENABLE_DEBUG
   for (int i = 0; i < T8_DTET_CHILDREN; i++) {

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_default_tet.hxx
@@ -244,7 +244,7 @@ struct t8_default_scheme_tet: public t8_default_scheme_common<T8_ECLASS_TET, t8_
    * \note level 0 elements do not form a family.
    */
   int
-  elements_are_family (t8_element_t *const *fam) const;
+  elements_are_family (const t8_element_t *const *fam) const;
 
   /** Compute the nearest common ancestor of two elements. That is, the element with highest level that still has both
    * given elements as descendants.

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.cxx
@@ -184,7 +184,7 @@ t8_default_scheme_tri::element_get_ancestor_id (const t8_element_t *elem, int le
 }
 
 int
-t8_default_scheme_tri::elements_are_family (t8_element_t *const *fam) const
+t8_default_scheme_tri::elements_are_family (const t8_element_t *const *fam) const
 {
 #if T8_ENABLE_DEBUG
   {

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.hxx
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_default_tri.hxx
@@ -243,7 +243,7 @@ struct t8_default_scheme_tri: public t8_default_scheme_common<T8_ECLASS_TRIANGLE
    * \note level 0 elements do not form a family.
    */
   int
-  elements_are_family (t8_element_t *const *fam) const;
+  elements_are_family (const t8_element_t *const *fam) const;
 
   /** Compute the nearest common ancestor of two elements. That is, the element with highest level that still has both
    * given elements as descendants.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.cxx
@@ -173,7 +173,7 @@ t8_default_scheme_vertex::element_get_ancestor_id ([[maybe_unused]] const t8_ele
 }
 
 int
-t8_default_scheme_vertex::elements_are_family (t8_element_t *const *fam) const
+t8_default_scheme_vertex::elements_are_family (const t8_element_t *const *fam) const
 {
 #if T8_ENABLE_DEBUG
   for (int i = 0; i < T8_DVERTEX_CHILDREN; i++) {

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.hxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_default_vertex.hxx
@@ -263,7 +263,7 @@ struct t8_default_scheme_vertex: public t8_default_scheme_common<T8_ECLASS_VERTE
    * \note level 0 elements do not form a family.
    */
   int
-  elements_are_family (t8_element_t *const *fam) const;
+  elements_are_family (const t8_element_t *const *fam) const;
 
   /** Compute the nearest common ancestor of two elements. That is,
    * the element with highest level that still has both given elements as

--- a/src/t8_schemes/t8_scheme.hxx
+++ b/src/t8_schemes/t8_scheme.hxx
@@ -532,7 +532,7 @@ struct t8_scheme
    * \note level 0 elements do not form a family.
    */
   inline bool
-  elements_are_family (const t8_eclass_t tree_class, t8_element_t *const *fam) const
+  elements_are_family (const t8_eclass_t tree_class, const t8_element_t *const *fam) const
   {
     return std::visit ([&] (auto &&scheme) { return scheme.elements_are_family (fam); }, eclass_schemes[tree_class]);
   };

--- a/src/t8_schemes/t8_standalone/t8_standalone_implementation.hxx
+++ b/src/t8_schemes/t8_standalone/t8_standalone_implementation.hxx
@@ -577,7 +577,7 @@ struct t8_standalone_scheme: public t8_scheme_helpers<TEclass, t8_standalone_sch
    * \note level 0 elements do not form a family.
    */
   static constexpr int
-  elements_are_family (t8_element_t *const *fam) noexcept
+  elements_are_family (const t8_element_t *const *fam) noexcept
   {
 #if T8_ENABLE_DEBUG
     const int num_siblings = element_get_num_siblings (fam[0]);


### PR DESCRIPTION
**_Describe your changes here:_**

Closes #2163 

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] README.md files are updated if necessary.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).