### PR TITLE
Bugfix: Tree offset in refine_every_nth_element_callback

### DIFF
--- a/test/t8_gtest_adapt_callbacks.hxx
+++ b/test/t8_gtest_adapt_callbacks.hxx
@@ -54,12 +54,12 @@ t8_test_adapt_first_child (t8_forest_t forest, t8_forest_t forest_from, t8_locid
                            const int is_family, const int num_elements, t8_element_t *elements[]);
 
 /**
- * Adapt callback that refines every n-th local element, where \a n is given as template parameter.
+ * Adapt callback that refines every n-th global element, where \a n is given as template parameter.
  *
- * Optionally, an \a offset < \a n may be defined to not start with the first local leaf eleement.
+ * Optionally, an \a offset < \a n may be defined to not start with the first leaf eleement.
  *
- * \tparam n      every n-th local leaf element will be refined
- * \tparam offset local ID of the first element to refine
+ * \tparam n      every n-th global leaf element will be refined
+ * \tparam offset global ID of the first element to refine
  *
  * Note: The argument list has to be the same as for \ref t8_forest_adapt_t, even
  *       if most arguments are unused. For their meaning, please refer to \ref t8_forest_adapt_t.
@@ -86,8 +86,12 @@ refine_every_nth_element_callback ([[maybe_unused]] t8_forest_t forest, [[maybe_
                                    [[maybe_unused]] const int is_family, [[maybe_unused]] const int num_elements,
                                    [[maybe_unused]] t8_element_t *elements[])
 {
+  // Compute global element ID (forest offset + tree offset + id in tree).
+  t8_gloidx_t global_elem_id = t8_forest_get_first_local_leaf_element_id (forest_from)
+                               + t8_forest_get_tree_element_offset (forest_from, which_tree) + lelement_id;
+
   // Refine every n-th element, starting from offset (default: zero).
-  return (((t8_forest_get_tree_element_offset (forest_from, which_tree) + lelement_id) % n == offset) ? 1 : 0);
+  return ((global_elem_id % n == offset) ? 1 : 0);
 }
 
 #endif /* T8_GTEST_ADAPT_CALLBACKS */

--- a/test/t8_gtest_adapt_callbacks.hxx
+++ b/test/t8_gtest_adapt_callbacks.hxx
@@ -87,7 +87,7 @@ refine_every_nth_element_callback ([[maybe_unused]] t8_forest_t forest, [[maybe_
                                    [[maybe_unused]] t8_element_t *elements[])
 {
   // Refine every n-th element, starting from offset (default: zero).
-  return ((lelement_id % n == offset) ? 1 : 0);
+  return (((t8_forest_get_tree_element_offset (forest_from, which_tree) + lelement_id) % n == offset) ? 1 : 0);
 }
 
 #endif /* T8_GTEST_ADAPT_CALLBACKS */


### PR DESCRIPTION
Closes #2416

**_Describe your changes here:_**

Minor fix, but the callback so far refined every n-th element of a tree, not of all process-local elements as the description said; so I had to adjust either description or implementation to make it consistent and went for the latter 🙂 

**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [x] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [x] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [x] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation. Make sure to add a file documentation for each file!
- [ ] README.md files are updated if necessary.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] The code coverage of the project (reported in the CI) should not decrease. If coverage is decreased, make sure that this is reasonable and acceptable.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `scripts/internal/find_all_source_files.sh` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).